### PR TITLE
热更下载停滞超时（治莫名卡住）+ AGENTS.md 残留错句补齐

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,4 +110,4 @@ CI（push main 触发 `guards` + `mobile-release-contracts`；ship-* release 触
 
 ---
 
-**一句话**：打包发版**全程走 `scripts/release.js`**，别手搓任何一步；改派生物必 sync 且落相对路径；OTA 只发跟踪代码、assets 走全量包；改完本机跑绿第五节全部门禁再报完成。
+**一句话**：打包发版**全程走 `scripts/release.js`（两阶段 prepare/publish）**，别手搓任何一步；改派生物必 sync 且落相对路径；**OTA 必须自带全部 `web/assets`（~800MB+·绝不收敛成"只发跟踪码"·见第三节血泪教训）**；改完本机跑绿第五节全部门禁再报完成。

--- a/main-impl.js
+++ b/main-impl.js
@@ -890,7 +890,22 @@ async function _downloadRemoteFileOnce(url, dest, maxBytes, onProgress, opts = {
   }
   const headers = Object.assign({}, opts.headers || {});
   if (resume && startByte > 0) headers.Range = 'bytes=' + startByte + '-';
-  const resp = await net.fetch(url, { bypassCustomProtocolHandlers: true, headers });
+  // 2026-07-20·停滞超时：连接挂起但不断流（socket 不断、数据不来·Cloudflare/弱网极常见）时，
+  //   reader.read() 会永久阻塞、不报错 → 上层重试（只在抛错时触发）永不启动 → UI「莫名卡住」。
+  //   用 AbortController + 空闲计时器：每次等新数据块超过 idleTimeoutMs（默认 30s·首字节/续读通用）
+  //   就 abort → 抛错 → 走 downloadRemoteFile 的可续传重试（从 .part 断点续）。
+  const IDLE_MS = Math.max(5000, Number(opts.idleTimeoutMs || 30000));
+  const _ac = new AbortController();
+  let _idleTimer = null;
+  const _armIdle = () => { if (_idleTimer) clearTimeout(_idleTimer); _idleTimer = setTimeout(() => { try { _ac.abort(); } catch (_) {} }, IDLE_MS); };
+  const _disarmIdle = () => { if (_idleTimer) { clearTimeout(_idleTimer); _idleTimer = null; } };
+  _armIdle();
+  let resp;
+  try {
+    resp = await net.fetch(url, { bypassCustomProtocolHandlers: true, headers, signal: _ac.signal });
+  } finally {
+    _disarmIdle();
+  }
   if (resp.status === 416) {
     const err = new Error('HTTP 416 Range Not Satisfiable（本地半成品与远端不符）');
     err._httpStatus = 416;
@@ -922,7 +937,9 @@ async function _downloadRemoteFileOnce(url, dest, maxBytes, onProgress, opts = {
     const out = fs.createWriteStream(partPath, { flags: writeFlags });
     try {
       while (true) {
+        _armIdle();                 // 等下一数据块·超过 IDLE_MS 无数据即 abort
         const chunk = await reader.read();
+        _disarmIdle();              // 已拿到响应（块/结束）·写盘期间不误触发超时
         if (chunk.done) break;
         const buf = Buffer.from(chunk.value);
         received += buf.length;
@@ -938,6 +955,7 @@ async function _downloadRemoteFileOnce(url, dest, maxBytes, onProgress, opts = {
         if (typeof onProgress === 'function') onProgress({ received, total, percent: total ? (received / total * 100) : 0 });
       }
     } finally {
+      _disarmIdle();
       await new Promise(resolve => out.end(resolve));
       // 中断时取消 body·让底层 HTTP 请求真正中止（不取消会泄漏挂起连接）
       try { reader.cancel().catch(() => {}); } catch (e) {}
@@ -953,7 +971,9 @@ async function _downloadRemoteFileOnce(url, dest, maxBytes, onProgress, opts = {
     return { path: dest, size: received, sha256: inlineHash.digest('hex') };
   }
 
-  const ab = await resp.arrayBuffer();
+  _armIdle();
+  let ab;
+  try { ab = await resp.arrayBuffer(); } finally { _disarmIdle(); }
   const buf = Buffer.from(ab);
   if (buf.length > maxBytes) {
     const err = new Error('下载文件超过大小上限');

--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,12 +2,12 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.10",
   "entry": "index.html",
-  "generatedAt": "2026-07-20T03:01:05.357Z",
+  "generatedAt": "2026-07-20T08:22:09.067Z",
   "files": [
     {
       "path": "_app_main.js",
-      "sha256": "553ff7924bd27c719f86f9cdf8a4131ee8cfb8cca9cc04671d3df2e2475985ff",
-      "size": 137080
+      "sha256": "b1cbe79162f7204e9caa2c657520671f91c936c16bde05a3f09d4c86383d3451",
+      "size": 138308
     },
     {
       "path": "_app_preload.js",


### PR DESCRIPTION
@
## 问题（仓主反馈）
热更新有时「莫名其妙卡住」。

## 病根
`main-impl.js` 下载用 `net.fetch` + `reader.read()` 逐块读。连接**挂起但不断流**（socket 还在、数据不来·Cloudflare/弱网极常见）时 `reader.read()` **永久阻塞、不报错** → 上层「带重试 + 断点续传」逻辑（只在抛错时触发）**永不启动** → UI 干等。续传设施本就有（写 `.part` + HTTP Range·`resume:true`·版本键控稳定路径·app 重开也复用），只是卡住时没触发它。

## 修（`main-impl.js` · `_downloadRemoteFileOnce` 四刀）
`AbortController` + 空闲计时器：每次等新数据块超过 `idleTimeoutMs`（默认 30s）就 `abort` → 抛错 → 走已有的可续传重试（从 `.part` 断点续）。arm 只围「读」、写盘期 disarm 不误触发；fetch / 读循环 / arrayBuffer 兜底 / finally 全路径清计时器。**→ 卡住自动转成「续传恢复」**。`node --check` 通过。

安卓 Capgo 侧续传是更大改动（涉及原生下载器），另议。

## 顺补
`AGENTS.md` line 113「一句话」残留的「OTA 只发跟踪代码」旧句（PR #14 漏改·Codex 发版演练眼尖发现）→ 纠正为「OTA 必须自带 web/assets」，与第三节血泪教训一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@