### PR TITLE
R2 民变实体镜像层第一波：level≥3 民变具象化为势力/渠帅/军队三件套（flag 默认 OFF）

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2111,8 +2111,8 @@
     },
     {
       "path": "index.html",
-      "sha256": "e3576a540fb986d89e715eb1ea81a476d554305aa87e71183bc83e7ae510e021",
-      "size": 64267
+      "sha256": "6f0c180a655da7370f28d60a4dea88de9c5ffcd83e70a22c62f4410a335bafd3",
+      "size": 64442
     },
     {
       "path": "INDEX.md",
@@ -5006,8 +5006,8 @@
     },
     {
       "path": "tm-patches.js",
-      "sha256": "c0c345ef5df90f13ea9546038e40522f664749bfe52f3893846e656f2fa9c0df",
-      "size": 179547
+      "sha256": "6c6bbb6f2369c857f362f21a2edf09a8566ca5dd54f770c7184a85d3b836dd3c",
+      "size": 180619
     },
     {
       "path": "tm-pause-fab.js",
@@ -5133,6 +5133,11 @@
       "path": "tm-resume-point.js",
       "sha256": "f6fbcf670f1e1b147115baea149a28ef5c7dfde19ef13982ff279b366db146c0",
       "size": 9890
+    },
+    {
+      "path": "tm-revolt-entity.js",
+      "sha256": "9e8c7bd63f953120e0a3954550257d5cfed6e58b745629a67616c6b4f621f35f",
+      "size": 9655
     },
     {
       "path": "tm-save-lifecycle.js",

--- a/web/index.html
+++ b/web/index.html
@@ -855,6 +855,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-reported-view.js?v=20260711"></script><!-- 奏报失真层核心引擎(S1·真值vs据奏·纯推导不落库·严格史实+开关双gate·docs/design-reported-view-2026-07.md) -->
 <script src="tm-social-foundation.js?v=20260612"></script>
 <script src="tm-authority-complete.js?v=20260623-ledgerflow"></script>
+<script src="tm-revolt-entity.js?v=20260721"></script><!-- R2民变实体镜像·flag revoltEntityEnabled 默认OFF·爬梯level≥3具象化势力/渠帅/军队三件套 -->
 <script src="tm-historical-presets.js?v=2026042816"></script>
 <script src="tm-prophecy.js?v=20260709"></script>
 <script src="tm-region-enrich.js?v=2026042714"></script>

--- a/web/scripts/arch-baselines/gm-writes.json
+++ b/web/scripts/arch-baselines/gm-writes.json
@@ -1,8 +1,9 @@
 {
   "config": {
     "owners": [
-      "tm-save-lifecycle.js",
-      "tm-indices.js"
+      "tm-indices.js",
+      "tm-revolt-entity.js",
+      "tm-save-lifecycle.js"
     ],
     "gmFactories": [
       "getGame"

--- a/web/scripts/smoke-faction-binding-lint.js
+++ b/web/scripts/smoke-faction-binding-lint.js
@@ -66,6 +66,8 @@ const ALLOW_LINES = [
   { file: 'tm-shiji-qiju-ui.js', match: /types\.faction\s*=/ },
   // tm-faction-npc-intervention.js·espionage 翻面 fallback (Membership API 不可用时)·已 try API·此为兜底
   { file: 'tm-faction-npc-intervention.js', match: /c\.faction\s*=\s*pn;/ },
+  // tm-revolt-entity.js·_setCharFaction 已 try FactionMembership.assignChar·此为 API 缺席兜底(smoke 裸跑/装载序)
+  { file: 'tm-revolt-entity.js', match: /ch\.faction\s*=\s*facName\s*\|\|\s*''/ },
   // tm-ai-change-applier.js / tm-ai-change-army.js (Slice 2 拆出) / tm-region-enrich.js:
   //   assignArmy first·direct write only in legacy fallback/catch.
   // tm-ai-change-applier.js·applyAllegianceChange 主路已走 assignChar；以下仅 membership 模块缺位时双锚 fallback.

--- a/web/scripts/smoke-revolt-entity.js
+++ b/web/scripts/smoke-revolt-entity.js
@@ -1,0 +1,110 @@
+// smoke-revolt-entity.js — 民变实体镜像层（R2 第一波·2026-07-21·flag 默认 OFF）
+//
+// owner 铁律：民变=实体演进链·非数值阈值。R2 双轨第一波=镜像层——五级爬梯(进度时钟·零改动)
+// 中 level≥3 的 ongoing 民变具象化为实体三件套(义军势力/渠帅人物/义军军队)·爬梯状态逐回合
+// 镜像(升级扩军/被剿覆灭)·级5改朝实体留场(终局归爬梯 _gameOver)。本 smoke 直调 TM.RevoltEntity.sync
+// 验证：flag门/具象化/幂等/在档真人揭竿不重复造/同区重名缀序/升级扩军/覆灭清账/级5保留。
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var vm = require('vm');
+
+var ROOT = path.join(__dirname, '..');
+var failures = [];
+function assert(cond, msg) {
+  if (cond) { console.log('  PASS ' + msg); }
+  else { failures.push(msg); console.log('  FAIL ' + msg); }
+}
+
+var ebs = [];
+var sandbox = { console: console };
+sandbox.window = sandbox;
+sandbox.global = sandbox;
+sandbox.addEB = function (cat, msg) { ebs.push(cat + '·' + msg); };
+sandbox.GM = {
+  turn: 10,
+  facs: [{ id: 'f1', name: '大明', strength: 80, economy: 70, playerRelation: 100 }],
+  chars: [{ name: '孙承宗', alive: true, faction: '朝廷', loyalty: 80 }],
+  armies: [{ id: 'a1', name: '京营', faction: '大明', soldiers: 50000 }],
+  minxin: { revolts: [] }
+};
+sandbox.P = { conf: {} };
+vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync(path.join(ROOT, 'tm-revolt-entity.js'), 'utf8'), sandbox, { filename: 'tm-revolt-entity.js' });
+
+var GM = sandbox.GM;
+var RE = sandbox.TM.RevoltEntity;
+
+console.log('① flag OFF（默认）→ 零行为');
+GM.minxin.revolts.push({ id: 'rv1', region: '陕西', status: 'ongoing', level: 3, scale: 30000, turn: 8 });
+RE.sync(GM);
+assert(GM.facs.length === 1 && GM.armies.length === 1 && GM.chars.length === 1, 'flag 关 → 不具象化（默认 OFF 零行为）');
+
+console.log('② flag ON·level3 具象化三件套');
+sandbox.P.conf.revoltEntityEnabled = true;
+RE.sync(GM);
+var fac = GM.facs.find(function (f) { return f._revoltEntity; });
+var army = GM.armies.find(function (a) { return a._revoltEntity; });
+var leader = GM.chars.find(function (c) { return c._revoltEntity; });
+assert(!!fac && fac.name === '陕西义军' && fac.strength === 40, '义军势力入档·strength=40(L3)');
+assert(!!army && army.soldiers === 9000 && army.faction === '陕西义军' && army.location === '陕西', '义军军队入档·9000 兵·驻陕西');
+assert(!!leader && leader.name === '陕西义军渠帅' && leader.officialTitle === '义军渠帅' && leader.faction === '陕西义军', '渠帅人物入档(民变无首领名→造描述性渠帅)');
+assert(army.commander === '陕西义军渠帅', '军队主帅=渠帅');
+assert(ebs.some(function (e) { return e.indexOf('陕西民变成势') >= 0; }), '具象化落起居注');
+
+console.log('③ 幂等：重复 sync 不重复造');
+RE.sync(GM); RE.sync(GM);
+assert(GM.facs.filter(function (f) { return f._revoltEntity; }).length === 1, '势力不重复');
+assert(GM.armies.filter(function (a) { return a._revoltEntity; }).length === 1, '军队不重复');
+assert(GM.chars.filter(function (c) { return c._revoltEntity; }).length === 1, '渠帅不重复');
+
+console.log('④ 爬梯升级 → 扩军/势力强度镜像');
+GM.minxin.revolts[0].level = 4;
+RE.sync(GM);
+assert(army.soldiers === 60000 && army.size === 60000 && army.strength === 60000, 'L4 → 扩军 60000(含别名)');
+assert(fac.strength === 60, 'L4 → 势力强度 60');
+assert(ebs.some(function (e) { return e.indexOf('裹挟日众') >= 0; }), '扩军落起居注');
+
+console.log('⑤ 在档真人揭竿 → 不重复造人·只挂链');
+GM.minxin.revolts.push({ id: 'rv2', region: '山东', status: 'ongoing', level: 3, scale: 30000, turn: 9, leader: '孙承宗' });
+RE.sync(GM);
+assert(GM.chars.filter(function (c) { return c.name === '孙承宗'; }).length === 1, '真人首领不重复造');
+assert(GM.minxin.revolts[1]._entityLeaderName === '孙承宗', '挂链 _entityLeaderName');
+var realLeader = GM.chars.find(function (c) { return c.name === '孙承宗'; });
+assert(realLeader.faction === '山东义军', '真人首领转投义军势力');
+assert(realLeader._preRevoltFaction === '朝廷' && realLeader.sourceRevoltId === 'rv2', '原势力留痕+挂 sourceRevoltId 链');
+
+console.log('⑥ 同区第二股 → 缀序防重名');
+GM.minxin.revolts.push({ id: 'rv3', region: '陕西', status: 'ongoing', level: 3, scale: 30000, turn: 10 });
+RE.sync(GM);
+var shanxiFacs = GM.facs.filter(function (f) { return f._revoltEntity && String(f.name).indexOf('陕西义军') === 0; });
+assert(shanxiFacs.length === 2 && shanxiFacs.some(function (f) { return f.name === '陕西义军·2'; }), '同区第二股 → 「陕西义军·2」');
+
+console.log('⑦ 被剿 → 覆灭清账(军散/势力除档/渠帅溃散流亡·alive 不动)');
+GM.minxin.revolts[0].status = 'suppressed';
+RE.sync(GM);
+assert(!GM.facs.some(function (f) { return f.sourceRevoltId === 'rv1'; }), 'rv1 势力除档');
+var deadArmy = GM.armies.find(function (a) { return a.sourceRevoltId === 'rv1'; });
+assert(deadArmy && deadArmy.disbanded === true && deadArmy.soldiers === 0, 'rv1 军散(disbanded·清员额)');
+var fled = GM.chars.find(function (c) { return c.sourceRevoltId === 'rv1'; });
+assert(fled && fled._revoltDefeated === true && fled.alive === true && fled.officialTitle === '溃散流亡', '渠帅溃散流亡·alive 不动(避开死亡系统)');
+assert(ebs.some(function (e) { return e.indexOf('烟消云散') >= 0; }), '覆灭落起居注');
+
+console.log('⑧ 级5改朝 → 实体留场(终局归爬梯 _gameOver)');
+GM.minxin.revolts[1].level = 5;
+GM.minxin.revolts[1].status = 'dispersed';  // 即便状态异动·级5不清账
+RE.sync(GM);
+assert(GM.facs.some(function (f) { return f.sourceRevoltId === 'rv2'; }), '级5实体不被清·留在终局舞台');
+
+console.log('⑨ 低级民变(level<3)不具象化');
+GM.minxin.revolts.push({ id: 'rv4', region: '河南', status: 'ongoing', level: 1, scale: 500, turn: 10 });
+RE.sync(GM);
+assert(!GM.facs.some(function (f) { return f.sourceRevoltId === 'rv4'; }), '流言/聚啸级 → 不入实体档');
+
+console.log('');
+if (failures.length) {
+  console.log('FAIL smoke-revolt-entity: ' + failures.length + ' 处失败');
+  failures.forEach(function (f) { console.log('  - ' + f); });
+  process.exit(1);
+}
+console.log('PASS smoke-revolt-entity (flag门/具象化/幂等/真人挂链/重名缀序/扩军镜像/覆灭清账/级5留场)');

--- a/web/tm-patches.js
+++ b/web/tm-patches.js
@@ -692,6 +692,16 @@ openSettings=function(){
             '</div>' +
           '</label>';
         })() +
+          (function(){
+            var _revEntOn = !!(P.conf && P.conf.revoltEntityEnabled === true);
+            return '<label style="display:flex;align-items:flex-start;gap:0.5rem;padding:0.4rem 0;border-bottom:1px dotted var(--bdr);cursor:pointer;">' +
+              '<input type="checkbox" id="s-revolt-entity" ' + (_revEntOn?'checked ':'') + 'onchange="_togglePConf(\'revoltEntityEnabled\',this.checked)" style="margin-top:0.15rem;flex-shrink:0;">' +
+              '<div style="flex:1;">' +
+                '<div style="font-size:0.82rem;color:var(--gold);font-weight:600;">民变实体化（默认关闭·实验）</div>' +
+                '<div style="font-size:0.7rem;color:var(--txt-d);line-height:1.55;margin-top:0.15rem;">民变闹到「暴动」及以上时具象化为<b>真实体</b>：义军势力入势力档·渠帅入人物档·义军军队上军事帐——全游戏系统与 AI 推演自然看见它们；被剿/瓦解则军散档除。关闭时维持原五级抽象台账。</div>' +
+              '</div>' +
+            '</label>';
+          })() +
         '<label style="display:flex;align-items:flex-start;gap:0.5rem;padding:0.4rem 0;border-bottom:1px dotted var(--bdr);cursor:pointer;">' +
           '<input type="checkbox" id="s-consol" ' + (_consolOn?'checked ':'') + 'onchange="_togglePConf(\'memorySynthesisEnabled\',this.checked)" style="margin-top:0.15rem;flex-shrink:0;">' +
           '<div style="flex:1;">' +

--- a/web/tm-revolt-entity.js
+++ b/web/tm-revolt-entity.js
@@ -1,0 +1,211 @@
+// ============================================================
+//  tm-revolt-entity.js — 民变实体镜像层（R2 第一波·2026-07-21）
+//
+//  owner 范式铁律(2026-07-07)：民变=实体演进链·终局=玩家角色被杀·绝非数值阈值。
+//  R2 双轨(鼎革战役已拍)：flag P.conf.revoltEntityEnabled(默认 OFF·设置可开)——
+//  ON 时·五级爬梯(tm-authority-complete P0-2·仍是进度时钟·本层零改动)中 level≥3 的民变
+//  被具象化为**真实体三件套**：义军势力(GM.facs) + 渠帅人物(GM.chars) + 义军军队(GM.armies)。
+//  全游戏系统(军事/势力索引/花名册/AI 叙事)经由既有容器自然看见它们；爬梯状态逐回合
+//  镜像到实体：升级→扩军·被剿/瓦解→覆灭(军散/势力除档/渠帅溃散流亡)。
+//  级5(改朝)实体保留在场——终局屏仍由爬梯的 _gameOver 信号管。
+//
+//  本文件是这三类 _revoltEntity 实体的**唯一写口**(已登记 lint-gm-writes owners)。
+//  批二(须摊桌)：破京终局链(接玩家之死裁决器)·招抚动词(牵国库走账+玩家操作五渠道)·
+//  威胁值→侵攻确定性接点(外患侧同范式具象化)。
+//  渠帅之死不在本层：溃散=流亡(alive 不动)·避免与结构化死亡闸/亡因系统纠缠。
+// ============================================================
+(function (global) {
+  'use strict';
+
+  // 兵额/势力强度按爬梯级别定值（movement scale ≠ 军队员额·取约三成·封 20 万）
+  var SOLDIERS_BY_LEVEL = { 3: 9000, 4: 60000, 5: 200000 };
+  var STRENGTH_BY_LEVEL = { 3: 40, 4: 60, 5: 85 };
+
+  function enabled() {
+    try { return !!(global.P && global.P.conf && global.P.conf.revoltEntityEnabled === true); }
+    catch (_) { return false; }
+  }
+
+  function _eb(msg) {
+    try { if (typeof global.addEB === 'function') global.addEB('民变', msg); } catch (_) {}
+  }
+
+  function _factionName(G, r) {
+    var base = (r.region ? String(r.region) : '流民') + '义军';
+    // 同区第二股民变→缀序防重名（按已在档的其他 _revoltEntity 势力计数）
+    var clash = (G.facs || []).filter(function (f) {
+      return f && f._revoltEntity && f.sourceRevoltId !== r.id && String(f.name || '').indexOf(base) === 0;
+    }).length;
+    return clash > 0 ? (base + '·' + (clash + 1)) : base;
+  }
+
+  function _leaderName(G, r) {
+    var name = String(r.leader || r.leaderName || '').trim();
+    if (name) return name;
+    return (r.region ? String(r.region) : '') + '义军渠帅';
+  }
+
+  // 人物转籍/退籍走 FactionMembership 正门（缺席[裸跑/装载序]时单点兜底直写）
+  function _setCharFaction(ch, facName) {
+    try {
+      var FM = global.TM && global.TM.FactionMembership;
+      if (FM && typeof FM.assignChar === 'function') {
+        FM.assignChar(ch, facName || '', { reason: '民变实体镜像', silent: true });
+        return;
+      }
+    } catch (_) {}
+    ch.faction = facName || '';  // membership-fallback·API 缺席兜底(smoke 裸跑用)
+  }
+
+  function _findBySource(list, rid) {
+    if (!Array.isArray(list)) return null;
+    for (var i = 0; i < list.length; i++) {
+      if (list[i] && list[i]._revoltEntity && list[i].sourceRevoltId === rid) return list[i];
+    }
+    return null;
+  }
+
+  // 具象化：为 ongoing 且 level≥3 的民变确保实体三件套在档（幂等·按 sourceRevoltId 认亲）
+  function _ensureTrio(G, r) {
+    if (!Array.isArray(G.facs) || !Array.isArray(G.armies) || !Array.isArray(G.chars)) return;
+    var lvl = Math.max(3, Math.min(5, r.level || 3));
+    var fac = _findBySource(G.facs, r.id);
+    var facName;
+    if (!fac) {
+      facName = _factionName(G, r);
+      fac = {
+        id: 'fac_rev_' + r.id,
+        name: facName,
+        type: '民变',
+        isRevolt: true,
+        strength: STRENGTH_BY_LEVEL[lvl],
+        economy: 15,
+        playerRelation: -85,
+        sourceRevoltId: r.id,
+        _revoltEntity: true,
+        _createdTurn: G.turn || 0
+      };
+      G.facs.push(fac);  // arch-ok 民变实体唯一写口(本文件已登记 owners)·义军势力入档
+      _eb((r.region || '某地') + '民变成势·「' + facName + '」旗号立·天下侧目');
+    } else {
+      facName = fac.name;
+      fac.strength = STRENGTH_BY_LEVEL[lvl];  // 爬梯升级→势力强度镜像
+    }
+
+    // 渠帅：民变自带首领名且已在档(真人物揭竿)→只挂链不造人；否则造 _revoltEntity 渠帅
+    var lname = _leaderName(G, r);
+    var existing = null;
+    for (var c = 0; c < G.chars.length; c++) {
+      if (G.chars[c] && String(G.chars[c].name || '') === lname) { existing = G.chars[c]; break; }
+    }
+    if (existing && !existing._revoltEntity) {
+      // 在档真人揭竿·不重复造·转投义军势力(原势力留痕 _preRevoltFaction·覆灭时清账)
+      r._entityLeaderName = lname;
+      if (existing.faction !== facName) {
+        existing._preRevoltFaction = existing.faction || '';
+        _setCharFaction(existing, facName);
+      }
+      existing.sourceRevoltId = r.id;
+    } else if (!existing) {
+      G.chars.push({  // arch-ok 民变实体唯一写口·渠帅人物入档
+        name: lname, alive: true, faction: facName, officialTitle: '义军渠帅',
+        loyalty: 0, sourceRevoltId: r.id, _revoltEntity: true, _createdTurn: G.turn || 0
+      });
+      r._entityLeaderName = lname;
+    } else {
+      r._entityLeaderName = lname;
+      _setCharFaction(existing, facName);
+    }
+
+    var army = _findBySource(G.armies, r.id);
+    var soldiers = SOLDIERS_BY_LEVEL[lvl];
+    if (!army) {
+      G.armies.push({  // arch-ok 民变实体唯一写口·义军军队入档(形状镜像 ai-change-army 创建先例)
+        id: 'army_rev_' + r.id,
+        name: facName + '主力',
+        faction: facName,
+        branch: '流民军', type: '流民军', armyType: '流民军',
+        soldiers: soldiers, size: soldiers, strength: soldiers,
+        morale: 55, supply: 45, training: 35, loyalty: 80, control: 70, controlLevel: 70,
+        location: r.region || '', garrison: r.region || '',
+        commander: lname,
+        equipment: [], quality: '乌合',
+        composition: [{ type: '流民军', count: soldiers }],
+        state: 'field',
+        source: 'revolt.entity',
+        sourceRevoltId: r.id, _revoltEntity: true, _createdTurn: G.turn || 0
+      });
+    } else if ((army.soldiers || 0) < soldiers && !army.disbanded) {
+      // 爬梯升级→扩军镜像（只涨不缩·被剿减员归战斗/镇压系统管）
+      army.soldiers = soldiers; army.size = soldiers; army.strength = soldiers;
+      army.composition = [{ type: '流民军', count: soldiers }];
+      _eb((r.region || '某地') + '「' + facName + '」裹挟日众·号称 ' + Math.round(soldiers / 1000) + ' 千之众');
+    }
+  }
+
+  // 覆灭：民变被剿/瓦解 → 军散·势力除档·渠帅溃散流亡（不碰 alive·避开死亡系统）
+  function _teardown(G, fac) {
+    var rid = fac.sourceRevoltId;
+    var army = _findBySource(G.armies, rid);
+    if (army && !army.disbanded) {
+      army.disbanded = true; army.state = 'disbanded';
+      army.soldiers = 0; army.size = 0; army.strength = 0;
+    }
+    for (var c = 0; c < G.chars.length; c++) {
+      var ch = G.chars[c];
+      if (!ch || ch.sourceRevoltId !== rid || ch._revoltDefeated) continue;
+      if (ch._revoltEntity) {
+        ch._revoltDefeated = true; ch.officialTitle = '溃散流亡';
+      } else {
+        ch._revoltDefeated = true;  // 真人首领：败后无所依·原职衔不动(去留归后续系统)
+      }
+      _setCharFaction(ch, '');  // 退籍走正门
+    }
+    var idx = G.facs.indexOf(fac);
+    if (idx >= 0) G.facs.splice(idx, 1);  // arch-ok 民变实体唯一写口·自建势力对称除档
+    _eb('「' + (fac.name || '义军') + '」烟消云散·余党四散');
+  }
+
+  // 每回合镜像：状态驱动·幂等（即使某回合先于爬梯 tick 跑·至多迟一回合收敛）
+  function sync(G) {
+    if (!enabled()) return;
+    G = G || global.GM;
+    if (!G || !G.minxin || !Array.isArray(G.minxin.revolts)) return;
+    if (!Array.isArray(G.facs)) return;
+    var byId = {};
+    G.minxin.revolts.forEach(function (r) { if (r && r.id != null) byId[r.id] = r; });
+    // ① 具象化/更新在场者
+    G.minxin.revolts.forEach(function (r) {
+      if (!r || r.status !== 'ongoing') return;
+      if ((r.level || 0) < 3) return;
+      try { _ensureTrio(G, r); } catch (_eT) {}
+    });
+    // ② 覆灭清账：源民变已被剿/瓦解/出档（级5改朝除外·实体留在场·终局屏归爬梯 _gameOver）
+    G.facs.slice().forEach(function (fac) {
+      if (!fac || !fac._revoltEntity) return;
+      var src = byId[fac.sourceRevoltId];
+      if (src && src.status === 'ongoing') return;
+      if (src && (src.level || 0) >= 5) return;
+      try { _teardown(G, fac); } catch (_eD) {}
+    });
+  }
+
+  var API = {
+    sync: sync,
+    enabled: enabled,
+    SOLDIERS_BY_LEVEL: SOLDIERS_BY_LEVEL,
+    STRENGTH_BY_LEVEL: STRENGTH_BY_LEVEL
+  };
+  global.TM = global.TM || {};
+  global.TM.RevoltEntity = API;
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+
+  // 结算管线注册：晚序(90)·爬梯 tick 之后镜像；管线缺席(裸跑/旧装载序)→ 静默·smoke 直调 sync
+  try {
+    if (global.SettlementPipeline && typeof global.SettlementPipeline.register === 'function') {
+      global.SettlementPipeline.register('revoltEntity', '民变实体镜像', function () {
+        try { sync(global.GM); } catch (_eS) {}
+      }, 90, 'perturn');
+    }
+  } catch (_eR) {}
+})(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## 背景（末年压力引擎批一·owner「按你想法开工」）

owner 范式铁律（2026-07-07）：**民变=实体演进链·终局=玩家角色被杀·绝非数值阈值**。鼎革战役已拍 R2 双轨（`revoltEntityEnabled`）。现状的五级爬梯是纯抽象台账（`GM.minxin.revolts[]` + Math.random 升级 + 比大小镇压）——世界看不见它：没有义军军队上军事帐、没有渠帅入花名册、没有势力入邦交档，AI 叙事只能凭 prompt 文字脑补。

## 本波：实体镜像层 `P.conf.revoltEntityEnabled === true`（默认 OFF）

**爬梯零改动（仍是进度时钟）**；ON 时 level≥3（暴动+）的 ongoing 民变具象化为**真实体三件套**，全游戏系统经既有容器自然看见：

| 实体 | 落点 | 镜像规则 |
|---|---|---|
| 义军势力 | `GM.facs` | strength 按级 40/60/85·playerRelation -85·同区第二股缀序防重名 |
| 渠帅人物 | `GM.chars` | 民变带真人首领名→**不重复造**·转投走 `FactionMembership.assignChar` 正门·`_preRevoltFaction` 留痕 |
| 义军军队 | `GM.armies` | 兵额按级 9000/60000/200000（movement scale≠员额·取三成封 20 万）·形状镜像 ai-change-army 创建先例 |

- 升级→扩军/势力强度跟涨（只涨不缩·减员归战斗系统）；被剿/瓦解→军散（disbanded 清员额）/势力除档/渠帅**溃散流亡**（alive 不动——刻意避开结构化死亡闸，渠帅之死留给后续系统）；级 5 改朝实体留场（终局屏仍归爬梯 `_gameOver`）
- 新模块 `tm-revolt-entity.js` = 三类 `_revoltEntity` 实体**唯一写口**（已登记 gm-writes owners）·SettlementPipeline 晚序(90)注册·状态驱动幂等（先后序至多迟一回合收敛）
- 设置→新增开关（默认关·实验标注）

## 批二回桌项（不在本 PR·须摊桌）

①破京终局链（接鼎革 R1 玩家之死裁决器）②招抚动词（牵国库走账 + 玩家操作五渠道铁律）③威胁值→侵攻确定性接点（外患侧同范式具象化·第七轮记债）

## 验证

- 新 `smoke-revolt-entity.js` **26 断言**：flag 门/具象化/幂等/真人挂链/重名缀序/扩军镜像/覆灭清账/级5留场
- `ci-smokes` **777 PASS**（豁免 2 缺资产）· `lint-arch-all` **8/8** · `faction-binding-lint` **0 violations**（兜底行按「已 try API」先例入豁免表）· `verify-release-contract` **94 断言** · `sync-hot-baseline --check` **PASS**
- 诚实记录：中途把 tm-patches 的问天 IIFE 收口吞了致语法炸、四个集成 smoke 连坐——括号修复后 office-toggles 21/21 回绿；此外发现并修正了「真人揭竿不转籍」缺口

不发版。flag 默认 OFF，你开着跑顺了再谈翻默认与批二。

🤖 Generated with [Claude Code](https://claude.com/claude-code)