### PR TITLE
末年压力引擎批二：破京终局链（三拍·继统续玩）+ 威胁→侵攻确定性接点（flag 默认 OFF）

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2111,8 +2111,8 @@
     },
     {
       "path": "index.html",
-      "sha256": "6f0c180a655da7370f28d60a4dea88de9c5ffcd83e70a22c62f4410a335bafd3",
-      "size": 64442
+      "sha256": "2553e94ba0f828503cdc75b231aece71660d5dce299269e5716423183becb719",
+      "size": 64621
     },
     {
       "path": "INDEX.md",
@@ -3546,8 +3546,8 @@
     },
     {
       "path": "tm-authority-complete.js",
-      "sha256": "a5d6fb7c76ca4b3c09c838ba82d25933244abc1aaa00874492c30e9c373ae7b5",
-      "size": 82294
+      "sha256": "7a581de94be59d08b35356a36a00b8c428dace785ae8872067bc33e50d361366",
+      "size": 82954
     },
     {
       "path": "tm-authority-deep.js",
@@ -3593,6 +3593,11 @@
       "path": "tm-bgm-config.js",
       "sha256": "205e6746b1b1b01e2d01a30c6081dab654230b5a9dce2deffc181dd64f64c8a2",
       "size": 1297
+    },
+    {
+      "path": "tm-border-invasion.js",
+      "sha256": "be2854bcde32b8fc2680352e94ed40918893fb7950a76b1895c5a4f6f03590bc",
+      "size": 6689
     },
     {
       "path": "tm-border-risk.js",
@@ -5006,8 +5011,8 @@
     },
     {
       "path": "tm-patches.js",
-      "sha256": "6c6bbb6f2369c857f362f21a2edf09a8566ca5dd54f770c7184a85d3b836dd3c",
-      "size": 180619
+      "sha256": "cd38978ffd8fb9908b4df9c6535149f4b65667d547ede348b75f3d7dbf93e810",
+      "size": 181788
     },
     {
       "path": "tm-pause-fab.js",
@@ -5136,8 +5141,8 @@
     },
     {
       "path": "tm-revolt-entity.js",
-      "sha256": "9e8c7bd63f953120e0a3954550257d5cfed6e58b745629a67616c6b4f621f35f",
-      "size": 9655
+      "sha256": "bd902fd33c4200f4722368a0c8c87c637eda2cefcab3729c45a9fd28d78eed2b",
+      "size": 13126
     },
     {
       "path": "tm-save-lifecycle.js",

--- a/web/index.html
+++ b/web/index.html
@@ -600,6 +600,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-storage.js?v=2026042714"></script>
 <script src="tm-endturn-helpers.js?v=2026050701"></script>
 <script src="tm-border-risk.js?v=2026062002"></script><!-- P1-A1a 边境风险结算·激活死字段 borderRisk·A4 消费 defenseBonus -->
+<script src="tm-border-invasion.js?v=20260721"></script><!-- 批二刀2·威胁→侵攻确定性接点·flag borderInvasionEnabled 默认OFF·高压3回合具象化入侵军 -->
 <script src="tm-coastal-raid.js?v=2026062001"></script><!-- P1-A3b 沿海袭击结算·激活死字段 coastalDefense -->
 <script src="tm-office-vacancy.js?v=2026062002"></script><!-- P1-C1 地方官缺写口·激活死字段 officeVacancy·A4 消费 officialSupply -->
 <script src="tm-custom-build-agent.js?v=2026062006"></script><!-- 自拟营建 agent·A1-A4·A5 多步(inspect/recall)+谏官对抗审·全走次要API -->

--- a/web/scripts/arch-baselines/gm-writes.json
+++ b/web/scripts/arch-baselines/gm-writes.json
@@ -1,6 +1,7 @@
 {
   "config": {
     "owners": [
+      "tm-border-invasion.js",
       "tm-indices.js",
       "tm-revolt-entity.js",
       "tm-save-lifecycle.js"

--- a/web/scripts/smoke-border-invasion.js
+++ b/web/scripts/smoke-border-invasion.js
@@ -1,0 +1,110 @@
+// smoke-border-invasion.js — 威胁→侵攻确定性接点（批二刀2·2026-07-21·flag 默认 OFF）
+//
+// 第七轮记债：borderRisk 只涨不咬·「威胁高→南侵」停在文案层。修法=确定性具象化：
+// 玩家领 leaf.borderRisk≥70 连续3回合 → 最强敌对势力(排除义军)出一支真入侵军(每势力至多
+// 一支·每回合至多一支)·风险<40 连续2回合或被打散→退兵+6回合冷却。战斗归既有军事系统。
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var vm = require('vm');
+
+var ROOT = path.join(__dirname, '..');
+var failures = [];
+function assert(cond, msg) {
+  if (cond) { console.log('  PASS ' + msg); }
+  else { failures.push(msg); console.log('  FAIL ' + msg); }
+}
+
+var leaves = [
+  { name: '蓟州', borderRisk: 80 },
+  { name: '大同', borderRisk: 50 }
+];
+var sandbox = { console: console };
+sandbox.window = sandbox;
+sandbox.global = sandbox;
+sandbox._ebs = [];
+sandbox.addEB = function (cat, msg) { sandbox._ebs.push(cat + '·' + msg); };
+sandbox.IntegrationBridge = { getLeafDivisions: function () { return leaves; } };
+sandbox.GM = {
+  turn: 30,
+  adminHierarchy: { player: {} },
+  facs: [
+    { id: 'f_hj', name: '后金', strength: 80, playerRelation: -90 },
+    { id: 'f_mg', name: '漠南部', strength: 60, playerRelation: -70 },
+    { id: 'f_cx', name: '朝鲜', strength: 40, playerRelation: 60 },
+    { id: 'f_rev', name: '陕西义军', strength: 60, playerRelation: -85, _revoltEntity: true, sourceRevoltId: 'rvX' }
+  ],
+  armies: [],
+  chars: []
+};
+sandbox.P = { conf: {} };
+vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync(path.join(ROOT, 'tm-border-invasion.js'), 'utf8'), sandbox, { filename: 'tm-border-invasion.js' });
+
+var GM = sandbox.GM;
+var BI = sandbox.TM.BorderInvasion;
+
+console.log('① flag OFF（默认）→ 零行为');
+BI.tick(GM); BI.tick(GM); BI.tick(GM); BI.tick(GM);
+assert(GM.armies.length === 0, 'flag 关 → 永不出兵');
+assert(!leaves[0]._invRiskStreak, 'flag 关 → 连 streak 都不记');
+
+console.log('② 高压三回合 → 最强敌对势力出兵（义军被排除）');
+sandbox.P.conf.borderInvasionEnabled = true;
+BI.tick(GM); GM.turn++;
+assert(GM.armies.length === 0 && leaves[0]._invRiskStreak === 1, '第1回合高压 → 只记账不出兵');
+BI.tick(GM); GM.turn++;
+assert(GM.armies.length === 0 && leaves[0]._invRiskStreak === 2, '第2回合高压 → 仍不出兵(确定性·非随机)');
+BI.tick(GM); GM.turn++;
+var inv = GM.armies.find(function (a) { return a._borderInvasion; });
+assert(!!inv, '第3回合高压 → 出兵');
+assert(inv.faction === '后金' && inv.sourceFacName === '后金', '攻方=最强敌对(后金80>漠南60)·义军(-85)被排除');
+assert(inv.soldiers === 20000 + 80 * 800, '兵额=20000+strength×800=84000');
+assert(inv.location === '蓟州', '兵锋落最险 leaf(蓟州80>大同50)');
+assert(sandbox._ebs.some(function (e) { return e.indexOf('大举犯边') >= 0; }), '出兵落起居注');
+
+console.log('③ 每势力同时至多一支·streak 出兵后清零重计');
+BI.tick(GM); GM.turn++; BI.tick(GM); GM.turn++; BI.tick(GM); GM.turn++;
+var hjArmies = GM.armies.filter(function (a) { return a._borderInvasion && a.sourceFacName === '后金' && !a.disbanded; });
+assert(hjArmies.length === 1, '后金在场入侵军恒一支');
+var mnArmy = GM.armies.find(function (a) { return a._borderInvasion && a.sourceFacName === '漠南部' && !a.disbanded; });
+assert(!!mnArmy, '后金占位后·次强漠南部继起犯边(高压持续)');
+
+console.log('④ 风险回落两回合 → 饱掠而归+冷却');
+leaves[0].borderRisk = 20; leaves[1].borderRisk = 20;
+BI.tick(GM); GM.turn++;
+assert(!inv.disbanded, '低压第1回合 → 未撤(需连续2回合)');
+BI.tick(GM); GM.turn++;
+assert(inv.disbanded === true && inv.soldiers === 0, '低压第2回合 → 退兵散档');
+var hjFac = GM.facs.find(function (f) { return f.name === '后金'; });
+assert((hjFac._invCooldownUntil || 0) > GM.turn, '后金进冷却');
+assert(sandbox._ebs.some(function (e) { return e.indexOf('饱掠而归') >= 0; }), '退兵落起居注');
+
+console.log('⑤ 冷却期不再犯·期满可再犯');
+leaves[0].borderRisk = 90;
+BI.tick(GM); GM.turn++; BI.tick(GM); GM.turn++; BI.tick(GM); GM.turn++;
+var hjActive = GM.armies.filter(function (a) { return a._borderInvasion && a.sourceFacName === '后金' && !a.disbanded; });
+assert(hjActive.length === 0, '冷却中后金不再犯(漠南部在场也占位)');
+GM.turn = hjFac._invCooldownUntil + 1;
+// 漠南部先撤(模拟被打散)·腾出唯一新增位
+var mn = GM.armies.find(function (a) { return a.sourceFacName === '漠南部' && !a.disbanded; });
+if (mn) mn.soldiers = 0;
+BI.tick(GM); GM.turn++;              // 本回合处理漠南覆没
+BI.tick(GM); GM.turn++; BI.tick(GM); GM.turn++; BI.tick(GM); GM.turn++;
+hjActive = GM.armies.filter(function (a) { return a._borderInvasion && a.sourceFacName === '后金' && !a.disbanded; });
+assert(hjActive.length === 1, '冷却期满+高压再续 → 后金再犯');
+
+console.log('⑥ 被打散 → 覆没退场');
+var cur = hjActive[0];
+cur.soldiers = 0;
+BI.tick(GM);
+assert(cur.disbanded === true, 'soldiers≤0 → 全军覆没散档');
+assert(sandbox._ebs.some(function (e) { return e.indexOf('全军覆没') >= 0; }), '覆没落起居注');
+
+console.log('');
+if (failures.length) {
+  console.log('FAIL smoke-border-invasion: ' + failures.length + ' 处失败');
+  failures.forEach(function (f) { console.log('  - ' + f); });
+  process.exit(1);
+}
+console.log('PASS smoke-border-invasion (flag门/三回合确定出兵/义军排除/单支限额/退兵冷却/覆没退场)');

--- a/web/scripts/smoke-revolt-breach.js
+++ b/web/scripts/smoke-revolt-breach.js
@@ -1,0 +1,102 @@
+// smoke-revolt-breach.js — R2 破京终局链（批二刀1·2026-07-21·随 revoltEntityEnabled）
+//
+// owner 铁律：终局=玩家角色被杀·被杀有储君=继统续玩。旧轨=爬梯级5瞬时 _gameOver(数值阈值终局)。
+// 新轨(flag ON)：authority-complete 级5改挂 r._breachMarch·镜像层三拍接力——拍1进军京师(反应窗)
+// →拍2破京(G._capitalFallen 首个真写入者)→玩家过 adjudicatePlayerDeath(kind=regicide)：
+// succession=继统续玩残局·gameover=裁决器 _playerDead 信号独家收场(绝不双发 _gameOver)·
+// 裁决器缺席=回落经典 _gameOver 契约形状+breach 增强。另静态验 authority 旧轨字节保留。
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var vm = require('vm');
+
+var ROOT = path.join(__dirname, '..');
+var failures = [];
+function assert(cond, msg) {
+  if (cond) { console.log('  PASS ' + msg); }
+  else { failures.push(msg); console.log('  FAIL ' + msg); }
+}
+
+function freshSandbox(adjImpl) {
+  var sb = { console: console };
+  sb.window = sb; sb.global = sb;
+  sb.addEB = function (cat, msg) { sb._ebs.push(cat + '·' + msg); };
+  sb._ebs = [];
+  if (adjImpl) sb.adjudicatePlayerDeath = adjImpl;
+  sb.GM = {
+    turn: 20,
+    facs: [], chars: [{ name: '朱由检', isPlayer: true, alive: true }], armies: [],
+    minxin: { revolts: [{ id: 'rv9', region: '陕西', status: 'ongoing', level: 5, scale: 1000000, turn: 10, _breachMarch: { started: 20 } }] }
+  };
+  sb.P = { conf: { revoltEntityEnabled: true } };
+  vm.createContext(sb);
+  vm.runInContext(fs.readFileSync(path.join(ROOT, 'tm-revolt-entity.js'), 'utf8'), sb, { filename: 'tm-revolt-entity.js' });
+  return sb;
+}
+
+console.log('① 拍1·进军：义军移师京师·不破京不终局');
+var adjCalls = [];
+var sb = freshSandbox(function (ch, cause, opts) {
+  adjCalls.push({ name: ch && ch.name, cause: cause, kind: opts && opts.kind });
+  return { outcome: 'succession', heir: '皇太子' };
+});
+sb.TM.RevoltEntity.sync(sb.GM);
+var army = sb.GM.armies.find(function (a) { return a && a._revoltEntity; });
+assert(!!army && army.location === '京师' && army.state === 'march', '义军主力移师京师(march 态)');
+assert(!sb.GM._capitalFallen && !sb.GM._gameOver, '拍1 不破京不终局（一回合反应窗）');
+assert(adjCalls.length === 0, '拍1 不叫裁决器');
+assert(sb._ebs.some(function (e) { return e.indexOf('进逼京师') >= 0; }), '进军落起居注');
+
+console.log('② 拍2·破京→有储君=继统续玩残局');
+sb.GM.turn = 21;
+sb.TM.RevoltEntity.sync(sb.GM);
+assert(sb.GM._capitalFallen === true, '破京 → _capitalFallen 竖旗(皇威 capitalFall 信号端既有消费)');
+assert(adjCalls.length === 1 && adjCalls[0].kind === 'regicide' && adjCalls[0].name === '朱由检', '玩家过裁决器·kind=regicide(R1f 合法性门生效)');
+assert(!sb.GM._gameOver, 'succession → 不写 _gameOver·续玩残局');
+assert(sb.GM._dynastyFallInfo && sb.GM._dynastyFallInfo.fate === 'succession', '_dynastyFallInfo 记实(富屏增强·新字段)');
+assert(sb.GM.minxin.revolts[0]._breachDone === true, '_breachDone 竖旗');
+assert(sb.GM.facs.some(function (f) { return f._revoltEntity; }), '实体留场(残局舞台)');
+assert(sb._ebs.some(function (e) { return e.indexOf('京师陷落') >= 0; }) && sb._ebs.some(function (e) { return e.indexOf('继统') >= 0; }), '破京+继统落起居注');
+
+console.log('③ 幂等：破京后不重复裁决');
+sb.GM.turn = 22;
+sb.TM.RevoltEntity.sync(sb.GM);
+assert(adjCalls.length === 1, '_breachDone 后不再叫裁决器');
+
+console.log('④ 无嗣终局：裁决器 gameover → 信号独家收场·绝不双发 _gameOver');
+var adjCalls2 = [];
+var sb2 = freshSandbox(function (ch, cause, opts) {
+  adjCalls2.push(1);
+  sb2.GM._playerDead = true;  // 模拟裁决器行为
+  return { outcome: 'gameover' };
+});
+sb2.TM.RevoltEntity.sync(sb2.GM);  // 拍1
+sb2.GM.turn = 21;
+sb2.TM.RevoltEntity.sync(sb2.GM);  // 拍2
+assert(adjCalls2.length === 1 && sb2.GM._playerDead === true, '裁决器定终局(_playerDead)');
+assert(!sb2.GM._gameOver, '裁决器接手 → 不再写 _gameOver（单发纪律·防双终局屏）');
+assert(sb2.GM._dynastyFallInfo && sb2.GM._dynastyFallInfo.fate === 'gameover', '_dynastyFallInfo 记 gameover');
+
+console.log('⑤ 裁决器缺席 → 回落经典 _gameOver 契约形状+breach 增强');
+var sb3 = freshSandbox(null);
+sb3.GM.minxin.revolts[0].leader = '高迎祥';
+sb3.TM.RevoltEntity.sync(sb3.GM);  // 拍1
+sb3.GM.turn = 21;
+sb3.TM.RevoltEntity.sync(sb3.GM);  // 拍2
+var go = sb3.GM._gameOver;
+assert(!!go && go.type === 'dynasty_change' && go.revolt === 'rv9' && go.region === '陕西' && go.level === 5 && go.levelName === '改朝' && go.leader === '高迎祥', '回落 _gameOver 保留旧消费端契约字段(_consumeDynastyEndSignal)');
+assert(go.breach === true && go.capitalFallen === true, 'breach/capitalFallen 增强字段');
+
+console.log('⑥ 静态契约：authority-complete 旧轨字节保留+新轨路由');
+var authSrc = fs.readFileSync(path.join(ROOT, 'tm-authority-complete.js'), 'utf8');
+assert(/type:\s*'dynasty_change',\s*revolt:\s*r\.id,\s*turn:\s*ctx\.turn/.test(authSrc), '旧轨 _gameOver 块仍在(flag OFF 字节级旧行为)');
+assert(/revoltEntityEnabled === true/.test(authSrc) && /_breachMarch\s*=\s*\{\s*started:\s*ctx\.turn\s*\}/.test(authSrc), '新轨:flag ON 改挂 _breachMarch(镜像层接力)');
+assert(/改朝换代！天命已移/.test(authSrc), '旧轨终局起居注文案未动');
+
+console.log('');
+if (failures.length) {
+  console.log('FAIL smoke-revolt-breach: ' + failures.length + ' 处失败');
+  failures.forEach(function (f) { console.log('  - ' + f); });
+  process.exit(1);
+}
+console.log('PASS smoke-revolt-breach (三拍进军窗/破京信号/继统续玩/终局单发/裁决器缺席回落/旧轨字节保留)');

--- a/web/tm-authority-complete.js
+++ b/web/tm-authority-complete.js
@@ -374,6 +374,14 @@
             } else if (typeof global.GM.huangwei === 'object') global.GM.huangwei.index = Math.max(0, global.GM.huangwei.index - 8);
           }
           if (r.level === 5) {
+            // R2破京链(2026-07-21·owner铁律「终局=玩家角色被杀」)：实体链开启时不再瞬时 _gameOver——
+            // 改为兵临京师三拍(进军→破京→裁决器定命·tm-revolt-entity 接力·有储君=继统续玩残局)。
+            // flag 关=下方旧轨字节级不动。
+            var _r2On = !!(global.P && global.P.conf && global.P.conf.revoltEntityEnabled === true);
+            if (_r2On) {
+              r._breachMarch = { started: ctx.turn };
+              if (global.addEB) global.addEB('民变', (r.region || '') + '义军号称百万·旌旗蔽野·剑指京师');
+            } else {
             // 真亡因随信号走(第七轮·2026-07-07)：此前只带 type/revolt-id/turn·消费端(_consumeDynastyEndSignal)
             // 拿不到亡在何省何级·终局屏与太史公评语只能写套话。region/level/levelName 皆 revolt 真数据。
             global.GM._gameOver = {
@@ -383,6 +391,7 @@
               leader: r.leader || r.leaderName || ''
             };
             if (global.addEB) global.addEB('民变', '改朝换代！天命已移');
+            }
           }
         }
       }

--- a/web/tm-border-invasion.js
+++ b/web/tm-border-invasion.js
@@ -1,0 +1,128 @@
+// ============================================================
+//  tm-border-invasion.js — 威胁→侵攻确定性接点（批二刀2·2026-07-21）
+//
+//  第七轮记债(2026-07-08)：威胁值/borderRisk 只涨不咬——敌强边虚多年·从不真出一支入侵军·
+//  「威胁高→南侵」始终停在文案层。修法与民变实体镜像同范式：**确定性具象化·非随机**——
+//  玩家领内 leaf.borderRisk ≥ 70 连续 3 回合(streak 记在 leaf 上·tm-border-risk 每回合重算 risk)
+//  → 最强敌对势力(playerRelation<-50·排除 _revoltEntity 义军·民变走破京链不走边患链)具象化
+//  一支入侵军入 GM.armies(faction=敌方·驻该 leaf)——军事系统/junqing/AI 推演自然看见并接战。
+//  每势力同时至多一支·每回合至多新出一支(最险 leaf)·撤军=风险<40 连续2回合(饱掠而归)或
+//  军被打散(soldiers≤0)·撤后该势力 6 回合冷却。战斗归既有军事系统·本层只管「出现/撤走」。
+//  flag P.conf.borderInvasionEnabled === true(默认 OFF·设置可开)。
+//  本文件是 _borderInvasion 军队的唯一写口(已登记 gm-writes owners)。
+// ============================================================
+(function (global) {
+  'use strict';
+
+  var RISK_HIGH = 70, STREAK_NEED = 3;   // 高压阈值·连续回合数→出兵
+  var RISK_LOW = 40, LOW_STREAK = 2;     // 低压阈值·连续回合数→撤军
+  var COOLDOWN_TURNS = 6;                // 撤军后该势力冷却
+  var BASE_SOLDIERS = 20000, PER_STRENGTH = 800;  // 兵额 = 20000 + strength×800
+
+  function enabled() {
+    try { return !!(global.P && global.P.conf && global.P.conf.borderInvasionEnabled === true); }
+    catch (_) { return false; }
+  }
+
+  function _eb(msg) {
+    try { if (typeof global.addEB === 'function') global.addEB('边患', msg); } catch (_) {}
+  }
+
+  function _hostilesOf(G) {
+    return (G.facs || []).filter(function (f) {
+      if (!f || f._revoltEntity) return false;             // 义军走破京链·不走边患链
+      return (Number(f.playerRelation) || 0) < -50;
+    });
+  }
+
+  function _activeInvasionOf(G, facName) {
+    return (G.armies || []).find(function (a) {
+      return a && a._borderInvasion && !a.disbanded && a.sourceFacName === facName;
+    }) || null;
+  }
+
+  function _withdraw(G, army, why) {
+    army.disbanded = true; army.state = 'disbanded';
+    var left = army.soldiers || 0;
+    army.soldiers = 0; army.size = 0; army.strength = 0;
+    var fac = (G.facs || []).find(function (f) { return f && f.name === army.sourceFacName; });
+    if (fac) fac._invCooldownUntil = (G.turn || 0) + COOLDOWN_TURNS;
+    _eb('「' + (army.name || '犯边之师') + '」' + (why === 'destroyed' ? '全军覆没·边尘暂息' : '饱掠而归·出塞而去') + (left > 0 && why !== 'destroyed' ? '' : ''));
+  }
+
+  function tick(G) {
+    if (!enabled()) return;
+    G = G || global.GM;
+    if (!G || !G.adminHierarchy || !Array.isArray(G.armies)) return;
+    var IB = global.IntegrationBridge;
+    if (!IB || typeof IB.getLeafDivisions !== 'function') return;  // 无取叶能力·静默(镜像 tm-border-risk 约定)
+    var turn = G.turn || 0;
+    var leaves = IB.getLeafDivisions(G.adminHierarchy, 'player') || [];
+
+    // ① streak 记账 + 找最险候选
+    var worst = null;
+    leaves.forEach(function (leaf) {
+      if (!leaf) return;
+      var risk = Number(leaf.borderRisk) || 0;
+      if (risk >= RISK_HIGH) leaf._invRiskStreak = (leaf._invRiskStreak || 0) + 1;
+      else leaf._invRiskStreak = 0;
+      if (leaf._invRiskStreak >= STREAK_NEED && (!worst || risk > (Number(worst.borderRisk) || 0))) worst = leaf;
+    });
+
+    // ② 在场入侵军去留（风险回落/被打散）
+    G.armies.forEach(function (a) {
+      if (!a || !a._borderInvasion || a.disbanded) return;
+      if ((a.soldiers || 0) <= 0) { _withdraw(G, a, 'destroyed'); return; }
+      var leaf = leaves.find(function (l) { return l && (l.name === a.location || l.name === a.garrison); });
+      var risk = leaf ? (Number(leaf.borderRisk) || 0) : 0;
+      if (risk < RISK_LOW) {
+        a._lowRiskStreak = (a._lowRiskStreak || 0) + 1;
+        if (a._lowRiskStreak >= LOW_STREAK) _withdraw(G, a, 'retreat');
+      } else {
+        a._lowRiskStreak = 0;
+      }
+    });
+
+    // ③ 出兵（每回合至多一支·最险 leaf·最强合格敌对势力）
+    if (!worst) return;
+    var attacker = null;
+    _hostilesOf(G).forEach(function (f) {
+      if (_activeInvasionOf(G, f.name)) return;                        // 每势力同时至多一支
+      if ((f._invCooldownUntil || 0) > turn) return;                   // 冷却中
+      if (!attacker || (Number(f.strength) || 0) > (Number(attacker.strength) || 0)) attacker = f;
+    });
+    if (!attacker) return;
+    var soldiers = BASE_SOLDIERS + Math.round(Math.max(0, Math.min(100, Number(attacker.strength) || 50)) * PER_STRENGTH);
+    G.armies.push({  // arch-ok 边患入侵军唯一写口(本文件已登记 owners)·形状镜像 ai-change-army 创建先例
+      id: 'army_inv_' + (attacker.id || attacker.name) + '_' + turn,
+      name: attacker.name + '犯边之师',
+      faction: attacker.name,
+      branch: '边军', type: '边军', armyType: '边军',
+      soldiers: soldiers, size: soldiers, strength: soldiers,
+      morale: 70, supply: 60, training: 65, loyalty: 85, control: 75, controlLevel: 75,
+      location: worst.name || '', garrison: worst.name || '',
+      commander: '',
+      equipment: [], quality: '劲旅',
+      composition: [{ type: '边军', count: soldiers }],
+      state: 'field',
+      source: 'border.invasion',
+      sourceFacName: attacker.name, _borderInvasion: true, _createdTurn: turn
+    });
+    worst._invRiskStreak = 0;  // 出兵后重新计压
+    _eb('边警告急！「' + attacker.name + '」大举犯边·兵锋直指' + (worst.name || '边地') + '·号称 ' + Math.round(soldiers / 10000) + ' 万之众');
+  }
+
+  var API = { tick: tick, enabled: enabled, RISK_HIGH: RISK_HIGH, STREAK_NEED: STREAK_NEED, RISK_LOW: RISK_LOW, COOLDOWN_TURNS: COOLDOWN_TURNS };
+  global.TM = global.TM || {};
+  global.TM.BorderInvasion = API;
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+
+  // 结算注册：序 18(紧随 borderRisk 17.5 之后·读的就是它刚算好的 risk)
+  try {
+    if (global.SettlementPipeline && typeof global.SettlementPipeline.register === 'function') {
+      global.SettlementPipeline.register('borderInvasion', '边患侵攻接点', function () {
+        try { tick(global.GM); } catch (_eT) {}
+      }, 18, 'perturn');
+    }
+  } catch (_eR) {}
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/web/tm-patches.js
+++ b/web/tm-patches.js
@@ -698,7 +698,14 @@ openSettings=function(){
               '<input type="checkbox" id="s-revolt-entity" ' + (_revEntOn?'checked ':'') + 'onchange="_togglePConf(\'revoltEntityEnabled\',this.checked)" style="margin-top:0.15rem;flex-shrink:0;">' +
               '<div style="flex:1;">' +
                 '<div style="font-size:0.82rem;color:var(--gold);font-weight:600;">民变实体化（默认关闭·实验）</div>' +
-                '<div style="font-size:0.7rem;color:var(--txt-d);line-height:1.55;margin-top:0.15rem;">民变闹到「暴动」及以上时具象化为<b>真实体</b>：义军势力入势力档·渠帅入人物档·义军军队上军事帐——全游戏系统与 AI 推演自然看见它们；被剿/瓦解则军散档除。关闭时维持原五级抽象台账。</div>' +
+                '<div style="font-size:0.7rem;color:var(--txt-d);line-height:1.55;margin-top:0.15rem;">民变闹到「暴动」及以上时具象化为<b>真实体</b>：义军势力入势力档·渠帅入人物档·义军军队上军事帐——全游戏系统与 AI 推演自然看见它们；被剿/瓦解则军散档除。开启后民变打到顶级不再瞬间终局·而是<b>兵临京师三拍</b>：进军→破京→社稷定命（有储君则继统续玩残局）。关闭时维持原五级抽象台账。</div>' +
+              '</div>' +
+            '</label>' +
+            '<label style="display:flex;align-items:flex-start;gap:0.5rem;padding:0.4rem 0;border-bottom:1px dotted var(--bdr);cursor:pointer;">' +
+              '<input type="checkbox" id="s-border-invasion" ' + ((P.conf && P.conf.borderInvasionEnabled === true)?'checked ':'') + 'onchange="_togglePConf(\'borderInvasionEnabled\',this.checked)" style="margin-top:0.15rem;flex-shrink:0;">' +
+              '<div style="flex:1;">' +
+                '<div style="font-size:0.82rem;color:var(--gold);font-weight:600;">边患·真实入侵（默认关闭·实验）</div>' +
+                '<div style="font-size:0.7rem;color:var(--txt-d);line-height:1.55;margin-top:0.15rem;">边境风险持续高压（边军空虚+强敌在侧连续三回合）时·敌对势力<b>真的出兵</b>：一支入侵军出现在最危急的州府·军事系统照常接战；风险回落或击破则退兵（六回合内不再犯）。关闭时边患仅停留在数值与文案。</div>' +
               '</div>' +
             '</label>';
           })() +

--- a/web/tm-revolt-entity.js
+++ b/web/tm-revolt-entity.js
@@ -166,6 +166,64 @@
     _eb('「' + (fac.name || '义军') + '」烟消云散·余党四散');
   }
 
+
+// ── R2·破京终局链（批二刀1·2026-07-21·级5三拍：进军→破京→裁决器定命）──────────
+// 爬梯级5时(flag ON)tm-authority-complete 不再瞬时 _gameOver·改挂 r._breachMarch 由本层接力：
+// 拍1(升级当回合)：义军主力移师京师·九门戒严——给玩家与推演一回合反应窗；
+// 拍2(次回合)：破京——G._capitalFallen 首个真写入者(皇威 capitalFall 事件端一直在等此信号)·
+// 玩家角色过「玩家之死裁决器」(adjudicatePlayerDeath·kind=regicide·R1f 合法性门生效)：
+// 有储君=继统续玩残局(民变实体留场·南渡故事自然涌现)·无嗣=裁决器终局信号(_playerDead)独家收场·
+// 裁决器缺席(裸跑/装载序)=回落经典 _gameOver(保留 _consumeDynastyEndSignal 旧契约字段+breach 增强)。
+// ★终局信号单发纪律：裁决器接手就绝不再写 _gameOver(防双终局屏)·富屏增强走新字段 _dynastyFallInfo。
+function _tickBreach(G, r) {
+  if (!r || !r._breachMarch || r._breachDone) return;
+  var turn = G.turn || 0;
+  var army = _findBySource(G.armies, r.id);
+  var facName = (function () { var f = _findBySource(G.facs, r.id); return (f && f.name) || ((r.region || '') + '义军'); })();
+  if (!r._breachMarch.marched) {
+    // 拍1·进军
+    r._breachMarch.marched = turn;
+    if (army && !army.disbanded) { army.location = '京师'; army.garrison = '京师'; army.state = 'march'; }
+    _eb('「' + facName + '」百万之众进逼京师·九门戒严·中外震动');
+    return;
+  }
+  if (turn <= r._breachMarch.marched) return;  // 拍1当回合幂等·次回合才破京
+  // 拍2·破京
+  r._breachDone = true;
+  G._capitalFallen = true;  // 破京链首个真写入者·皇威 capitalFall 信号端(tm-authority-complete)既有消费
+  _eb('京师陷落！「' + facName + '」入据宫阙·社稷倾覆在即');
+  var player = null;
+  for (var i = 0; i < (G.chars || []).length; i++) {
+    var ch = G.chars[i];
+    if (ch && ch.isPlayer && ch.alive !== false) { player = ch; break; }
+  }
+  var fate = null;
+  try {
+    if (player && typeof global.adjudicatePlayerDeath === 'function') {
+      fate = global.adjudicatePlayerDeath(player, '京师陷落·殁于社稷', { kind: 'regicide', deadReason: '京师陷落·殁于社稷' });
+    }
+  } catch (_eA) {}
+  G._dynastyFallInfo = {  // 终局富屏/本纪增强(新字段·无旧消费端契约风险)
+    revolt: r.id, turn: turn, region: r.region || '',
+    leader: r.leader || r.leaderName || r._entityLeaderName || '',
+    facName: facName, breach: true,
+    fate: fate ? fate.outcome : 'no-adjudicator'
+  };
+  if (fate && fate.outcome === 'succession') {
+    _eb('嗣君于乱军之外继统·社稷不绝如线·天下事犹未可知');
+    return;  // 续玩残局：实体留场·_capitalFallen 持续·爬梯照走
+  }
+  if (fate) return;  // 裁决器已定终局(_playerDead 信号独家收场·绝不双发)
+  // 裁决器缺席回落：经典 _gameOver·字段形状=旧轨契约(_consumeDynastyEndSignal)+breach 增强
+  G._gameOver = {
+    type: 'dynasty_change', revolt: r.id, turn: turn,
+    region: r.region || '', level: 5, levelName: '改朝',
+    leader: r.leader || r.leaderName || r._entityLeaderName || '',
+    breach: true, capitalFallen: true
+  };
+  _eb('改朝换代！天命已移');
+}
+
   // 每回合镜像：状态驱动·幂等（即使某回合先于爬梯 tick 跑·至多迟一回合收敛）
   function sync(G) {
     if (!enabled()) return;
@@ -179,6 +237,7 @@
       if (!r || r.status !== 'ongoing') return;
       if ((r.level || 0) < 3) return;
       try { _ensureTrio(G, r); } catch (_eT) {}
+      if ((r.level || 0) >= 5) { try { _tickBreach(G, r); } catch (_eB) {} }  // 破京链三拍(批二刀1)
     });
     // ② 覆灭清账：源民变已被剿/瓦解/出档（级5改朝除外·实体留在场·终局屏归爬梯 _gameOver）
     G.facs.slice().forEach(function (fac) {


### PR DESCRIPTION
## 刀1 破京终局链（随 `revoltEntityEnabled`·owner 铁律「终局=玩家角色被杀·有储君=继统续玩」）

旧轨=爬梯级5**瞬时** `_gameOver`（数值阈值终局，正是铁律要退役的范式）。新轨（flag ON；OFF=旧轨**字节级不动**，smoke 有静态契约钉着）：

**三拍**：①升级当回合义军主力**进军京师**（九门戒严·给玩家与推演一回合反应窗）→ ②次回合**破京**——`G._capitalFallen` 的**首个真写入者**（皇威 capitalFall 事件端 6 月建成后一直在等这个信号）→ ③玩家过**玩家之死裁决器**（`adjudicatePlayerDeath`·kind=regicide·鼎革 R1f 合法性门生效）：
- **有储君 → 继统续玩残局**：实体留场、京师沦陷态持续——南渡故事引擎自然涌现
- **无嗣 → 终局**：裁决器 `_playerDead` 信号**独家收场**（★终局单发纪律：绝不再写 `_gameOver`，防双终局屏）
- 裁决器缺席（裸跑/装载序）→ 回落经典 `_gameOver` 契约形状（`_consumeDynastyEndSignal` 旧字段全保留）+ breach 增强
- 终局富屏增强走新字段 `_dynastyFallInfo`（零旧契约风险）

## 刀2 威胁→侵攻确定性接点（新 flag `borderInvasionEnabled` 默认 OFF）

第七轮记债：「borderRisk 只涨不咬——威胁高→南侵永远停在文案层」。新模块 `tm-border-invasion.js`（同民变实体镜像范式·**确定性非随机**·登记 gm-writes owners·结算序 18 紧随 borderRisk 的 17.5）：

- 玩家领 `leaf.borderRisk ≥ 70` **连续 3 回合**（streak 记在 leaf 上）→ 最强敌对势力（playerRelation<-50·**排除义军**——民变走破京链不走边患链）真出一支入侵军：兵额 20000+strength×800，驻最险州府，每势力至多一支、每回合至多一支
- 风险 <40 连续 2 回合 → 饱掠而归；被打散（soldiers≤0）→ 全军覆没；撤后该势力 **6 回合冷却**
- 战斗归既有军事系统——本层只管「出现/撤走」这个确定性接点

## 设置

「民变实体化」描述补破京三拍说明；新增「边患·真实入侵」开关（默认关·实验）。

## 验证

- 新 `smoke-revolt-breach`（**20 断言**：进军窗/破京信号/继统续玩/终局单发/裁决器缺席回落/authority 旧轨字节保留静态契约）+ `smoke-border-invasion`（**19 断言**：flag 门/三回合确定出兵/义军排除/单支限额/退兵冷却/覆没退场）
- 批一 `smoke-revolt-entity` 回归绿 · `ci-smokes` **779 PASS**（豁免 2 缺资产）· `lint-arch-all` **8/8** · 契约绿 · 基线 `--check` PASS（四条目外科对齐+新文件按序插入）

## 批三回桌（不在本 PR）

招抚动词方案已摊桌待 owner 拍板（牵国库走账+玩家操作五渠道）；真人渠帅败后人事（招安/系狱）；残局南渡专项。

🤖 Generated with [Claude Code](https://claude.com/claude-code)