### PR TITLE
安卓OTA下载健壮性：停滞看门狗+有界自动重试+busy泄漏修复

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -3606,8 +3606,8 @@
     },
     {
       "path": "tm-capacitor-boot.js",
-      "sha256": "3e53de57f04cd152aada0e4955cd8765502b9f30cb7d3a72d0cc746c43e93b2e",
-      "size": 23148
+      "sha256": "f9c65ba9af91e8162acb4491e3875a32747a5d71734f0c722ce022085d287e93",
+      "size": 27836
     },
     {
       "path": "tm-ceming.js",

--- a/web/scripts/smoke-capgo-ota-stall-retry.js
+++ b/web/scripts/smoke-capgo-ota-stall-retry.js
@@ -1,0 +1,178 @@
+// smoke-capgo-ota-stall-retry.js — 安卓 Capgo OTA 下载健壮性（停滞看门狗/有界重试/busy 泄漏）
+//
+// 病灶(玩家真机实证·2026-07-20 1.3.4.10 发版当天)：850MB 全量包下载「卡在10%不动」——
+// tm-capacitor-boot.js 原实现①无停滞侦测(插件 promise 挂住→进度卡冻结永不动)②失败文案说
+// "稍后重试"但从未排程任何重试③busy 旗一挂·玩家手动「检查更新」被静默吞掉(点了没反应)。
+// 修法：percent 看门狗(90s 无前进→卡面如实示「下载停滞」·恢复自动回正常态·Capgo v6 无取消
+// API 故绝不假取消)+ 失败 15s/45s 退避自动重试共 3 次 + 彻底失败 10 分钟单发再查 + busy 中
+// verbose 检查如实回显状态。本 smoke 用假时钟/假 DOM/mock 插件把整条链走一遍。
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var vm = require('vm');
+
+var ROOT = path.join(__dirname, '..');
+var failures = [];
+function assert(cond, msg) {
+  if (cond) { console.log('  PASS ' + msg); }
+  else { failures.push(msg); console.log('  FAIL ' + msg); }
+}
+
+// ── 假时钟（模块内 setTimeout/setInterval/Date.now 全走它·vm realm 本无 timer 全局）──
+var fakeNow = 0;
+var timers = [];
+var tid = 1;
+function addTimer(fn, ms, isInterval) {
+  timers.push({ id: tid, fn: fn, at: fakeNow + (Number(ms) || 0), interval: isInterval ? Math.max(1, Number(ms) || 1) : 0 });
+  return tid++;
+}
+function killTimer(id) {
+  for (var i = timers.length - 1; i >= 0; i--) if (timers[i].id === id) timers.splice(i, 1);
+}
+function flush() { // 跨 realm promise 链要多轮微任务才能走完
+  return new Promise(function (r) {
+    var n = 0;
+    (function step() { if (++n > 6) return r(); setImmediate(step); })();
+  });
+}
+async function advance(ms) {
+  var target = fakeNow + ms;
+  for (;;) {
+    var next = null;
+    for (var i = 0; i < timers.length; i++) if (timers[i].at <= target && (!next || timers[i].at < next.at)) next = timers[i];
+    if (!next) break;
+    fakeNow = Math.max(fakeNow, next.at);
+    if (next.interval) next.at = fakeNow + next.interval;
+    else timers.splice(timers.indexOf(next), 1);
+    try { next.fn(); } catch (e) { failures.push('timer fn threw: ' + e.message); }
+    await flush();
+  }
+  fakeNow = target;
+}
+
+// ── 假 DOM（进度卡只 set 属性·stub 即可）──
+function el() {
+  var self = {
+    style: {}, textContent: '', innerHTML: '', hidden: false, id: '', className: '',
+    classList: { add: function () {}, remove: function () {}, contains: function () { return false; } },
+    setAttribute: function () {}, getAttribute: function () { return null; },
+    addEventListener: function () {}, appendChild: function () {}, removeChild: function () {},
+    contains: function () { return true; }, parentNode: null,
+    querySelector: function () { return el(); }
+  };
+  return self;
+}
+
+// ── mock Capgo 插件 ──
+var calls = { download: 0, set: 0, notifyReady: 0 };
+var pendingDl = null; // {resolve, reject, opt}
+var progressCbs = [];
+function emitPct(p) {
+  progressCbs.slice().forEach(function (cb) { cb({ percent: p }); });
+}
+var U = {
+  notifyAppReady: function () { calls.notifyReady++; },
+  current: function () { return Promise.resolve({ bundle: { version: '1.3.4.9' } }); },
+  addListener: function (_name, cb) {
+    progressCbs.push(cb);
+    return Promise.resolve({ remove: function () { var i = progressCbs.indexOf(cb); if (i >= 0) progressCbs.splice(i, 1); } });
+  },
+  download: function (opt) {
+    calls.download++;
+    return new Promise(function (res, rej) { pendingDl = { resolve: res, reject: rej, opt: opt }; });
+  },
+  set: function () { calls.set++; return Promise.resolve(); },
+  reload: function () { return Promise.resolve(); }
+};
+
+// ── 沙箱 ──
+var sandbox = { console: console };
+sandbox.window = sandbox;
+sandbox.global = sandbox;
+sandbox.Date = { now: function () { return fakeNow; } };
+sandbox.setTimeout = function (fn, ms) { return addTimer(fn, ms, false); };
+sandbox.setInterval = function (fn, ms) { return addTimer(fn, ms, true); };
+sandbox.clearTimeout = killTimer;
+sandbox.clearInterval = killTimer;
+sandbox.document = {
+  readyState: 'complete',
+  head: el(), documentElement: el(), body: el(),
+  getElementById: function () { return null; },
+  querySelector: function () { return null; },
+  createElement: function () { return el(); }
+};
+sandbox.fetch = function () {
+  return Promise.resolve({
+    ok: true,
+    json: function () { return Promise.resolve({ version: '1.3.4.10', url: 'https://x/capgo/bundles/1.3.4.10.zip', size: 854845027 }); },
+    headers: { get: function () { return '854845027'; } }
+  });
+};
+sandbox.Capacitor = { isNativePlatform: function () { return true; }, Plugins: { CapacitorUpdater: U } };
+vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync(path.join(ROOT, 'tm-capacitor-boot.js'), 'utf8'), sandbox, { filename: 'tm-capacitor-boot.js' });
+
+function dbg() { return sandbox.TM.capacitorUpdate._dl(); }
+
+(async function main() {
+  await flush();
+
+  console.log('① 启动自检→发现新版→开始下载');
+  await advance(5000); // arm(): notifyReady@1.8s + 自动检查@5s
+  assert(calls.notifyReady === 1, 'notifyAppReady 已调用');
+  assert(calls.download === 1, '发现 1.3.4.10 高于本地 1.3.4.9 → download 启动');
+  assert(dbg().busy === true && dbg().active === true, '下载中 busy/active 竖旗');
+
+  console.log('② 进度前进·无停滞误报');
+  emitPct(5); await flush();
+  emitPct(10); await flush();
+  assert(dbg().lastPct === 10, 'percent 前进记账到 10%');
+  await advance(30000);
+  assert(dbg().stalled === false, '30s 未超阈值·不误报停滞');
+
+  console.log('③ 停滞看门狗（90s 无前进→判停滞·真机「卡在10%」案）');
+  await advance(95000);
+  assert(dbg().stalled === true, '95s 无进度 → stalled 竖旗·卡面示「下载停滞」');
+
+  console.log('④ busy 泄漏修复：下载中手动检查不吞·不重复起下载');
+  sandbox.TM.capacitorUpdate.check(); await flush();
+  assert(calls.download === 1, 'busy 中手动 check 不新起下载');
+  assert(dbg().busy === true, 'busy 状态如实保持');
+
+  console.log('⑤ 进度恢复→停滞旗自动落');
+  emitPct(12); await flush();
+  assert(dbg().stalled === false, '进度恢复 → stalled 自动清·回正常下载态');
+
+  console.log('⑥ 下载失败→15s/45s 退避自动重试');
+  pendingDl.reject(new Error('ENETDOWN')); pendingDl = null; await flush();
+  assert(dbg().attempts === 1, '第 1 次尝试失败已记账');
+  await advance(15000);
+  assert(calls.download === 2, '15s 退避后自动重试（第 2 次）');
+  pendingDl.reject(new Error('ENETDOWN')); pendingDl = null; await flush();
+  await advance(45000);
+  assert(calls.download === 3, '45s 退避后自动重试（第 3 次）');
+
+  console.log('⑦ 三连败→彻底失败·busy 释放·10 分钟单发再查');
+  pendingDl.reject(new Error('ENETDOWN')); pendingDl = null; await flush();
+  assert(dbg().active === false, '三连败后下载态收旗');
+  assert(dbg().busy === false, 'busy 释放·手动检查通道恢复');
+  await advance(600000);
+  assert(calls.download === 4, '10 分钟后自动再查 → 新一轮下载');
+
+  console.log('⑧ 成功收尾：set 生效·busy 释放');
+  pendingDl.resolve({ id: 'bundle-1' }); pendingDl = null; await flush(); await flush();
+  assert(calls.set === 1, '下载成功 → set(bundle) 已调用');
+  assert(dbg().busy === false && dbg().active === false, '成功后 busy/active 全收旗');
+  assert(progressCbs.length === 0, '进度监听器全部摘除·无泄漏');
+
+  console.log('');
+  if (failures.length) {
+    console.log('FAIL smoke-capgo-ota-stall-retry: ' + failures.length + ' 处失败');
+    failures.forEach(function (f) { console.log('  - ' + f); });
+    process.exit(1);
+  }
+  console.log('PASS smoke-capgo-ota-stall-retry (' + '停滞看门狗/有界重试/busy 泄漏' + ')');
+})().catch(function (e) {
+  console.error('SMOKE CRASH:', e);
+  process.exit(1);
+});

--- a/web/tm-capacitor-boot.js
+++ b/web/tm-capacitor-boot.js
@@ -9,6 +9,11 @@
 //     → set（下次启动生效）。下载过程把 Capgo 的 download 进度事件接到屏幕上的
 //     「下载进度卡」：百分比 + 已下载/总大小 + 实时速度 + 剩余时间，下完弹「重启生效」。
 //  ③ 仅 capacitor 原生端执行；桌面/web 整模块 no-op。
+//  ④ 健壮性（2026-07-20·玩家真机「卡在10%不动」实案）：停滞看门狗（长时间无进度→卡面如实
+//     示「下载停滞」·进度恢复自动回正常态）+ 下载失败有界自动重试（15s/45s 退避·共 3 次）+
+//     彻底失败 10 分钟后自动再查一次；下载中手动「检查更新」不再被 busy 旗静默吞掉。
+//     Capgo v6 无取消下载 API·原生下载挂死时 JS 杀不掉它——故停滞只做诚实提示与恢复自愈，
+//     绝不假装取消；promise 真拒绝（断网/写盘失败）才走自动重试。
 // ============================================================
 
 (function () {
@@ -242,6 +247,15 @@
       var eta = (bps && totalBytes) ? (totalBytes - doneBytes) / bps : 0;
       etaEl.textContent = eta ? fmtEta(eta) : '';
     }
+    function stalled(pct, sec) {
+      ensure();
+      root.classList.remove('tm-ota-done');
+      root.classList.add('tm-ota-settled'); // 停扫光·别再假装在动
+      titleEl.textContent = '下载停滞';
+      spdEl.textContent = '已停滞 ' + Math.max(0, sec || 0) + ' 秒';
+      etaEl.textContent = '网络无响应·恢复后自动继续';
+      // 百分比与已下大小保留不清——诚实呈现卡在哪
+    }
     function done(ver) {
       clearDismiss();
       ensure();
@@ -283,7 +297,7 @@
       setTimeout(function () { if (root && root.parentNode) { root.parentNode.removeChild(root); } root = null; }, 380);
     }
 
-    return { show: show, progress: progress, done: done, toast: toast, fail: fail, hide: hide };
+    return { show: show, progress: progress, stalled: stalled, done: done, toast: toast, fail: fail, hide: hide };
   })();
 
   // ── 拿 zip 总大小（算速度/ETA 用）：优先 latest.size，否则 HEAD content-length ──
@@ -297,6 +311,21 @@
     }).catch(function () { return 0; });
   }
 
+  // ── 停滞侦测 + 有界自动重试（2026-07-20·玩家「卡在10%不动」实案）──────────
+  var STALL_MS = 90000;               // 90s 无进度前进→判停滞（850MB 级大包·percent 事件粒度粗·阈值放宽防慢网误报）
+  var STALL_POLL_MS = 5000;
+  var MAX_ATTEMPTS = 3;               // 首次 + 自动重试 2 次
+  var RETRY_DELAY_MS = [15000, 45000];
+  var RECHECK_AFTER_FAIL_MS = 600000; // 彻底失败后 10 分钟整体再查一次（单发·不无限轮询）
+
+  var dl = { active: false, stalled: false, attempts: 0, lastPct: 0, lastAdvanceAt: 0, version: '' };
+  var recheckArmed = false;
+  function scheduleRecheck() {
+    if (recheckArmed) return;
+    recheckArmed = true;
+    setTimeout(function () { recheckArmed = false; runCheck(false); }, RECHECK_AFTER_FAIL_MS);
+  }
+
   // ── 主流程：检查 → （有更新则）可视化下载 → set ───────────────────────────
   var busy = false;
   function runCheck(verbose) {
@@ -305,7 +334,15 @@
       if (verbose) ui.fail('更新组件不可用');
       return Promise.resolve();
     }
-    if (busy) return Promise.resolve();
+    if (busy) {
+      // busy 泄漏修复：下载进行中玩家手动点「检查更新」不再被静默吞掉——把卡重新亮出来·如实反映状态
+      if (verbose) {
+        if (dl.active && dl.stalled) ui.stalled(dl.lastPct, Math.round((now() - dl.lastAdvanceAt) / 1000));
+        else if (dl.active) ui.show('正在下载更新', dl.version);
+        else ui.toast('正在检查更新…', '', 2500);
+      }
+      return Promise.resolve();
+    }
     if (typeof fetch !== 'function') return Promise.resolve();
     busy = true;
     if (verbose) ui.show('正在检查更新…');
@@ -339,6 +376,8 @@
 
   function startDownload(U, latest) {
     ui.show('正在下载更新', latest.version);
+    dl.active = true; dl.stalled = false; dl.attempts = 0;
+    dl.lastPct = 0; dl.lastAdvanceAt = now(); dl.version = latest.version;
     return resolveTotal(latest).then(function (total) {
       // 速度采样（滚动 2.5s 窗口）
       var samples = [];
@@ -356,42 +395,76 @@
       var lastPaint = 0;
       function onPercent(pct) {
         pct = Math.max(0, Math.min(100, pct || 0));
+        if (pct > dl.lastPct) {              // 只认真前进·停滞计时随之清零
+          dl.lastPct = pct; dl.lastAdvanceAt = now();
+          if (dl.stalled) { dl.stalled = false; ui.show('正在下载更新', latest.version); } // 停滞恢复→回正常态
+        }
         var bytes = total ? total * pct / 100 : 0;
         if (total) pushSample(bytes);
         var t = now();
         if (t - lastPaint < 200 && pct < 100) return;   // 限频，避免过度重绘
         lastPaint = t;
-        ui.progress(pct, bytes, total, total ? speed() : 0);
-      }
-
-      // 接 download 进度事件
-      var handle = null;
-      try {
-        if (typeof U.addListener === 'function') {
-          handle = U.addListener('download', function (e) {
-            onPercent(e && typeof e.percent === 'number' ? e.percent : 0);
-          });
-        }
-      } catch (_) {}
-      function removeListener() {
-        try { Promise.resolve(handle).then(function (h) { if (h && h.remove) h.remove(); }); } catch (_) {}
+        if (!dl.stalled) ui.progress(pct, bytes, total, total ? speed() : 0);
       }
 
       var opt = { version: latest.version, url: latest.url || '' };
       if (latest.manifest && latest.manifest.length) opt.manifest = latest.manifest;
 
-      ui.progress(0, 0, total, 0);
-      return Promise.resolve(U.download(opt)).then(function (b) {
-        removeListener();
-        if (b && b.id && U.set) {
-          return Promise.resolve(U.set({ id: b.id })).then(function () { ui.done(latest.version); });
+      function attempt() {
+        dl.attempts++;
+        dl.stalled = false; dl.lastAdvanceAt = now();
+        // 接 download 进度事件（每次尝试各自挂/摘·避免旧监听器窜台）
+        var handle = null;
+        try {
+          if (typeof U.addListener === 'function') {
+            handle = U.addListener('download', function (e) {
+              onPercent(e && typeof e.percent === 'number' ? e.percent : 0);
+            });
+          }
+        } catch (_) {}
+        function removeListener() {
+          try { Promise.resolve(handle).then(function (h) { if (h && h.remove) h.remove(); }); } catch (_) {}
         }
-        ui.done(latest.version);
-      }).catch(function (err) {
-        removeListener();
-        try { console.warn('[tm-capacitor-boot] 下载失败', err); } catch (_) {}
-        ui.fail('下载失败，稍后重试');
-      });
+        // 停滞看门狗：percent 长时间不前进→卡面如实亮「下载停滞」·进度一恢复自动回正常态
+        var watchdog = setInterval(function () {
+          if (!dl.active) return;
+          var idle = now() - dl.lastAdvanceAt;
+          if (idle > STALL_MS) {
+            if (!dl.stalled) {
+              dl.stalled = true;
+              try { console.warn('[tm-capacitor-boot] 下载停滞 ' + Math.round(idle / 1000) + 's @' + dl.lastPct + '%'); } catch (_) {}
+            }
+            ui.stalled(dl.lastPct, Math.round(idle / 1000));
+          }
+        }, STALL_POLL_MS);
+        function cleanup() {
+          removeListener();
+          try { clearInterval(watchdog); } catch (_) {}
+        }
+
+        ui.progress(dl.lastPct, total ? total * dl.lastPct / 100 : 0, total, 0);
+        return Promise.resolve(U.download(opt)).then(function (b) {
+          cleanup(); dl.active = false; dl.stalled = false;
+          if (b && b.id && U.set) {
+            return Promise.resolve(U.set({ id: b.id })).then(function () { ui.done(latest.version); });
+          }
+          ui.done(latest.version);
+        }).catch(function (err) {
+          cleanup();
+          try { console.warn('[tm-capacitor-boot] 下载失败(第' + dl.attempts + '/' + MAX_ATTEMPTS + '次)', err); } catch (_) {}
+          if (dl.attempts < MAX_ATTEMPTS) {
+            var wait = RETRY_DELAY_MS[dl.attempts - 1] || 45000;
+            ui.toast('下载失败·' + Math.round(wait / 1000) + ' 秒后自动重试（第 ' + (dl.attempts + 1) + '/' + MAX_ATTEMPTS + ' 次）', latest.version, 0);
+            return new Promise(function (res) {
+              setTimeout(function () { ui.show('正在下载更新', latest.version); res(attempt()); }, wait);
+            });
+          }
+          dl.active = false; dl.stalled = false;
+          ui.fail('下载失败·10 分钟后自动再查·也可在设置里手动检查');
+          scheduleRecheck();
+        });
+      }
+      return attempt();
     });
   }
 
@@ -418,6 +491,10 @@
         var U = updater();
         if (U && typeof U.reload === 'function') return U.reload();
         return Promise.resolve();
+      },
+      // 调试/测试探针：下载状态快照（smoke 与真机排查用·非游戏 API）
+      _dl: function () {
+        return { busy: busy, active: dl.active, stalled: dl.stalled, attempts: dl.attempts, lastPct: dl.lastPct, version: dl.version };
       }
     };
   } catch (_) {}


### PR DESCRIPTION
## 病灶（玩家真机实案·2026-07-20 1.3.4.10 发版当天）

QQ 群玩家两台设备 850MB 全量包下载**「卡在 10% 不动」**、手动点「检查更新」没反应。`tm-capacitor-boot.js` 三处硬伤：

1. **无停滞侦测**——Capgo `download()` promise 挂住时进度卡永远冻结，玩家只能干瞪眼
2. **失败不重试**——fail 文案说「稍后重试」但从未排程任何重试
3. **busy 旗泄漏**——下载挂住后手动「检查更新」被 `if (busy) return` 静默吞掉

Capgo v6.45 **没有取消下载 API**（已核 definitions.d.ts），JS 杀不掉挂起的原生下载——所以停滞处理只做**诚实提示 + 恢复自愈**，绝不假装取消；promise 真拒绝（断网/写盘失败）才走自动重试。

## 修法

- **停滞看门狗**：90s 无 percent 前进 → 卡面如实示「下载停滞 · 已停滞 Ns · 恢复后自动继续」（停扫光·保留百分比）；进度一恢复自动回正常下载态。阈值 90s 放宽是因为 850MB 包 percent 事件粒度粗（1%≈8.5MB），防慢网误报
- **有界自动重试**：download 拒绝时 15s/45s 退避重试共 3 次，每次尝试独立挂/摘进度监听器；彻底失败 10 分钟后单发自动再查（不无限轮询）
- **busy 泄漏修复**：下载中 verbose 手动检查如实回显当前状态（下载中/停滞中），不再静默 no-op
- `TM.capacitorUpdate._dl()` 调试探针（smoke 与真机 adb 排查用）

## 验证

- 新 smoke `smoke-capgo-ota-stall-retry.js`（假时钟+假 DOM+mock 插件走全链）：停滞判定/不误报/恢复自愈/busy 不吞/三连败退避/10 分钟再查/成功收尾/监听器无泄漏 **16 断言全绿**
- `ci-smokes` **775 PASS**（豁免 2 缺资产白名单）· `lint-arch-all` **8/8** · `verify-release-contract` **94 断言** · `sync-hot-baseline --check` **PASS**
- 基线为单条目外科对齐（worktree 无未跟踪资产不可跑 `--write`，diff 仅 4 行，`--check` 与 CI 同尺验证）

不发版：修复随下个热更自然带出。安卓**断点续传**属更大改动（Capgo 全量 zip 机制所限），本 PR 不含，另行立案。

🤖 Generated with [Claude Code](https://claude.com/claude-code)