### PR TITLE
问天升级批：兑现对账（确定性核验）+ 直改当回合撤销（flag 默认 OFF）

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -4081,8 +4081,8 @@
     },
     {
       "path": "tm-endturn-render.js",
-      "sha256": "3e7ad57aef3675c22946763813d33c8c41b966e6f6d203b39e0c9690437609d1",
-      "size": 29774
+      "sha256": "bd9f8db1d7d7739716e0d9dc74e4eb9dd0056a1c6b1cb68157aa8785f78fd2bc",
+      "size": 30022
     },
     {
       "path": "tm-endturn-shiji-compose.js",
@@ -4296,13 +4296,13 @@
     },
     {
       "path": "tm-game-loop-wentian-hardchange.js",
-      "sha256": "8d26025c6850d85fbb9e55d07197fd7d91239f45b579ccf573a271ee86843d9a",
-      "size": 56796
+      "sha256": "11783df70d44dac8ea240f47313f8b2e8632d7773caf00e1940421a2568f5f9e",
+      "size": 66524
     },
     {
       "path": "tm-game-loop.js",
-      "sha256": "ae52d82435baddba8aa624463da4213eeca9f7e27d66043b9e3846cb3adb181e",
-      "size": 102409
+      "sha256": "dbb59c1ed1338d8d6fba32a9c620d49ccea50cbf516e6c231422cac01b5cd4da",
+      "size": 105049
     },
     {
       "path": "tm-game-ui-shell.js",
@@ -5006,8 +5006,8 @@
     },
     {
       "path": "tm-patches.js",
-      "sha256": "0f9990c6ec0760a2116bcd6ecb7f56d4f7f8bf4b0aced466d57dc7c4f132b1b1",
-      "size": 177600
+      "sha256": "c0c345ef5df90f13ea9546038e40522f664749bfe52f3893846e656f2fa9c0df",
+      "size": 179547
     },
     {
       "path": "tm-pause-fab.js",
@@ -5331,8 +5331,8 @@
     },
     {
       "path": "tm-wentian-agent.js",
-      "sha256": "60382dc6fa2040ab680a879be1f6dc2ad5514070b1a21b7ae211b7f49aa6f775",
-      "size": 10905
+      "sha256": "7103c9fc9e93f1915e719dcd59c8016b4995b403c27ae8c8748cf2ab2ce9b9a3",
+      "size": 12154
     },
     {
       "path": "tm-worker.js",

--- a/web/scripts/smoke-wentian-fulfill-audit.js
+++ b/web/scripts/smoke-wentian-fulfill-audit.js
@@ -1,0 +1,115 @@
+// smoke-wentian-fulfill-audit.js — 问天·兑现对账（刀A·2026-07-21·flag 默认 OFF）
+//
+// 病灶：问天 rule/directive 入库时承诺「每回合回报执行状况」·但既有回报=推演 AI 自报作业
+// (directive_compliance)·没有任何确定性核查——AI 说「已遵」而在档数字没动·玩家无从得知。
+// 修法：submit 可附 watch 指标(path+expect[+value])·注册时快照基线·回合末 _wtRunFulfillAudit
+// 按在档真值确定性对账·盖进既有 _lastStatus 徽章(⚖︎对账前缀)·状态变化时入问天历史。
+// P.conf.wentianFulfillAudit === true 才启用(默认 OFF·设置→性能)。
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var vm = require('vm');
+
+var ROOT = path.join(__dirname, '..');
+var failures = [];
+function assert(cond, msg) {
+  if (cond) { console.log('  PASS ' + msg); }
+  else { failures.push(msg); console.log('  FAIL ' + msg); }
+}
+
+var sandbox = { console: console };
+sandbox.window = sandbox;
+sandbox.global = sandbox;
+sandbox.setTimeout = function () { return 0; };
+sandbox.clearTimeout = function () {};
+sandbox.GM = {
+  turn: 5,
+  chars: [{ name: '袁崇焕', loyalty: 55, alive: true }],
+  armies: [{ name: '关宁军', soldiers: 10000, morale: 50 }],
+  _playerDirectives: [],
+  _wentianHistory: []
+};
+sandbox.P = { conf: { wentianFulfillAudit: true } };
+vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync(path.join(ROOT, 'tm-game-loop-wentian-hardchange.js'), 'utf8'), sandbox, { filename: 'tm-game-loop-wentian-hardchange.js' });
+
+var GM = sandbox.GM;
+
+console.log('① 只读取值 _wtReadHardChangeValue（七类 resolver 复用·绝不创建）');
+var rv = sandbox._wtReadHardChangeValue('chars[袁崇焕].loyalty');
+assert(rv.ok === true && rv.value === 55, '人物路径读到真值 55');
+rv = sandbox._wtReadHardChangeValue('armies[关宁军].soldiers');
+assert(rv.ok === true && rv.value === 10000, '军队路径读到真值 10000');
+rv = sandbox._wtReadHardChangeValue('chars[幽灵人].loyalty');
+assert(rv.ok === false, '不在档人物 → ok:false（不创建幽灵键）');
+rv = sandbox._wtReadHardChangeValue('GM.guoku');
+assert(rv.ok === false, '不存在的 generic 字段 → ok:false');
+assert(!('guoku' in GM), '读操作没有创建 guoku 幽灵键');
+
+console.log('② watch 注册：可读的入账·读不到的丢弃·全不可读→null');
+var reg = sandbox._wtRegisterWatch([
+  { path: 'chars[袁崇焕].loyalty', expect: 'gte', value: 80, note: '袁崇焕忠诚' },
+  { path: 'armies[关宁军].soldiers', expect: 'increase' },
+  { path: 'chars[幽灵人].loyalty', expect: 'increase' }
+]);
+assert(reg && reg.items.length === 2, '3 条指标 → 幽灵路径丢弃 → 2 条入账');
+assert(reg.baseline['chars[袁崇焕].loyalty'] === 55 && reg.baseline['armies[关宁军].soldiers'] === 10000, '基线快照 55/10000');
+assert(reg.registeredTurn === 5, '注册回合=5');
+assert(sandbox._wtRegisterWatch([{ path: 'chars[幽灵人].loyalty', expect: 'increase' }]) === null, '全不可读 → null（诚实：不做假对账）');
+assert(sandbox._wtRegisterWatch([{ path: 'chars[袁崇焕].loyalty', expect: '不合法' }]) === null, '非法 expect → 不入账');
+
+var dir = { id: 'd1', content: '整顿关宁军·安抚袁崇焕', type: 'rule', _watch: reg };
+GM._playerDirectives.push(dir);
+
+console.log('③ 注册当回合不对账（推演还没跑）');
+sandbox._wtRunFulfillAudit();
+assert(dir._lastStatus === undefined, '当回合不盖状态');
+assert(GM._wentianHistory.length === 0, '当回合不落史行');
+
+console.log('④ 次回合对账：1/2 中 → partial·⚖︎对账前缀·落史');
+GM.turn = 6;
+GM.chars[0].loyalty = 85;   // gte 80 达标
+sandbox._wtRunFulfillAudit();
+assert(dir._lastStatus === 'partial', '1/2 → partial');
+assert(String(dir._lastReason || '').indexOf('⚖︎对账 1/2') === 0, '_lastReason 带「⚖︎对账 1/2」前缀（可与 AI 自报区分）');
+assert(GM._wentianHistory.length === 1 && GM._wentianHistory[0].content.indexOf('部分兑现') >= 0, '状态首判 → 落史「部分兑现」');
+
+console.log('⑤ 同回合幂等（多 pass 结算只审一次）');
+sandbox._wtRunFulfillAudit();
+assert(GM._wentianHistory.length === 1, '同回合重跑不重复落史');
+
+console.log('⑥ 再次回合全中 → followed·状态变化落史');
+GM.turn = 7;
+GM.armies[0].soldiers = 12000;  // increase 达标（基线 10000）
+sandbox._wtRunFulfillAudit();
+assert(dir._lastStatus === 'followed', '2/2 → followed（账本可纠 AI 自报）');
+assert(GM._wentianHistory.length === 2 && GM._wentianHistory[1].content.indexOf('已兑现') >= 0, '状态变化 → 落史「已兑现」');
+
+console.log('⑦ 状态未变不刷屏');
+GM.turn = 8;
+sandbox._wtRunFulfillAudit();
+assert(GM._wentianHistory.length === 2, '连续 followed → 不重复落史');
+
+console.log('⑧ 判定算子逐一验证');
+var J = sandbox._wtJudgeWatchItem;
+assert(J({ expect: 'decrease' }, 50, true, 40).met === true, 'decrease 50→40 met');
+assert(J({ expect: 'decrease' }, 50, true, 60).met === false, 'decrease 50→60 未met');
+assert(J({ expect: 'lte', value: 30 }, 50, true, 25).met === true, 'lte 25≤30 met');
+assert(J({ expect: 'eq', value: '京师' }, '辽东', true, '京师').met === true, 'eq 字符串相等 met');
+assert(J({ expect: 'change' }, '辽东', true, '辽东').met === false, 'change 未变 未met');
+assert(J({ expect: 'increase' }, 10, false, null).met === false, '读不到现值 → 未met');
+
+console.log('⑨ flag OFF → 零行为');
+sandbox.P.conf.wentianFulfillAudit = false;
+GM.turn = 9;
+GM.chars[0].loyalty = 1;  // 若审会翻 ignored
+sandbox._wtRunFulfillAudit();
+assert(dir._lastStatus === 'followed' && GM._wentianHistory.length === 2, 'flag 关 → 不审不落史（默认 OFF 零行为）');
+
+console.log('');
+if (failures.length) {
+  console.log('FAIL smoke-wentian-fulfill-audit: ' + failures.length + ' 处失败');
+  failures.forEach(function (f) { console.log('  - ' + f); });
+  process.exit(1);
+}
+console.log('PASS smoke-wentian-fulfill-audit (确定性兑现对账·基线快照/幂等/状态变化落史/flag门)');

--- a/web/scripts/smoke-wentian-undo.js
+++ b/web/scripts/smoke-wentian-undo.js
@@ -1,0 +1,110 @@
+// smoke-wentian-undo.js — 问天·直改当回合撤销（刀B·2026-07-21·flag 默认 OFF）
+//
+// 病灶：问天 hardChange 即时生效·无后悔药——AI 裁定看走眼/玩家点快了·只能反向再改一笔。
+// 修法：确认现场 flag 开时每笔 apply 武装 _wtBeginUndoCapture 捕获窗·经 _wtAfterHardChange
+// 快照 before 值(顺修军队主帅分支原传 '' 的假 old)·当回合内 _wtUndoHardChange 逆序回滚——
+// replay 走同一 _wtApplyHardChange·别名(size/strength)/镜像/UI 刷新随之复原。
+// 过回合不可撤(推演已消化)·天意 allowCreate 造物不给快照·P.conf.wentianUndo===true 才启用。
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var vm = require('vm');
+
+var ROOT = path.join(__dirname, '..');
+var failures = [];
+function assert(cond, msg) {
+  if (cond) { console.log('  PASS ' + msg); }
+  else { failures.push(msg); console.log('  FAIL ' + msg); }
+}
+
+var toasts = [];
+var sandbox = { console: console };
+sandbox.window = sandbox;
+sandbox.global = sandbox;
+sandbox.setTimeout = function () { return 0; };
+sandbox.clearTimeout = function () {};
+sandbox.toast = function (m) { toasts.push(String(m || '')); };
+sandbox.GM = {
+  turn: 3,
+  chars: [{ name: '袁崇焕', loyalty: 55, alive: true }],
+  armies: [{ name: '关宁军', soldiers: 10000, size: 10000, strength: 10000, morale: 50, commander: '满桂' }],
+  _playerDirectives: [],
+  _wentianHistory: []
+};
+sandbox.P = { conf: { wentianUndo: true } };
+vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync(path.join(ROOT, 'tm-game-loop-wentian-hardchange.js'), 'utf8'), sandbox, { filename: 'tm-game-loop-wentian-hardchange.js' });
+
+var GM = sandbox.GM;
+
+console.log('① 捕获窗：每笔 apply 恰捕一笔·old 为落笔前真值');
+sandbox._wtBeginUndoCapture();
+var ok1 = sandbox._wtApplyHardChange('chars[袁崇焕].loyalty', 'set', 100);
+var cap1 = sandbox._wtEndUndoCapture();
+assert(ok1 === true && GM.chars[0].loyalty === 100, '直改生效 loyalty 55→100');
+assert(cap1.length === 1 && cap1[0].old === 55, '捕获 old=55');
+
+sandbox._wtBeginUndoCapture();
+var ok2 = sandbox._wtApplyHardChange('armies[关宁军].soldiers', 'add', 5000);
+var cap2 = sandbox._wtEndUndoCapture();
+assert(ok2 === true && GM.armies[0].soldiers === 15000, '军队 add 生效 10000→15000');
+assert(GM.armies[0].size === 15000 && GM.armies[0].strength === 15000, '别名 size/strength 同步 15000');
+assert(cap2.length === 1 && cap2[0].old === 10000, '捕获 old=10000');
+
+console.log('② 主帅分支真 old（原传 \'\' 的假 old 已修）');
+sandbox._wtBeginUndoCapture();
+var ok3 = sandbox._wtApplyHardChange('armies[关宁军].commander', 'set', '祖大寿');
+var cap3 = sandbox._wtEndUndoCapture();
+assert(ok3 === true && GM.armies[0].commander === '祖大寿', '主帅直改生效 满桂→祖大寿');
+assert(cap3.length === 1 && cap3[0].old === '满桂', '主帅捕获真 old=满桂（非空串）');
+
+console.log('③ 未武装时零捕获（捕获窗只在确认现场存在）');
+var ok4 = sandbox._wtApplyHardChange('chars[袁崇焕].loyalty', 'set', 90);
+assert(ok4 === true && sandbox._wtEndUndoCapture().length === 0, '未 begin → 不捕获');
+GM.chars[0].loyalty = 100;  // 复位到①后状态
+
+console.log('④ 一键回滚：逆序 replay·别名/镜像随之复原');
+var dir = {
+  id: 'u1', content: '直改批', type: 'correction',
+  _undoSnapshot: { turn: 3, changes: [
+    { reqPath: 'chars[袁崇焕].loyalty', old: 55 },
+    { reqPath: 'armies[关宁军].soldiers', old: 10000 },
+    { reqPath: 'armies[关宁军].commander', old: '满桂' }
+  ] }
+};
+GM._playerDirectives.push(dir);
+sandbox._wtUndoHardChange('u1');
+assert(GM.chars[0].loyalty === 55, 'loyalty 回滚 100→55');
+assert(GM.armies[0].soldiers === 10000 && GM.armies[0].size === 10000 && GM.armies[0].strength === 10000, '兵力+别名整体回滚 10000');
+assert(GM.armies[0].commander === '满桂', '主帅回滚 祖大寿→满桂');
+assert(dir._undone === true, '_undone 竖旗');
+assert(GM._wentianHistory.length === 1 && GM._wentianHistory[0].content.indexOf('已撤销直改 3/3') >= 0, '落史「已撤销直改 3/3」');
+assert(String(dir._lastReason || '').indexOf('玩家已撤销') === 0, '_lastReason=玩家已撤销');
+
+console.log('⑤ 双重撤销拒绝');
+GM.chars[0].loyalty = 77;
+sandbox._wtUndoHardChange('u1');
+assert(GM.chars[0].loyalty === 77 && GM._wentianHistory.length === 1, '已撤过 → no-op');
+
+console.log('⑥ 过回合拒绝（推演已消化·不可再撤）');
+var dir2 = { id: 'u2', content: '过期批', _undoSnapshot: { turn: 3, changes: [{ reqPath: 'chars[袁崇焕].loyalty', old: 55 }] } };
+GM._playerDirectives.push(dir2);
+GM.turn = 4;
+toasts.length = 0;
+sandbox._wtUndoHardChange('u2');
+assert(GM.chars[0].loyalty === 77 && !dir2._undone, '跨回合 → 不回滚');
+assert(toasts.some(function (t) { return t.indexOf('已过回合') >= 0; }), '提示「已过回合·不可撤销」');
+
+console.log('⑦ flag OFF → 零行为');
+sandbox.P.conf.wentianUndo = false;
+GM.turn = 3;
+sandbox._wtUndoHardChange('u2');
+assert(GM.chars[0].loyalty === 77 && !dir2._undone, 'flag 关 → 撤销入口死（默认 OFF 零行为）');
+
+console.log('');
+if (failures.length) {
+  console.log('FAIL smoke-wentian-undo: ' + failures.length + ' 处失败');
+  failures.forEach(function (f) { console.log('  - ' + f); });
+  process.exit(1);
+}
+console.log('PASS smoke-wentian-undo (捕获窗/真old/逆序回滚/别名复原/回合闸/flag门)');

--- a/web/tm-endturn-render.js
+++ b/web/tm-endturn-render.js
@@ -422,6 +422,8 @@ function _endTurn_render(shizhengji, zhengwen, playerStatus, playerInner, edicts
       try {
         if (typeof _awaitPostTurnJobsForSave === 'function') await _awaitPostTurnJobsForSave(typeof _postTurnSaveRequiredIds === 'function' ? _postTurnSaveRequiredIds() : ['sc25', 'sc25c']);
         if (!_endturnSaveStillCurrent()) return;
+        // 问天·兑现对账（刀A·flag 默认 OFF·同回合幂等）——放推演各 pass 落定后、autosave 前·结果随档入库
+        try { if (typeof _wtRunFulfillAudit === 'function') _wtRunFulfillAudit(); } catch (_wtFaHkE) {}
         _prepareGMForSave();
         if (!_endturnSaveStillCurrent()) return;
     // A-1·端回合自动封存·统一 snapshot builder·保持 IDB {GM,P} 格式

--- a/web/tm-game-loop-wentian-hardchange.js
+++ b/web/tm-game-loop-wentian-hardchange.js
@@ -331,6 +331,8 @@ function _wtScheduleHardChangeRefresh(normalizedPath, oldVal, newVal) {
 }
 
 function _wtAfterHardChange(normalizedPath, oldVal, newVal) {
+  // \u64A4\u9500\u5FEB\u7167\u7A97\u53E3\uFF08\u5200B\u00B7\u4EC5\u786E\u8BA4\u73B0\u573A\u6B66\u88C5\uFF09\u00B7typeof \u5B88\u536B\uFF1A\u90E8\u5206 smoke \u6309\u7A97\u53E3\u5207\u7247\u88C5\u8F7D\u672C\u6587\u4EF6\u00B7\u58F0\u660E\u53EF\u80FD\u4E0D\u5728\u5207\u7247\u5185
+  try { if (typeof _wtUndoCaptureBuf !== 'undefined' && _wtUndoCaptureBuf) _wtUndoCaptureBuf.push({ path: normalizedPath, old: oldVal, nv: newVal }); } catch (_wtCapE) {}
   _wtScheduleHardChangeRefresh(normalizedPath, oldVal, newVal);
   if (typeof addEB === 'function') addEB('\u95EE\u5929', '\u76F4\u6539 ' + normalizedPath + ' \u00B7 ' + oldVal + '\u2192' + newVal);
 }
@@ -868,12 +870,13 @@ function _wtApplyHardChange(path, op, value, opts) {
       var _armyPath = 'armies.' + armyChange.index + '.' + _f;
       if (_f === 'commander') {
         var _cmdVal = String(value == null ? '' : value).trim();
+        var _oldCmd = String(_a.commander == null ? '' : _a.commander);  // 真 old（原传 ''·撤销快照/变更日志都需要真值）
         try {
           if (typeof TM !== 'undefined' && TM.AIChange && TM.AIChange.Army && typeof TM.AIChange.Army.applyAIArmyChange === 'function') {
             TM.AIChange.Army.applyAIArmyChange({ armyName: _a.name, commander: _cmdVal, reason: '问天直改主帅' }, { source: 'wentian.hardChange' });
           } else { _a.commander = _cmdVal; }
         } catch (_wtCmdE) { _a.commander = _cmdVal; }
-        _wtAfterHardChange(_armyPath, '', _cmdVal);
+        _wtAfterHardChange(_armyPath, _oldCmd, _cmdVal);
         return true;
       }
       var _oldA = _a[_f];
@@ -1091,4 +1094,157 @@ function _wtClearDirectives() {
   GM._wentianHistory.push({ role: 'system', content: '\u6240\u6709\u6307\u4EE4\u5DF2\u6E05\u9664\u3002' });
   _wtRenderHistory();
   toast('\u6307\u4EE4\u5DF2\u6E05\u9664');
+}
+
+// ═══ 问天升级批（2026-07-21·两刀·flag 默认 OFF·设置→性能可开）════════════════════
+// 刀A 兑现对账：推演 AI 的合规回报(directive_compliance)是自报作业——本刀在回合末用在档真值
+//   对 watch 指标做确定性复核·盖进既有 _lastStatus 徽章体系（_lastReason 带「⚖︎对账」前缀·
+//   与 AI 自报可区分且能纠正它）。P.conf.wentianFulfillAudit === true 才启用。
+// 刀B 直改撤销：hardChange 档落笔时经 _wtAfterHardChange 快照 before 值·当回合内一键回滚
+//   （replay 走同一 _wtApplyHardChange·别名/镜像/UI 刷新随之复原）。天意 allowCreate 造物不可撤。
+//   P.conf.wentianUndo === true 才启用。
+
+// ── 只读取值（对账基线/现值用·复用七类 resolver·绝不创建任何字段）──
+function _wtReadHardChangeValue(path) {
+  try {
+    var normalizedPath = _wtNormalizeHardChangePath(path);
+    var parts = String(normalizedPath).split('.');
+    var root;
+    if (parts[0] === 'GM' || parts[0] === 'gm') { parts.shift(); root = (typeof GM !== 'undefined') ? GM : null; }
+    else if (parts[0] === 'P' || parts[0] === 'p') { parts.shift(); root = (typeof P !== 'undefined') ? P : null; }
+    else root = (typeof GM !== 'undefined') ? GM : null;
+    if (!root || !parts.length || !parts[0]) return { ok: false };
+    if (typeof GM !== 'undefined' && root === GM) {
+      var r;
+      if ((r = _wtResolveCharacterHardChange(parts)) && r.ch) {
+        var v = (r.field === 'location')
+          ? (r.ch.location || r.ch.place || r.ch.currentLocation || r.ch.loc || '')
+          : r.ch[r.field];
+        return { ok: true, value: v };
+      }
+      if ((r = _wtResolveArmyHardChange(parts)) && r.army) return { ok: true, value: r.army[r.field] };
+      if ((r = _wtResolveClassHardChange(parts)) && r.cls) return { ok: true, value: r.cls[r.field] };
+      if ((r = _wtResolveFacHardChange(parts)) && r.fac) return { ok: true, value: r.fac[r.field] };
+      if ((r = _wtResolvePartyHardChange(parts)) && r.party) return { ok: true, value: r.party[r.field] };
+      if ((r = _wtResolveDivisionHardChange(parts)) && r.div) {
+        var cur = r.div, fp = r.field.split('.');
+        for (var i = 0; i < fp.length; i++) {
+          if (cur == null || typeof cur !== 'object') return { ok: false };
+          cur = cur[fp[i]];
+        }
+        return { ok: true, value: cur };
+      }
+      if ((r = _wtResolveOfficeHardChange(parts)) && r.pos) return { ok: true, value: Number(r.pos.publicTreasury) || 0 };
+      if (/^(region|地域|丁口|田|田土|役|役政)$/i.test(String(parts[0]))) return { ok: false };  // renli 无只读探针·不入对账
+    }
+    // generic 只读导航（'in' 逐级核在·绝不创建）
+    var cur2 = root;
+    for (var j = 0; j < parts.length; j++) {
+      if (cur2 == null || typeof cur2 !== 'object' || !(parts[j] in cur2)) return { ok: false };
+      cur2 = cur2[parts[j]];
+    }
+    return { ok: true, value: cur2 };
+  } catch (_) { return { ok: false }; }
+}
+
+// ── 刀A·watch 注册（确认入库前调）：逐条校验可读性并快照基线·全不可读→null（诚实：不做假对账）──
+function _wtRegisterWatch(watchArr) {
+  if (!Array.isArray(watchArr) || !watchArr.length) return null;
+  var okExpect = { increase: 1, decrease: 1, gte: 1, lte: 1, eq: 1, change: 1 };
+  var items = [], baseline = {};
+  for (var i = 0; i < watchArr.length && items.length < 6; i++) {
+    var w = watchArr[i];
+    if (!w || !w.path || !okExpect[String(w.expect || '')]) continue;
+    var cur = _wtReadHardChangeValue(w.path);
+    if (!cur.ok) continue;
+    items.push({ path: String(w.path), expect: String(w.expect), value: (w.value != null ? w.value : null), note: String(w.note || '').slice(0, 40) });
+    baseline[String(w.path)] = cur.value;
+  }
+  if (!items.length) return null;
+  return { items: items, baseline: baseline, registeredTurn: (typeof GM !== 'undefined' && GM && GM.turn) || 0 };
+}
+
+function _wtJudgeWatchItem(item, baseVal, curOk, curVal) {
+  if (!curOk) return { met: false, text: '读不到现值' };
+  var nb = Number(baseVal), nc = Number(curVal), nv = Number(item.value);
+  var text = String(baseVal) + '→' + String(curVal);
+  switch (item.expect) {
+    case 'increase': return { met: isFinite(nc) && isFinite(nb) && nc > nb, text: text };
+    case 'decrease': return { met: isFinite(nc) && isFinite(nb) && nc < nb, text: text };
+    case 'gte': return { met: isFinite(nc) && isFinite(nv) && nc >= nv, text: '现' + String(curVal) + '/须≥' + String(item.value) };
+    case 'lte': return { met: isFinite(nc) && isFinite(nv) && nc <= nv, text: '现' + String(curVal) + '/须≤' + String(item.value) };
+    case 'eq': return { met: (isFinite(nc) && isFinite(nv)) ? nc === nv : String(curVal) === String(item.value), text: '现' + String(curVal) + '/须=' + String(item.value) };
+    case 'change': return { met: String(curVal) !== String(baseVal), text: text };
+  }
+  return { met: false, text: text };
+}
+
+// ── 刀A·回合末对账（tm-endturn-render 收尾调·同回合幂等·多 pass 结算安全）──
+function _wtRunFulfillAudit() {
+  try {
+    if (typeof GM === 'undefined' || !GM || !Array.isArray(GM._playerDirectives)) return;
+    if (!(typeof P !== 'undefined' && P && P.conf && P.conf.wentianFulfillAudit === true)) return;  // 默认 OFF
+    var turn = GM.turn || 0;
+    if (GM._wtAuditTurn === turn) return;  // arch-ok 问天对账回合戳·同回合多 pass 只审一次(与 _directivesAppliedTurn 同范式)
+    GM._wtAuditTurn = turn;  // arch-ok 同上
+    var stamps = [];
+    GM._playerDirectives.forEach(function (d) {
+      if (!d || !d._watch || !Array.isArray(d._watch.items) || !d._watch.items.length) return;
+      if (d._watch.registeredTurn === turn) return;  // 注册当回合不对账（推演还没跑）
+      var met = 0, parts = [];
+      d._watch.items.forEach(function (it) {
+        var cur = _wtReadHardChangeValue(it.path);
+        var j = _wtJudgeWatchItem(it, d._watch.baseline[it.path], cur.ok, cur.ok ? cur.value : null);
+        if (j.met) met++;
+        parts.push((j.met ? '✓' : '✗') + (it.note || it.path) + '(' + j.text + ')');
+      });
+      var status = met === d._watch.items.length ? 'followed' : (met > 0 ? 'partial' : 'ignored');
+      var prev = d._watch.lastStatus;
+      d._lastStatus = status;
+      d._lastReason = '⚖︎对账 ' + met + '/' + d._watch.items.length + '：' + parts.join('；');
+      d._lastCheckTurn = turn;
+      d._watch.lastStatus = status;
+      if (prev !== status) {
+        stamps.push('《' + String(d.content || '').slice(0, 18) + '》' + met + '/' + d._watch.items.length
+          + (status === 'followed' ? ' 已兑现' : status === 'partial' ? ' 部分兑现' : ' 未见兑现'));
+      }
+    });
+    if (stamps.length) {
+      if (!GM._wentianHistory) GM._wentianHistory = [];  // arch-ok 问天历史容器惰性初始化·与本文件既有范式同
+      var _faLine = '⚖︎ 兑现对账·T' + turn + '：' + stamps.join('；');
+      GM._wentianHistory.push({ role: 'system', content: _faLine });  // arch-ok 问天历史行·与本文件既有 _wentianHistory push 同容器同性质(刀A对账戳)
+    }
+  } catch (_wtFaErr) {}
+}
+
+// ── 刀B·撤销快照窗口 + 一键回滚 ──
+var _wtUndoCaptureBuf = null;
+function _wtBeginUndoCapture() { _wtUndoCaptureBuf = []; }
+function _wtEndUndoCapture() { var r = _wtUndoCaptureBuf; _wtUndoCaptureBuf = null; return r || []; }
+
+function _wtUndoHardChange(did) {
+  try {
+    if (!(typeof P !== 'undefined' && P && P.conf && P.conf.wentianUndo === true)) return;
+    if (typeof GM === 'undefined' || !GM || !Array.isArray(GM._playerDirectives)) return;
+    var d = null;
+    for (var i = 0; i < GM._playerDirectives.length; i++) {
+      if (GM._playerDirectives[i] && GM._playerDirectives[i].id === did) { d = GM._playerDirectives[i]; break; }
+    }
+    if (!d || !d._undoSnapshot || d._undone) return;
+    if ((GM.turn || 0) !== d._undoSnapshot.turn) {
+      if (typeof toast === 'function') toast('已过回合·不可撤销');
+      return;
+    }
+    var cs = d._undoSnapshot.changes || [], okN = 0;
+    for (var k = cs.length - 1; k >= 0; k--) {  // 逆序回滚
+      if (_wtApplyHardChange(cs[k].reqPath, 'set', cs[k].old)) okN++;
+    }
+    d._undone = true;
+    d._lastReason = '玩家已撤销(' + okN + '/' + cs.length + ')';
+    if (!GM._wentianHistory) GM._wentianHistory = [];  // arch-ok 问天历史容器惰性初始化·与本文件既有范式同
+    var _udLine = '↩ 已撤销直改 ' + okN + '/' + cs.length + ' 笔：' + cs.map(function (c2) { return c2.reqPath + '→' + c2.old; }).join('；') + ' [id=' + did + ']';
+    GM._wentianHistory.push({ role: 'system', content: _udLine });  // arch-ok 问天历史行·与本文件既有 _wentianHistory push 同容器同性质(刀B撤销记录)
+    if (typeof _wtRenderHistory === 'function') _wtRenderHistory();
+    if (typeof toast === 'function') toast('已撤销 ' + okN + ' 笔直改');
+  } catch (_wtUndoErr) {}
 }

--- a/web/tm-game-loop.js
+++ b/web/tm-game-loop.js
@@ -902,9 +902,12 @@ function _wtRenderHistory() {
       else statusChip = '<span style="display:inline-block;padding:1px 5px;background:rgba(184,154,83,0.12);color:var(--gold-300);border-radius:2px;font-size:0.62rem;margin-left:4px;">\u65B0\u5F55</span>';
       var borderCol = d._absolute ? '#b08bc8' : d._lastStatus === 'ignored' ? 'var(--vermillion-400)' : d._lastStatus === 'partial' ? 'var(--amber-400)' : d._lastStatus === 'followed' ? 'var(--celadon-400)' : 'var(--gold-400)';
       var absChip = d._absolute ? '<span style="display:inline-block;padding:1px 6px;background:linear-gradient(135deg,#8e6aa8,#b08bc8);color:#fff;border-radius:2px;font-size:0.62rem;margin-left:4px;font-weight:700;">\u2605\u5929\u610F</span>' : '';
+      // \u5200A\u00B7\u5151\u73B0\u5BF9\u8D26\u5728\u518C\u6807\u8BB0\uFF08title \u5217\u6307\u6807\uFF09
+      var watchChip = (d._watch && d._watch.items && d._watch.items.length)
+        ? '<span style="display:inline-block;padding:1px 5px;background:rgba(126,160,200,0.16);color:var(--ink-200,#cbb);border-radius:2px;font-size:0.62rem;margin-left:4px;" title="' + escHtml(d._watch.items.map(function(w){return (w.note||w.path)+'\u00B7'+w.expect;}).join('\uFF1B')) + '">\u2696\u5BF9\u8D26' + d._watch.items.length + '</span>' : '';
       html += '<div style="display:flex;justify-content:flex-end;margin-bottom:0.4rem;">';
       html += '<div style="max-width:85%;background:var(--color-accent-subtle);border-right:3px solid ' + borderCol + ';border-radius:var(--radius-md) 2px 2px var(--radius-md);padding:0.4rem 0.6rem;font-size:var(--text-xs);">';
-      html += '<div style="font-size:0.66rem;color:var(--gold-400);margin-bottom:2px;">T' + (d.turn||'?') + ' ' + (d.type === 'rule' ? '\u89C4\u5219' : d.type === 'correction' ? '\u7EA0\u6B63' : d.type === 'content' ? '\u5185\u5BB9' : '\u6307\u4EE4') + absChip + statusChip + '</div>';
+      html += '<div style="font-size:0.66rem;color:var(--gold-400);margin-bottom:2px;">T' + (d.turn||'?') + ' ' + (d.type === 'rule' ? '\u89C4\u5219' : d.type === 'correction' ? '\u7EA0\u6B63' : d.type === 'content' ? '\u5185\u5BB9' : '\u6307\u4EE4') + absChip + statusChip + watchChip + '</div>';
       html += escHtml(d.content);
       if (d.structured) {
         var sParts = [];
@@ -915,6 +918,10 @@ function _wtRenderHistory() {
         if (sParts.length > 0) html += '<div style="font-size:0.62rem;color:var(--ink-300);margin-top:2px;font-style:italic;">' + escHtml(sParts.join(' \u00B7 ')) + '</div>';
       }
       if (d._lastEvidence) html += '<div style="font-size:0.62rem;color:var(--celadon-400);margin-top:2px;">\u4E0A\u56DE\u5408\u6267\u884C\uFF1A' + escHtml(d._lastEvidence.slice(0, 60)) + '</div>';
+      // \u5200B\u00b7\u5f53\u56de\u5408\u5185\u53ef\u64a4\u9500\u76f4\u6539\uff08flag \u5f00 + \u6709\u5feb\u7167 + \u672a\u64a4 + \u540c\u56de\u5408\uff09
+      if (d._undoSnapshot && !d._undone && GM.turn === d._undoSnapshot.turn && (P.conf && P.conf.wentianUndo === true)) {
+        html += '<button style="font-size:0.62rem;color:var(--amber-400);background:none;border:1px solid rgba(201,168,76,0.35);border-radius:2px;cursor:pointer;margin-left:4px;padding:0 4px;" title="\u56de\u6eda\u672c\u6761\u76f4\u6539\uff08\u4ec5\u9650\u5f53\u56de\u5408\uff09" onclick="_wtUndoHardChange(\'' + d.id + '\')">\u21a9\u64a4</button>';
+      }
       html += '<button style="font-size:0.62rem;color:var(--vermillion-400);background:none;border:none;cursor:pointer;margin-left:4px;" onclick="GM._playerDirectives.splice(' + i + ',1);_wtRenderHistory();">\u2715</button>';
       html += '</div></div>';
     });
@@ -1209,6 +1216,14 @@ function _wtConfirmPending() {
     category: p.category,
     structured: p.structured, interpretation: p.interpretation, plan: p.plan
   };
+  // 刀A·兑现对账 watch 注册（flag OFF 或指标全不可读→静默不挂账·诚实原则）
+  try {
+    if (typeof P !== 'undefined' && P && P.conf && P.conf.wentianFulfillAudit === true
+        && typeof _wtRegisterWatch === 'function' && Array.isArray(p.watch)) {
+      var _wtW = _wtRegisterWatch(p.watch);
+      if (_wtW) dir._watch = _wtW;
+    }
+  } catch (_wtWE) {}
   var sysMsg = '';
 
   // 多改批量（agent 模式可提交多条 hardChanges·单条契约照旧）
@@ -1246,8 +1261,22 @@ function _wtConfirmPending() {
   } else if (p.category === 'hardChange' && _wtHcList.length) {
     // 立即写入 GM/P 数值（agent 模式可多笔·hc/ok 沿旧语义=首笔·多笔另补一条批量汇总历史行）
     var hOkN = 0;
+    // 刀B·撤销快照：flag 开时每笔 apply 各自武装捕获窗（一笔恰一次 _wtAfterHardChange）
+    var _wtUndoOn = (typeof P !== 'undefined' && P && P.conf && P.conf.wentianUndo === true && typeof _wtBeginUndoCapture === 'function');
+    var _wtUndoSnaps = [];
     var hDone = _wtHcList.map(function (hc1) {
-      var ok1 = _wtApplyHardChange(hc1.path, hc1.op || 'set', hc1.value);
+      var ok1;
+      if (_wtUndoOn) {
+        _wtBeginUndoCapture();
+        ok1 = _wtApplyHardChange(hc1.path, hc1.op || 'set', hc1.value);
+        var _cap = _wtEndUndoCapture();
+        // old 为对象/undefined 不可靠回滚→该笔不入快照（快照不全则整条不给撤销钮·拒绝部分撤销）
+        if (ok1 && _cap.length === 1 && _cap[0].old !== undefined && (_cap[0].old === null || typeof _cap[0].old !== 'object')) {
+          _wtUndoSnaps.push({ reqPath: hc1.path, old: _cap[0].old });
+        }
+      } else {
+        ok1 = _wtApplyHardChange(hc1.path, hc1.op || 'set', hc1.value);
+      }
       if (ok1) hOkN++;
       var hRec = Object.assign({}, hc1, { _applied: !!ok1 });
       delete hRec._dryRun;  // 预标只服务确认框·不入存档
@@ -1264,6 +1293,10 @@ function _wtConfirmPending() {
     dir._lastStatus = hOkN > 0 ? 'followed' : 'ignored';
     dir._lastReason = hOkN === hDone.length ? '问天直改即时生效' : (hOkN > 0 ? '部分生效(' + hOkN + '/' + hDone.length + ')' : '路径未找到/无法修改');
     dir._lastCheckTurn = GM.turn;
+    // 刀B·全部生效笔均有可靠快照才挂撤销（当回合内 _wtUndoHardChange 可回滚）
+    if (_wtUndoOn && hOkN > 0 && _wtUndoSnaps.length === hOkN) {
+      dir._undoSnapshot = { turn: GM.turn, changes: _wtUndoSnaps };
+    }
     sysMsg = ok
       ? ('\u2696\ufe0e \u5DF2\u5199\u5165\uFF1A' + hc.path + ' ' + (hc.op||'set') + ' ' + hc.value + ' [id=' + did + ']')
       : ('\u26A0 \u8DEF\u5F84\u672A\u627E\u5230\uFF1A' + hc.path);

--- a/web/tm-patches.js
+++ b/web/tm-patches.js
@@ -674,6 +674,24 @@ openSettings=function(){
             '</div>' +
           '</label>';
         })() +
+        (function(){
+          var _wtFaOn = !!(P.conf && P.conf.wentianFulfillAudit === true);
+          var _wtUdOn = !!(P.conf && P.conf.wentianUndo === true);
+          return '<label style="display:flex;align-items:flex-start;gap:0.5rem;padding:0.4rem 0;border-bottom:1px dotted var(--bdr);cursor:pointer;">' +
+            '<input type="checkbox" id="s-wentian-audit" ' + (_wtFaOn?'checked ':'') + 'onchange="_togglePConf(\'wentianFulfillAudit\',this.checked)" style="margin-top:0.15rem;flex-shrink:0;">' +
+            '<div style="flex:1;">' +
+              '<div style="font-size:0.82rem;color:var(--gold);font-weight:600;">问天·兑现对账（默认关闭·实验）</div>' +
+              '<div style="font-size:0.7rem;color:var(--txt-d);line-height:1.55;margin-top:0.15rem;">问天裁定可附带量化指标·回合结束后引擎按在档真值<b>确定性核验</b>是否兑现（AI 说「已遵」而数字没动时·账本说了算）·结果盖进指令徽章并入问天历史。零额外 AI 调用。</div>' +
+            '</div>' +
+          '</label>' +
+          '<label style="display:flex;align-items:flex-start;gap:0.5rem;padding:0.4rem 0;border-bottom:1px dotted var(--bdr);cursor:pointer;">' +
+            '<input type="checkbox" id="s-wentian-undo" ' + (_wtUdOn?'checked ':'') + 'onchange="_togglePConf(\'wentianUndo\',this.checked)" style="margin-top:0.15rem;flex-shrink:0;">' +
+            '<div style="flex:1;">' +
+              '<div style="font-size:0.82rem;color:var(--gold);font-weight:600;">问天·直改可撤销（默认关闭·实验）</div>' +
+              '<div style="font-size:0.7rem;color:var(--txt-d);line-height:1.55;margin-top:0.15rem;">问天数值直改落笔时快照原值·<b>当回合内</b>可在活跃指令列表一键回滚（↩撤）。过回合后推演已消化改动·不可再撤。天意造物类不可撤。</div>' +
+            '</div>' +
+          '</label>';
+        })() +
         '<label style="display:flex;align-items:flex-start;gap:0.5rem;padding:0.4rem 0;border-bottom:1px dotted var(--bdr);cursor:pointer;">' +
           '<input type="checkbox" id="s-consol" ' + (_consolOn?'checked ':'') + 'onchange="_togglePConf(\'memorySynthesisEnabled\',this.checked)" style="margin-top:0.15rem;flex-shrink:0;">' +
           '<div style="flex:1;">' +

--- a/web/tm-wentian-agent.js
+++ b/web/tm-wentian-agent.js
@@ -44,6 +44,20 @@
         edictChannel: { type: 'string', enum: ['pol', 'mil', 'dip', 'eco', 'oth'] },
         structured: { type: 'object', description: '{target,action,scope,forbidden,measurable,condition}' },
         ambiguity: { type: 'array', items: { type: 'string' } },
+        watch: {
+          type: 'array',
+          description: '(可选·仅当裁定含可量化的后续目标时填·最多6条)兑现对账指标——回合结束后引擎按在档真值自动核验并回报玩家。path 用与 hardChanges 相同的路径式·★须先用工具核实在档真名·勿凭空猜。expect: increase/decrease=相对现值方向·gte/lte/eq=与 value 比较·change=只要变动。',
+          items: {
+            type: 'object',
+            properties: {
+              path: { type: 'string' },
+              expect: { type: 'string', enum: ['increase', 'decrease', 'gte', 'lte', 'eq', 'change'] },
+              value: { description: 'gte/lte/eq 时的比较值' },
+              note: { type: 'string', description: '指标短名(给玩家看·如「袁崇焕忠诚」)' }
+            },
+            required: ['path', 'expect']
+          }
+        },
         clarify: { type: 'object', description: '仅当对象指代/意图拿不准且影响裁定时才填：向玩家提一个澄清问题·确认框会给可点选项·玩家一点即带澄清重裁。拿得准就不要填。', properties: { question: { type: 'string', description: '一句话问题' }, options: { type: 'array', items: { type: 'string' }, description: '2-4个候选短语(如两个同名人的身份区分)' } } }
       },
       required: ['category', 'interpretation']
@@ -99,9 +113,17 @@
     opts = opts || {};
     var rt = _readTools();
     if (!rt || typeof root.callAIWithTools !== 'function') return { ok: false };
+    // 兑现对账 flag OFF 时从 submit schema 剥掉 watch（省 token·真 OFF 零行为）
+    var submitDef = SUBMIT_TOOL;
+    try {
+      if (!(root.P && P.conf && P.conf.wentianFulfillAudit === true)) {
+        submitDef = JSON.parse(JSON.stringify(SUBMIT_TOOL));
+        delete submitDef.parameters.properties.watch;
+      }
+    } catch (_wtWsE) {}
     var tools = (typeof rt.defs === 'function' ? rt.defs() : []).filter(function (d) {
       return d && READ_TOOL_NAMES.indexOf(d.name) >= 0;
-    }).concat([SUBMIT_TOOL]);
+    }).concat([submitDef]);
 
     var transcript = '你是天命AI推演系统的元指令裁定官（agent 模式）。玩家对「问天」通道说了一条指令。\n'
       + '你的职责：①先用只读工具查证——指令涉及的人/军/阶层/党派/势力/区划在档真名是什么、现值多少（玩家可能写错字、用绰号、记错现状）；'


### PR DESCRIPTION
## 背景（owner 拍板批·2026-07-21「按你想法开工」）

问天 rule/directive 入库时对玩家承诺「每回合回报执行状况」——但既有回报是**推演 AI 自报作业**（`directive_compliance`），没有任何确定性核查：AI 说「已遵」而在档数字没动，玩家无从得知。群里居平报的「答应生成 NPC 不兑现」是这类病的特例（转介刀只堵了造实体口，总根还开着）。另外 hardChange 即时生效无后悔药。

## 刀A 兑现对账 `P.conf.wentianFulfillAudit === true`（默认 OFF）

- `submit_wentian` 可附 **watch 指标**（path + expect: increase/decrease/gte/lte/eq/change [+value]，≤6 条；flag OFF 时从 schema 剥掉，省 token 且真零行为）
- 注册时 `_wtRegisterWatch` 逐条校验可读性并**快照基线**；全不可读 → null（诚实：不做假对账）
- 回合末 `_wtRunFulfillAudit`（挂 tm-endturn-render·autosave 前·**同回合幂等**，多 pass 结算安全）按在档真值**确定性对账**，盖进既有 `_lastStatus` 徽章体系——`_lastReason` 带「⚖︎对账」前缀，与 AI 自报可区分且**能纠正它**；状态变化才落问天历史（不刷屏）；**零额外 AI 调用**
- 新增 `_wtReadHardChangeValue` 只读取值器（复用七类 resolver，绝不创建字段——smoke 验证读幽灵路径不落键）
- 指令列表加 ⚖对账 chip（title 列指标）

## 刀B 直改撤销 `P.conf.wentianUndo === true`（默认 OFF）

- 确认现场每笔 apply 武装捕获窗，经 `_wtAfterHardChange` 快照 before 值（typeof 守卫——部分 smoke 按窗口切片装载本文件不炸）；**顺修军队主帅分支原传 `''` 的假 old**
- old 为对象/undefined 不入快照；快照不全整条不给撤销钮（拒绝部分撤销的困惑语义）；天意 allowCreate 造物不可撤
- **当回合内** `_wtUndoHardChange` 逆序回滚——replay 走同一 `_wtApplyHardChange`，别名（size/strength）/镜像/UI 刷新随之复原；过回合拒绝（推演已消化）；双撤拒绝
- 指令列表挂 ↩撤 钮（仅同回合+有快照+flag 开）

## 设置

设置→性能新增两开关，默认关、标注实验。照家规：新 flag 默认 OFF + 配设置开关。

## 验证

- 新 `smoke-wentian-fulfill-audit.js`（28 断言：读值器/注册/幂等/状态变化落史/算子表/flag 门）+ `smoke-wentian-undo.js`（20 断言：捕获窗/真 old/逆序回滚/别名复原/回合闸/双撤/flag 门）
- 既有 `smoke-wentian-agent` **37/37** + `smoke-wentian-hardchange` 回归绿（中途踩过切片装载 ReferenceError·已 typeof 守卫根治）
- `ci-smokes` **776 PASS**（豁免 2 缺资产白名单）· `lint-arch-all` **8/8**（4 处 GM 直写按处置③行内 arch-ok 裁定注释）· `verify-release-contract` **94 断言** · `sync-hot-baseline --check` **PASS**
- 热更基线六条目外科对齐（worktree 无未跟踪资产不可跑 `--write`，`--check` 与 CI 同尺验证）

不发版：随下个热更自然带出。后续（方向三工单/方向五治理面板）依赖本刀账本数据，另行立案。

🤖 Generated with [Claude Code](https://claude.com/claude-code)