### PR TITLE
批三：民变演绎层（AI 主导）——起号立领袖 + 逐回合行为决断 + 招抚走诏令管线（宪法闸落账）

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2111,8 +2111,8 @@
     },
     {
       "path": "index.html",
-      "sha256": "2553e94ba0f828503cdc75b231aece71660d5dce299269e5716423183becb719",
-      "size": 64621
+      "sha256": "6eebaf6dc0c1c35a2ea44405854179062e5b09f18a535575fccde1c30ed765c2",
+      "size": 64844
     },
     {
       "path": "INDEX.md",
@@ -5011,8 +5011,8 @@
     },
     {
       "path": "tm-patches.js",
-      "sha256": "cd38978ffd8fb9908b4df9c6535149f4b65667d547ede348b75f3d7dbf93e810",
-      "size": 181788
+      "sha256": "b93cfb9c109cc359655c543d16b6a2b8a2c3b3780c480edda9ac07d52f09e624",
+      "size": 181944
     },
     {
       "path": "tm-pause-fab.js",
@@ -5141,8 +5141,13 @@
     },
     {
       "path": "tm-revolt-entity.js",
-      "sha256": "bd902fd33c4200f4722368a0c8c87c637eda2cefcab3729c45a9fd28d78eed2b",
-      "size": 13126
+      "sha256": "18f109069e10568e6ec18c172e86a452c756053322cc4b31eb09f6850c0c07d1",
+      "size": 15100
+    },
+    {
+      "path": "tm-revolt-inference.js",
+      "sha256": "3d3b33ecd1a96a612657c839f6bc45cade00e04246d18c8c4ab201766af214b0",
+      "size": 21008
     },
     {
       "path": "tm-save-lifecycle.js",

--- a/web/index.html
+++ b/web/index.html
@@ -857,6 +857,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-social-foundation.js?v=20260612"></script>
 <script src="tm-authority-complete.js?v=20260623-ledgerflow"></script>
 <script src="tm-revolt-entity.js?v=20260721"></script><!-- R2民变实体镜像·flag revoltEntityEnabled 默认OFF·爬梯level≥3具象化势力/渠帅/军队三件套 -->
+<script src="tm-revolt-inference.js?v=20260721b"></script><!-- 批三·民变演绎层(AI主导)·起号立领袖subcall+逐回合行为subcall(打/占/分合/建国/招抚谈判)·宪法闸落账·AI缺席模板兜底 -->
 <script src="tm-historical-presets.js?v=2026042816"></script>
 <script src="tm-prophecy.js?v=20260709"></script>
 <script src="tm-region-enrich.js?v=2026042714"></script>

--- a/web/scripts/arch-baselines/gm-writes.json
+++ b/web/scripts/arch-baselines/gm-writes.json
@@ -4,6 +4,7 @@
       "tm-border-invasion.js",
       "tm-indices.js",
       "tm-revolt-entity.js",
+      "tm-revolt-inference.js",
       "tm-save-lifecycle.js"
     ],
     "gmFactories": [

--- a/web/scripts/smoke-revolt-inference.js
+++ b/web/scripts/smoke-revolt-inference.js
@@ -1,0 +1,135 @@
+// smoke-revolt-inference.js — 民变演绎层（批三·2026-07-21·AI 主导·宪法闸落账）
+//
+// owner 重批落地：身份与行为交 AI(起号立领袖 subcall+逐回合行为 subcall)·引擎只验不产。
+// 本 smoke 不经真 AI：直接灌 canned 决策进 _applyActions·验全部宪法闸——
+// 身份具象化(真旗号/真渠帅)/锻造缓拍/占府闸(师未至·兵力不敌)/裹挟封顶/分裂封5/合流/
+// 僭号建国(交AI宪法只记账)/招抚闸(无旨不受抚·帑廪真扣·不足则败局)/受抚清账(授官·解占据)。
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var vm = require('vm');
+
+var ROOT = path.join(__dirname, '..');
+var failures = [];
+function assert(cond, msg) {
+  if (cond) { console.log('  PASS ' + msg); }
+  else { failures.push(msg); console.log('  FAIL ' + msg); }
+}
+
+var sandbox = { console: console };
+sandbox.window = sandbox;
+sandbox.global = sandbox;
+sandbox._ebs = [];
+sandbox.addEB = function (cat, msg) { sandbox._ebs.push(cat + '·' + msg); };
+var DIVS = {
+  '凤阳府': { name: '凤阳府', militaryRecruits: 3000, minxin: 20 },
+  '庐州府': { name: '庐州府', militaryRecruits: 40000, minxin: 30 }
+};
+sandbox.TM = { AIChange: { PathUtils: { findDivisionByNameFuzzy: function (G, n) { return DIVS[String(n || '').trim()] || null; } } } };
+sandbox.GM = {
+  turn: 6,
+  eraName: '天下将乱',
+  mapData: {},
+  guoku: { balance: 250000, ledgers: { money: { stock: 250000 } } },
+  facs: [{ id: 'f1', name: '大明', strength: 70, economy: 60, playerRelation: 100 }],
+  chars: [{ name: '朱由校', isPlayer: true, alive: true }],
+  armies: [],
+  minxin: {
+    trueIndex: 30,
+    revolts: [{ id: 'rvA', region: '凤阳', status: 'ongoing', level: 4, scale: 200000, turn: 5,
+      _identity: { banner: '闯字营', leaderName: '高闯王', leaderFrom: 'new', creed: '均田免赋', stance: '流动作战', agenda: '窥神京' } }]
+  },
+  _edictTracker: []
+};
+sandbox.P = { conf: { revoltEntityEnabled: true } };
+vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync(path.join(ROOT, 'tm-revolt-entity.js'), 'utf8'), sandbox, { filename: 'tm-revolt-entity.js' });
+vm.runInContext(fs.readFileSync(path.join(ROOT, 'tm-revolt-inference.js'), 'utf8'), sandbox, { filename: 'tm-revolt-inference.js' });
+
+var GM = sandbox.GM;
+var RE = sandbox.TM.RevoltEntity;
+var RI = sandbox.TM.RevoltInference;
+
+console.log('① AI 锻造身份具象化：真旗号真渠帅(非模板)');
+RE.sync(GM);
+var fac = GM.facs.find(function (f) { return f._revoltEntity; });
+var army = GM.armies.find(function (a) { return a._revoltEntity; });
+var leader = GM.chars.find(function (c) { return c._revoltEntity; });
+assert(!!fac && fac.name === '闯字营', '旗号=AI 锻造「闯字营」(非「凤阳义军」模板)');
+assert(!!leader && leader.name === '高闯王', '渠帅=AI 立的「高闯王」');
+assert(!!army && army.commander === '高闯王', '军主帅=渠帅');
+
+console.log('② 身份锻造中缓拍(双轨)');
+GM.minxin.revolts.push({ id: 'rvB', region: '山东', status: 'ongoing', level: 3, scale: 30000, turn: 6, _identityPending: 6 });
+RE.sync(GM);
+assert(!GM.facs.some(function (f) { return f._revoltEntity && f.sourceRevoltId === 'rvB'; }), '锻造中(_identityPending)→本回合不具象化');
+GM.turn = 8;
+RE.sync(GM);
+assert(GM.facs.some(function (f) { return f._revoltEntity && f.sourceRevoltId === 'rvB' && f.name === '山东义军'; }), '锻久未成→模板兜底具象化(双轨)');
+
+console.log('③ 占府宪法闸：师未至/兵力不敌皆拦·合规才易手');
+army.location = '陕西'; army.garrison = '陕西';  // 造真「师未至」态(驻地与目标府无涉)
+var r1 = RI._applyActions(GM, { stocks: [{ id: 'rvA', actions: [{ type: 'occupy', target: '凤阳府' }] }] });
+assert(r1.blocked === 1 && !DIVS['凤阳府'].occupiedBy, '师未至(驻陕西·图占凤阳府) → 拦·虚占无效');
+RI._applyActions(GM, { stocks: [{ id: 'rvA', actions: [{ type: 'move', target: '凤阳府' }] }] });
+RI._applyActions(GM, { stocks: [{ id: 'rvA', actions: [{ type: 'occupy', target: '凤阳府' }] }] });
+assert(DIVS['凤阳府'].occupiedBy === '闯字营', '军至+兵力(60000≥2×3000+2000)→凤阳府真易手 occupiedBy');
+assert((fac._occupiedDivs || []).indexOf('凤阳府') >= 0, '_occupiedDivs 记账');
+assert(GM.mapData.factionColors && GM.mapData.factionColors['闯字营'], '势力色已注册(地图改色数据层就绪)');
+var r3 = RI._applyActions(GM, { stocks: [{ id: 'rvA', actions: [{ type: 'move', target: '庐州府' }, { type: 'occupy', target: '庐州府' }] }] });
+assert(!DIVS['庐州府'].occupiedBy, '兵力不敌(60000<2×40000+2000)→庐州府拦下·虚占无效');
+assert(sandbox._ebs.some(function (e) { return e.indexOf('兵力不敌守备') >= 0; }), '拦下有诚实叙事');
+
+console.log('④ 裹挟封顶 25%');
+var before = army.soldiers;
+RI._applyActions(GM, { stocks: [{ id: 'rvA', actions: [{ type: 'recruit', delta: 999999 }] }] });
+assert(army.soldiers === before + Math.round(before * 0.25), '裹挟 999999 → 封顶 +25%');
+
+console.log('⑤ 僭号建国(时机交AI·宪法只记账)');
+RI._applyActions(GM, { stocks: [{ id: 'rvA', actions: [{ type: 'proclaim', stateName: '大顺' }] }] });
+assert(fac.isState === true && fac.stateName === '大顺', '建国落账 isState/国号');
+assert(leader.officialTitle === '「大顺」僭号之主', '渠帅称制');
+var r5b = RI._applyActions(GM, { stocks: [{ id: 'rvA', actions: [{ type: 'proclaim', stateName: '再建' }] }] });
+assert(r5b.blocked === 1 && fac.stateName === '大顺', '重复建国拦');
+
+console.log('⑥ 分裂(封5)与合流');
+RI._applyActions(GM, { stocks: [{ id: 'rvA', actions: [{ type: 'split', banner: '曹字营', leaderName: '罗曹操', creed: '就食于敌', target: '河南' }] }] });
+var srv = GM.minxin.revolts.find(function (r) { return r._aiBorn; });
+assert(!!srv && srv._identity && srv._identity.banner === '曹字营', '分裂生新股(带 AI 身份)');
+RE.sync(GM);
+var fac2 = GM.facs.find(function (f) { return f._revoltEntity && f.sourceRevoltId === srv.id; });
+assert(!!fac2 && fac2.name === '曹字营', '新股次回合具象化「曹字营」');
+RI._applyActions(GM, { stocks: [{ id: 'rvA', actions: [{ type: 'merge', target: srv.id }] }] });
+assert(srv.status === 'dispersed' && srv._mergedInto === 'rvA', '合流：目标股散·记 _mergedInto');
+RE.sync(GM);
+assert(!GM.facs.some(function (f) { return f.sourceRevoltId === srv.id; }), '被并股实体清账');
+
+console.log('⑦ 招抚宪法闸：无旨不受抚·帑廪真扣·不足败局');
+var r7 = RI._applyActions(GM, { stocks: [{ id: 'rvA', actions: [{ type: 'pacify_accept', silverDemand: 100000 }] }] });
+assert(r7.blocked === 1 && GM.minxin.revolts[0].status === 'ongoing', '无招抚旨 → 不得自称受抚');
+GM._edictTracker.push({ turn: 9, category: '政事', content: '着有司招抚凤阳流贼·许以自新' });
+var r7b = RI._applyActions(GM, { stocks: [{ id: 'rvA', actions: [{ type: 'pacify_accept', silverDemand: 300000, officeTitle: '游击将军' }] }] });
+assert(r7b.blocked === 1 && GM.minxin.revolts[0].status === 'ongoing' && GM.guoku.balance === 250000, '索银30万>帑廪25万 → 抚局败·分文未动');
+assert(sandbox._ebs.some(function (e) { return e.indexOf('帑廪不给') >= 0; }), '败局有诚实叙事');
+var r7c = RI._applyActions(GM, { stocks: [{ id: 'rvA', actions: [{ type: 'pacify_accept', silverDemand: 200000, officeTitle: '游击将军' }] }] });
+assert(GM.minxin.revolts[0].status === 'pacified' && GM.guoku.balance === 50000, '索银20万 → 真扣·受抚成局');
+assert(GM.guoku.ledgers.money.stock === 50000, 'money.stock 同步(镜像 openGranary 范式)');
+
+console.log('⑧ 受抚清账：授官·解占据·非溃散');
+RE.sync(GM);
+assert(leader._revoltPacified === true && leader.officialTitle === '游击将军', '渠帅得授讨来的官职(非「溃散流亡」)');
+assert(!GM.facs.some(function (f) { return f.sourceRevoltId === 'rvA'; }), '受抚势力除档');
+assert(!DIVS['凤阳府'].occupiedBy, '受抚 → 凤阳府占据解除归还');
+assert(sandbox._ebs.some(function (e) { return e.indexOf('受抚罢兵') >= 0; }), '受抚落起居注');
+
+console.log('⑨ 招抚旨匹配器');
+var eds = RI._recentPacifyEdicts(GM, { fac: { name: '曹字营' }, r: { region: '河南' }, leader: { name: '罗曹操' } });
+assert(eds.length >= 1, '泛旨「招抚…流贼」对任一股可见(点名语义交 AI 读原文)');
+
+console.log('');
+if (failures.length) {
+  console.log('FAIL smoke-revolt-inference: ' + failures.length + ' 处失败');
+  failures.forEach(function (f) { console.log('  - ' + f); });
+  process.exit(1);
+}
+console.log('PASS smoke-revolt-inference (AI身份具象化/缓拍双轨/占府闸/裹挟顶/建国记账/分合/招抚三闸/受抚清账)');

--- a/web/tm-patches.js
+++ b/web/tm-patches.js
@@ -698,7 +698,7 @@ openSettings=function(){
               '<input type="checkbox" id="s-revolt-entity" ' + (_revEntOn?'checked ':'') + 'onchange="_togglePConf(\'revoltEntityEnabled\',this.checked)" style="margin-top:0.15rem;flex-shrink:0;">' +
               '<div style="flex:1;">' +
                 '<div style="font-size:0.82rem;color:var(--gold);font-weight:600;">民变实体化（默认关闭·实验）</div>' +
-                '<div style="font-size:0.7rem;color:var(--txt-d);line-height:1.55;margin-top:0.15rem;">民变闹到「暴动」及以上时具象化为<b>真实体</b>：义军势力入势力档·渠帅入人物档·义军军队上军事帐——全游戏系统与 AI 推演自然看见它们；被剿/瓦解则军散档除。开启后民变打到顶级不再瞬间终局·而是<b>兵临京师三拍</b>：进军→破京→社稷定命（有储君则继统续玩残局）。关闭时维持原五级抽象台账。</div>' +
+                '<div style="font-size:0.7rem;color:var(--txt-d);line-height:1.55;margin-top:0.15rem;">民变闹到「暴动」及以上时具象化为<b>真实体</b>并交 <b>AI 演绎</b>：起真旗号·立有名有姓的渠帅·定纲领；此后每回合由 AI 决断攻守/裹挟/分裂合流/僭号建国·并按你的招抚旨意<b>真谈判</b>（讨价/诈许/真降皆有可能·银子真扣）。占据的府县真易手。被剿/瓦解则军散档除；打到顶级=<b>兵临京师三拍</b>（有储君则继统续玩残局）。无 AI 时落确定性兜底。每回合约多 1-2 次轻量调用（走次要 API）。关闭时维持原五级抽象台账。</div>' +
               '</div>' +
             '</label>' +
             '<label style="display:flex;align-items:flex-start;gap:0.5rem;padding:0.4rem 0;border-bottom:1px dotted var(--bdr);cursor:pointer;">' +

--- a/web/tm-revolt-entity.js
+++ b/web/tm-revolt-entity.js
@@ -31,7 +31,9 @@
   }
 
   function _factionName(G, r) {
-    var base = (r.region ? String(r.region) : '流民') + '义军';
+    // 批三·AI 锻造的真旗号优先(owner重批：禁「XX义军」式模板)·模板仅为 AI 缺席兜底(双轨)
+    var base = (r._identity && r._identity.banner) ? String(r._identity.banner)
+      : ((r.region ? String(r.region) : '流民') + '义军');
     // 同区第二股民变→缀序防重名（按已在档的其他 _revoltEntity 势力计数）
     var clash = (G.facs || []).filter(function (f) {
       return f && f._revoltEntity && f.sourceRevoltId !== r.id && String(f.name || '').indexOf(base) === 0;
@@ -40,7 +42,7 @@
   }
 
   function _leaderName(G, r) {
-    var name = String(r.leader || r.leaderName || '').trim();
+    var name = String((r._identity && r._identity.leaderName) || r.leader || r.leaderName || '').trim();
     if (name) return name;
     return (r.region ? String(r.region) : '') + '义军渠帅';
   }
@@ -143,9 +145,11 @@
     }
   }
 
-  // 覆灭：民变被剿/瓦解 → 军散·势力除档·渠帅溃散流亡（不碰 alive·避开死亡系统）
-  function _teardown(G, fac) {
+  // 覆灭/受抚：民变被剿/瓦解→军散·势力除档·渠帅溃散流亡；受抚(批三·AI 谈判成局)→遣散罢兵·
+  // 渠帅得授讨来的官职或归顺·真人首领复原籍。皆不碰 alive(避开死亡系统)。
+  function _teardown(G, fac, src) {
     var rid = fac.sourceRevoltId;
+    var pac = (src && src._pacified) || null;
     var army = _findBySource(G.armies, rid);
     if (army && !army.disbanded) {
       army.disbanded = true; army.state = 'disbanded';
@@ -153,17 +157,34 @@
     }
     for (var c = 0; c < G.chars.length; c++) {
       var ch = G.chars[c];
-      if (!ch || ch.sourceRevoltId !== rid || ch._revoltDefeated) continue;
-      if (ch._revoltEntity) {
+      if (!ch || ch.sourceRevoltId !== rid || ch._revoltDefeated || ch._revoltPacified) continue;
+      if (pac) {
+        ch._revoltPacified = true;
+        ch.officialTitle = pac.officeTitle || '受抚归顺';
+        _setCharFaction(ch, ch._preRevoltFaction || '');  // 真人招安复原籍·草莽渠帅无所属
+      } else if (ch._revoltEntity) {
         ch._revoltDefeated = true; ch.officialTitle = '溃散流亡';
+        _setCharFaction(ch, '');  // 退籍走正门
       } else {
         ch._revoltDefeated = true;  // 真人首领：败后无所依·原职衔不动(去留归后续系统)
+        _setCharFaction(ch, '');
       }
-      _setCharFaction(ch, '');  // 退籍走正门
     }
+    // 受抚/覆灭皆解占据(批三·occupiedBy 归还)
+    try {
+      (fac._occupiedDivs || []).forEach(function (dn) {
+        var div = null;
+        try {
+          var PU = global.TM && global.TM.AIChange && global.TM.AIChange.PathUtils;
+          var fn = PU && ((typeof PU.findDivisionByNameFuzzy === 'function') ? PU.findDivisionByNameFuzzy : PU.findDivisionByNameOrId);
+          div = fn ? fn(G, dn) : null;
+        } catch (_eDv) {}
+        if (div && div.occupiedBy === fac.name) { delete div.occupiedBy; delete div._occupiedTurn; }
+      });
+    } catch (_eOc) {}
     var idx = G.facs.indexOf(fac);
     if (idx >= 0) G.facs.splice(idx, 1);  // arch-ok 民变实体唯一写口·自建势力对称除档
-    _eb('「' + (fac.name || '义军') + '」烟消云散·余党四散');
+    _eb(pac ? ('「' + (fac.name || '义军') + '」受抚罢兵·遣散归农') : ('「' + (fac.name || '义军') + '」烟消云散·余党四散'));
   }
 
 
@@ -230,12 +251,19 @@ function _tickBreach(G, r) {
     G = G || global.GM;
     if (!G || !G.minxin || !Array.isArray(G.minxin.revolts)) return;
     if (!Array.isArray(G.facs)) return;
+    // 批三·演绎层排程(AI 起号立领袖+逐回合行为·AI 缺席时本层模板/静默=双轨)
+    try { if (global.TM && global.TM.RevoltInference && typeof global.TM.RevoltInference.schedule === 'function') global.TM.RevoltInference.schedule(G); } catch (_eI) {}
     var byId = {};
     G.minxin.revolts.forEach(function (r) { if (r && r.id != null) byId[r.id] = r; });
     // ① 具象化/更新在场者
     G.minxin.revolts.forEach(function (r) {
       if (!r || r.status !== 'ongoing') return;
       if ((r.level || 0) < 3) return;
+      // 批三·身份锻造中缓拍(subcall 起号立领袖·失败/超时自动落模板=双轨)
+      if (r._identityPending != null && !r._identity) {
+        if (r._identityPending >= (G.turn || 0) - 1) return;
+        delete r._identityPending;
+      }
       try { _ensureTrio(G, r); } catch (_eT) {}
       if ((r.level || 0) >= 5) { try { _tickBreach(G, r); } catch (_eB) {} }  // 破京链三拍(批二刀1)
     });
@@ -244,8 +272,8 @@ function _tickBreach(G, r) {
       if (!fac || !fac._revoltEntity) return;
       var src = byId[fac.sourceRevoltId];
       if (src && src.status === 'ongoing') return;
-      if (src && (src.level || 0) >= 5) return;
-      try { _teardown(G, fac); } catch (_eD) {}
+      if (src && (src.level || 0) >= 5 && src.status !== 'pacified') return;  // 级5留场·但受抚仍清账(批三)
+      try { _teardown(G, fac, src); } catch (_eD) {}
     });
   }
 

--- a/web/tm-revolt-inference.js
+++ b/web/tm-revolt-inference.js
@@ -1,0 +1,320 @@
+// ============================================================
+//  tm-revolt-inference.js — 民变演绎层（批三·2026-07-21·AI 主导）
+//
+//  owner 重批(2026-07-21)落地：「实体化≠模板化——身份与行为必须 AI 演绎·确定性只配兜底账本」。
+//  owner 三拍板：①起号立领袖=专门轻量 subcall ②建国时机交 AI（宪法只记账）③确定性层降级保双轨。
+//
+//  两个 subcall（皆随 revoltEntityEnabled·AI 缺席时镜像层模板兜底=双轨）：
+//  A. forgeIdentity(具象化时一次)：AI 起真旗号·立有名有姓的渠帅（优先从在档不满人物揭竿）·
+//     定纲领/stance/agenda——民变从此是「人」不是模板棋子。
+//  B. tickInference(每回合一次·post-turn job)：各股民变作为一等演员由 AI 决断——打哪/占哪/
+//     裹挟/分裂/合流/僭号建国/如何应对朝廷招抚旨（读 GM._edictTracker 真旨全文·可讨价/诈许/
+//     真受抚·不保成功·无独立 UI=owner 批三令）。
+//
+//  宪法闸（本层唯一硬码职责·只验不产）：占府须军至且兵力压过守备(防幻觉割地)·招抚须真有其旨
+//  且帑廪真拿得出银(GM.guoku.balance·镜像 openGranary 支出范式)·裹挟每回合封顶 25%·股数封 5·
+//  受抚真散伙·渠帅死亡仍只走裁决器。地图真改色=批四(数据层 occupiedBy+factionColors 本批就绪)。
+//  本文件为 occupiedBy/_occupiedDivs/受抚落账等的写口(已登记 gm-writes owners)。
+// ============================================================
+(function (global) {
+  'use strict';
+
+  var MAX_STOCKS = 5;              // 在场股数封顶(防AI裂殖爆炸)
+  var RECRUIT_CAP_RATIO = 0.25;    // 裹挟每回合封顶
+  var REBEL_COLORS = ['#8b3a2e', '#7a5c2e', '#5c2e7a', '#2e6b5c', '#7a2e50'];  // 义军势力色池(按序取)
+
+  function _eb(msg) {
+    try { if (typeof global.addEB === 'function') global.addEB('民变', msg); } catch (_) {}
+  }
+  function _chron(G, text) {
+    try {
+      if (!Array.isArray(G._chronicle)) G._chronicle = [];
+      G._chronicle.push({ turn: G.turn || 0, date: G._gameDate || '', type: '民变', text: text, tags: ['民变', 'AI演绎'] });
+    } catch (_) {}
+  }
+  function _aiOn() {
+    try { return typeof global.callAI === 'function'; } catch (_) { return false; }
+  }
+  function enabled() {
+    try { return !!(global.P && global.P.conf && global.P.conf.revoltEntityEnabled === true); }
+    catch (_) { return false; }
+  }
+  function _fuzzyDiv(G, name) {
+    try {
+      var PU = global.TM && global.TM.AIChange && global.TM.AIChange.PathUtils;
+      if (!PU || !name) return null;
+      var fn = (typeof PU.findDivisionByNameFuzzy === 'function') ? PU.findDivisionByNameFuzzy
+             : ((typeof PU.findDivisionByNameOrId === 'function') ? PU.findDivisionByNameOrId : null);
+      return fn ? fn(G, name) : null;
+    } catch (_) { return null; }
+  }
+  // 帑廪支出（镜像 GuokuEngine.Actions.openGranary 范式：balance 直扣+money.stock 同步·不足=false）
+  function _spendSilver(G, amount, label) {
+    amount = Math.max(0, Math.round(Number(amount) || 0));
+    if (!amount) return false;
+    try { if (typeof global.GuokuEngine !== 'undefined' && typeof global.GuokuEngine.ensureModel === 'function') global.GuokuEngine.ensureModel(); } catch (_) {}
+    var g = G.guoku;
+    if (!g || (Number(g.balance) || 0) < amount) return false;
+    g.balance -= amount;
+    try { if (g.ledgers && g.ledgers.money) g.ledgers.money.stock = g.balance; } catch (_) {}
+    try { if (typeof global.addEB === 'function') global.addEB('朝代', label + '·帑出 ' + amount + ' 两'); } catch (_) {}
+    return true;
+  }
+  function _ensureColor(G, facName) {
+    try {
+      if (!G.mapData) return;
+      if (!G.mapData.factionColors) G.mapData.factionColors = {};
+      if (!G.mapData.factionColors[facName]) {
+        var used = Object.keys(G.mapData.factionColors).length;
+        G.mapData.factionColors[facName] = REBEL_COLORS[used % REBEL_COLORS.length];
+      }
+    } catch (_) {}
+  }
+  function _stockOf(G, fac) {
+    var rid = fac.sourceRevoltId;
+    var revolts = (G.minxin && G.minxin.revolts) || [];
+    var r = null;
+    for (var i = 0; i < revolts.length; i++) if (revolts[i] && revolts[i].id === rid) { r = revolts[i]; break; }
+    var army = null;
+    for (var a = 0; a < (G.armies || []).length; a++) {
+      var x = G.armies[a];
+      if (x && x._revoltEntity && x.sourceRevoltId === rid && !x.disbanded) { army = x; break; }
+    }
+    var leader = null;
+    for (var c = 0; c < (G.chars || []).length; c++) {
+      var ch = G.chars[c];
+      if (ch && ch.sourceRevoltId === rid && !ch._revoltDefeated) { leader = ch; break; }
+    }
+    return { fac: fac, r: r, army: army, leader: leader };
+  }
+  function _recentPacifyEdicts(G, stock) {
+    var out = [];
+    var tracker = Array.isArray(G._edictTracker) ? G._edictTracker.slice(-8) : [];
+    var keys = [stock.fac.name, (stock.r && stock.r.region) || '', (stock.leader && stock.leader.name) || ''].filter(Boolean);
+    tracker.forEach(function (e) {
+      var t = String((e && (e.content || e.title)) || '');
+      if (!t) return;
+      if (t.indexOf('抚') < 0 && t.indexOf('招安') < 0) return;
+      var hit = keys.some(function (k) { return k && t.indexOf(k) >= 0; });
+      // 泛旨（「招抚流贼」不点名）也算·点名旨优先语义交给 AI 读原文
+      if (hit || t.indexOf('流贼') >= 0 || t.indexOf('义军') >= 0 || t.indexOf('乱民') >= 0) out.push(t.slice(0, 120));
+    });
+    return out;
+  }
+
+  // ── subcall A·起号立领袖（具象化时一次·owner 拍板①）────────────────────────
+  async function forgeIdentity(G, r) {
+    if (!_aiOn()) return null;
+    var localMx = '';
+    try { localMx = String((G.minxin && G.minxin.trueIndex) || ''); } catch (_) {}
+    var discontent = (G.chars || [])
+      .filter(function (c) { return c && c.alive !== false && !c.isPlayer && !c._revoltEntity && (Number(c.loyalty) || 50) < 40; })
+      .slice(0, 3)
+      .map(function (c) { return c.name + '(' + (c.officialTitle || '在野') + '·忠诚' + (Number(c.loyalty) || 0) + ')'; });
+    var prompt = '你是天命推演引擎的民变演绎官。' + (r.region || '某地') + '民乱已成燎原(' + (G.eraName || '') + '·当地民心约' + localMx + ')·须为这股民变立真身份。\n'
+      + (discontent.length ? '在档心怀怨望者(可选其揭竿·亦可另立草莽新人)：' + discontent.join('·') + '\n' : '')
+      + '要求：旗号须像真实史书里的名号(教门/年号/绰号皆可·2-6字·禁「XX义军」式模板)·渠帅要有名有姓·'
+      + '纲领要能号召饥民。只返回 JSON：\n'
+      + '{"banner":"旗号","leaderName":"渠帅姓名","leaderFrom":"existing|new","creed":"纲领≤20字","stance":"处世≤12字","agenda":"图谋≤20字"}';
+    try {
+      var resp = await global.callAI(prompt, 400, null, (typeof global._useSecondaryTier === 'function' && global._useSecondaryTier()) ? 'secondary' : undefined, { id: 'revolt-identity' });
+      var text = (resp && typeof resp === 'object') ? (resp.text || resp.content || '') : String(resp || '');
+      var j = (typeof global.robustParseJSON === 'function') ? global.robustParseJSON(text) : JSON.parse(text);
+      if (j && j.banner && j.leaderName) {
+        r._identity = {
+          banner: String(j.banner).slice(0, 10), leaderName: String(j.leaderName).slice(0, 12),
+          leaderFrom: j.leaderFrom === 'existing' ? 'existing' : 'new',
+          creed: String(j.creed || '').slice(0, 24), stance: String(j.stance || '').slice(0, 14), agenda: String(j.agenda || '').slice(0, 24)
+        };
+        delete r._identityPending;
+        _eb((r.region || '某地') + '乱民推「' + r._identity.leaderName + '」为主·树「' + r._identity.banner + '」之旗·倡言「' + (r._identity.creed || '替天行道') + '」');
+        return r._identity;
+      }
+    } catch (_eF) {}
+    delete r._identityPending;  // 失败→镜像层下回合模板兜底(双轨)
+    return null;
+  }
+
+  // ── subcall B·逐回合民变行为（AI 决断·宪法闸落账）───────────────────────────
+  function _buildTickPrompt(G, stocks) {
+    var lines = ['你是天命推演引擎的民变演绎官。天下汹汹·以下各股民变皆是活的势力——你为每股决断本回合作为。',
+      '【天下大势】回合T' + (G.turn || 0) + '·' + (G.eraName || '') + '·朝廷皇威' + ((G.huangwei && G.huangwei.index) || '?') + '·皇权' + ((G.huangquan && G.huangquan.index) || '?') + '·全国民心' + ((G.minxin && G.minxin.trueIndex) || '?')];
+    stocks.forEach(function (s, i) {
+      var idy = (s.r && s.r._identity) || {};
+      var occ = (s.fac._occupiedDivs || []).join('/') || '无';
+      lines.push('【股' + (i + 1) + '·id=' + s.fac.sourceRevoltId + '】「' + s.fac.name + '」渠帅' + ((s.leader && s.leader.name) || '?')
+        + '·纲领「' + (idy.creed || '?') + '」·stance「' + (idy.stance || '?') + '」·图谋「' + (idy.agenda || '?') + '」'
+        + '·兵' + ((s.army && s.army.soldiers) || 0) + '·士气' + ((s.army && s.army.morale) || '?') + '·驻' + ((s.army && s.army.location) || '?')
+        + '·已据：' + occ + '·声势级「' + (s.r ? (s.r.level || '?') : '?') + '」');
+      var eds = _recentPacifyEdicts(G, s);
+      if (eds.length) lines.push('  ↳朝廷近旨(与本股相关·据 stance/agenda 决定受抚/拒抚/讨价·亦可诈许)：' + eds.join('｜'));
+    });
+    lines.push('【可用动作】move(target=府县名)·occupy(target=府县名·须军已至且兵力足)·recruit(delta=裹挟人数)·'
+      + 'split(banner/leaderName/creed/target=分裂新股)·merge(target=并入的股id)·proclaim(stateName=国号·僭号建国·时机自断)·'
+      + 'pacify_accept(silverDemand=受抚索银·officeTitle=讨的官职)·pacify_refuse(reason)·pacify_counter(silverDemand/officeTitle=还价)。');
+    lines.push('【铁则】没有朝廷招抚旨不得 pacify_*；占府会被引擎验兵力·虚占无效；裹挟有上限；行动须合乎各股纲领与处境·宁少勿滥(每股1-3个)。');
+    lines.push('只返回 JSON：{"stocks":[{"id":"股id","narrative":"本回合作为叙事≤60字","actions":[{"type":"...","target":"","delta":0,"banner":"","leaderName":"","creed":"","silverDemand":0,"officeTitle":"","stateName":"","reason":""}]}]}');
+    return lines.join('\n');
+  }
+
+  // 动作落账（独立导出·smoke 不经真 AI 直验宪法闸）
+  function _applyActions(G, parsed) {
+    if (!parsed || !Array.isArray(parsed.stocks)) return { applied: 0, blocked: 0 };
+    var turn = G.turn || 0, applied = 0, blocked = 0;
+    var stockList = (G.facs || []).filter(function (f) { return f && f._revoltEntity; }).map(function (f) { return _stockOf(G, f); });
+    var byId = {};
+    stockList.forEach(function (s) { byId[s.fac.sourceRevoltId] = s; });
+
+    parsed.stocks.forEach(function (ps) {
+      var s = ps && byId[ps.id];
+      if (!s || !s.r || s.r.status !== 'ongoing') return;
+      if (ps.narrative) _chron(G, '「' + s.fac.name + '」' + String(ps.narrative).slice(0, 80));
+      (Array.isArray(ps.actions) ? ps.actions.slice(0, 3) : []).forEach(function (act) {
+        if (!act || !act.type) return;
+        try {
+          switch (String(act.type)) {
+            case 'move': {
+              if (!s.army || s.army.disbanded) { blocked++; return; }
+              var mdiv = _fuzzyDiv(G, act.target);
+              var dest = (mdiv && mdiv.name) || String(act.target || '').slice(0, 20);
+              if (!dest) { blocked++; return; }
+              s.army.location = dest; s.army.garrison = dest; s.army.state = 'march';
+              _eb('「' + s.fac.name + '」移师' + dest); applied++;
+              return;
+            }
+            case 'occupy': {
+              // 宪法闸：府在档+军已至+兵力压过守备(2×militaryRecruits+2000)·防 AI 幻觉割地
+              var div = _fuzzyDiv(G, act.target);
+              if (!div || !s.army || s.army.disbanded) { blocked++; return; }
+              var at = String(s.army.location || '');
+              var here = at && (at === div.name || at.indexOf(div.name) >= 0 || String(div.name).indexOf(at) >= 0);
+              var need = 2 * (Number(div.militaryRecruits) || 2000) + 2000;
+              if (!here || (s.army.soldiers || 0) < need) { blocked++; _eb('「' + s.fac.name + '」图占' + (div.name || act.target) + '而' + (!here ? '师未至' : '兵力不敌守备') + '·未逞'); return; }
+              div.occupiedBy = s.fac.name; div._occupiedTurn = turn;
+              if (!Array.isArray(s.fac._occupiedDivs)) s.fac._occupiedDivs = [];
+              if (s.fac._occupiedDivs.indexOf(div.name) < 0) s.fac._occupiedDivs.push(div.name);
+              _ensureColor(G, s.fac.name);
+              _eb('★「' + s.fac.name + '」攻陷' + div.name + '·开仓散粮·设官置吏'); _chron(G, div.name + '陷于「' + s.fac.name + '」'); applied++;
+              return;
+            }
+            case 'recruit': {
+              if (!s.army || s.army.disbanded) { blocked++; return; }
+              var cap = Math.round((s.army.soldiers || 0) * RECRUIT_CAP_RATIO);
+              var d = Math.max(0, Math.min(Number(act.delta) || 0, cap));
+              if (!d) { blocked++; return; }
+              s.army.soldiers += d; s.army.size = s.army.soldiers; s.army.strength = s.army.soldiers;
+              _eb('「' + s.fac.name + '」裹挟饥民 ' + d + ' 众'); applied++;
+              return;
+            }
+            case 'split': {
+              var ongoing = ((G.minxin && G.minxin.revolts) || []).filter(function (x) { return x && x.status === 'ongoing' && (x.level || 0) >= 3; });
+              if (ongoing.length >= MAX_STOCKS) { blocked++; return; }
+              var nr = {
+                id: s.r.id + '_s' + turn, region: String(act.target || s.r.region || ''), status: 'ongoing',
+                level: Math.max(3, (s.r.level || 3) - 1), turn: turn, leader: String(act.leaderName || ''), _aiBorn: true
+              };
+              if (act.banner) nr._identity = { banner: String(act.banner).slice(0, 10), leaderName: String(act.leaderName || '').slice(0, 12), leaderFrom: 'new', creed: String(act.creed || '').slice(0, 24), stance: '', agenda: '' };
+              G.minxin.revolts.push(nr);
+              _eb('「' + s.fac.name + '」分裂·' + (act.leaderName || '偏帅') + '自树「' + (act.banner || '别部') + '」之旗'); _chron(G, '「' + s.fac.name + '」裂为两股'); applied++;
+              return;
+            }
+            case 'merge': {
+              var t2 = byId[act.target];
+              if (!t2 || t2 === s || !t2.r || t2.r.status !== 'ongoing') { blocked++; return; }
+              if (s.army && t2.army && !t2.army.disbanded) { s.army.soldiers += (t2.army.soldiers || 0); s.army.size = s.army.soldiers; s.army.strength = s.army.soldiers; }
+              t2.r.status = 'dispersed'; t2.r._mergedInto = s.r.id;  // 镜像层覆灭清账走既有路径
+              _eb('「' + t2.fac.name + '」举众来投·并于「' + s.fac.name + '」麾下'); applied++;
+              return;
+            }
+            case 'proclaim': {
+              // owner 拍板②：建国时机交 AI·宪法只记账
+              if (s.fac.isState) { blocked++; return; }
+              s.fac.isState = true; s.fac.stateName = String(act.stateName || s.fac.name).slice(0, 8);
+              if (s.leader) s.leader.officialTitle = '「' + s.fac.stateName + '」僭号之主';
+              try { if (global.AuthorityEngines && global.AuthorityEngines.adjustHuangwei) global.AuthorityEngines.adjustHuangwei('lostVirtueRumor', -10, '「' + s.fac.stateName + '」僭号建国'); } catch (_) {}
+              _eb('★★「' + s.fac.name + '」僭号建国·国号「' + s.fac.stateName + '」·' + ((s.leader && s.leader.name) || '渠帅') + '称制'); _chron(G, '「' + s.fac.stateName + '」僭号立·天下震骇'); applied++;
+              return;
+            }
+            case 'pacify_accept': {
+              // 宪法闸：真有其旨才可受抚·帑廪真拿得出银才成局
+              if (!_recentPacifyEdicts(G, s).length) { blocked++; return; }
+              var ask = Math.max(0, Math.round(Number(act.silverDemand) || ((s.r.level || 3) * 100000)));
+              if (ask > 0 && !_spendSilver(G, ask, '招抚「' + s.fac.name + '」')) {
+                _eb('「' + s.fac.name + '」许抚而帑廪不给·抚局遂败·其众复叛'); blocked++;
+                return;
+              }
+              s.r.status = 'pacified';
+              s.r._pacified = { turn: turn, silver: ask, officeTitle: String(act.officeTitle || '').slice(0, 16) };
+              _eb('★「' + s.fac.name + '」受抚罢兵' + (ask ? '·得银 ' + ask + ' 两' : '') + (act.officeTitle ? '·' + ((s.leader && s.leader.name) || '渠帅') + '得授' + act.officeTitle : ''));
+              _chron(G, '「' + s.fac.name + '」受抚·' + (s.r.region || '') + '兵revolt息'); applied++;
+              return;
+            }
+            case 'pacify_refuse': {
+              if (!_recentPacifyEdicts(G, s).length) { blocked++; return; }
+              _eb('「' + s.fac.name + '」拒抚：' + String(act.reason || '不信朝廷').slice(0, 40)); applied++;
+              return;
+            }
+            case 'pacify_counter': {
+              if (!_recentPacifyEdicts(G, s).length) { blocked++; return; }
+              _eb('「' + s.fac.name + '」讨价：索银 ' + (Number(act.silverDemand) || 0) + ' 两' + (act.officeTitle ? '·求授' + act.officeTitle : '') + '·抚局未定'); applied++;
+              return;
+            }
+            default: blocked++;
+          }
+        } catch (_eA) { blocked++; }
+      });
+    });
+    return { applied: applied, blocked: blocked };
+  }
+
+  async function tickInference(G) {
+    G = G || global.GM;
+    if (!enabled() || !_aiOn() || !G) return null;
+    var stocks = (G.facs || []).filter(function (f) { return f && f._revoltEntity; }).map(function (f) { return _stockOf(G, f); })
+      .filter(function (s) { return s.r && s.r.status === 'ongoing'; });
+    if (!stocks.length) return null;
+    try {
+      var resp = await global.callAI(_buildTickPrompt(G, stocks), 1600, null, (typeof global._useSecondaryTier === 'function' && global._useSecondaryTier()) ? 'secondary' : undefined, { id: 'revolt-inference' });
+      var text = (resp && typeof resp === 'object') ? (resp.text || resp.content || '') : String(resp || '');
+      var j = (typeof global.robustParseJSON === 'function') ? global.robustParseJSON(text) : JSON.parse(text);
+      return _applyActions(G, j);
+    } catch (_eT) { return null; }
+  }
+
+  // 镜像层每回合调此口：具象化前先派身份 subcall·实体在场则排逐回合演绎(post-turn job·autosave 后落也幂等)
+  function schedule(G) {
+    if (!enabled() || !G) return;
+    var turn = G.turn || 0;
+    // A·待具象化的新股→派身份锻造(一次·失败下回合镜像层模板兜底)
+    try {
+      ((G.minxin && G.minxin.revolts) || []).forEach(function (r) {
+        if (!r || r.status !== 'ongoing' || (r.level || 0) < 3) return;
+        if (r._identity || r._identityPending == null && !_aiOn()) return;
+        var hasEntity = (G.facs || []).some(function (f) { return f && f._revoltEntity && f.sourceRevoltId === r.id; });
+        if (hasEntity || r._identity) return;
+        if (r._identityPending != null) return;  // 已在锻
+        if (!_aiOn()) return;                    // 无 AI→镜像层直接模板兜底(双轨)
+        r._identityPending = turn;
+        var job = function () { return forgeIdentity(G, r); };
+        if (typeof global._enqueuePostTurnJob === 'function') global._enqueuePostTurnJob('revoltIdentity_' + r.id, job);
+        else job();
+      });
+    } catch (_eS) {}
+    // B·逐回合行为演绎(每回合一次)
+    try {
+      if (!_aiOn()) return;
+      if (G._revoltInferTurn === turn) return;
+      var hasAny = (G.facs || []).some(function (f) { return f && f._revoltEntity; });
+      if (!hasAny) return;
+      G._revoltInferTurn = turn;  // arch-ok 民变演绎回合戳·幂等(与 _wtAuditTurn 同范式)
+      var job2 = function () { return tickInference(G); };
+      if (typeof global._enqueuePostTurnJob === 'function') global._enqueuePostTurnJob('revoltInference', job2);
+      else job2();
+    } catch (_eB) {}
+  }
+
+  var API = { schedule: schedule, forgeIdentity: forgeIdentity, tickInference: tickInference, _applyActions: _applyActions, _recentPacifyEdicts: _recentPacifyEdicts, _spendSilver: _spendSilver, enabled: enabled, MAX_STOCKS: MAX_STOCKS };
+  global.TM = global.TM || {};
+  global.TM.RevoltInference = API;
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+})(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## 背景（owner 重批落地）

「实体化≠模板化——身份与行为必须 AI 演绎，确定性只配做兜底账本；把民变视作一个整体是最烂的硬代码。」本 PR 把批一批二的确定性层**降级为宪法（账本+闸+兜底）**，其上立 AI 演绎层。三拍板照办：①起号立领袖=专门轻量 subcall ②建国时机交 AI ③确定性层保双轨。

## 演绎层（`tm-revolt-inference.js`·随 `revoltEntityEnabled`·post-turn job 承载）

**subcall A·锻造身份**（具象化时一次）：AI 起**真旗号**（prompt 明令禁「XX义军」式模板）、立**有名有姓的渠帅**（候选含在档低忠诚不满者——真人揭竿）、定纲领/stance/agenda。镜像层缓拍等身份；锻造失败或无 AI → 模板兜底（双轨）。

**subcall B·逐回合行为**（每回合一次·回合戳幂等）：各股民变是**一等演员**，AI 按各股身份/纲领/军情/占据/朝廷近旨决断：`move / occupy / recruit / split / merge / proclaim / pacify_accept|refuse|counter`。**招抚完全走诏令管线**：AI 读 `GM._edictTracker` 里你下的真旨原文，按该股 stance/agenda 谈判——讨价、诈许、真降皆有可能，不保成功，无独立 UI。**民变不再是一个整体**：可分裂（带新旗号新渠帅）、可合流、可各走各路。

## 宪法闸（引擎只验不产·`_applyActions` 独立导出供 smoke 直验）

- **占府**：军须真至 + 兵力压过守备（2×militaryRecruits+2000）——防 AI 幻觉割地；合规则 `div.occupiedBy` 真易手 + **势力色注册 `mapData.factionColors`**（地图改色数据层就绪，渲染层=批四）
- **招抚三闸**：真有其旨才可受抚（无旨自称受抚=拦）· 帑廪**真扣**（`GM.guoku.balance`·镜像 openGranary 支出范式+money.stock 同步）· 拿不出银=抚局败、其众复叛
- 裹挟封顶 25%/回合 · 股数封 5 · 建国只记账（isState/国号/渠帅称制/皇威代价走 AuthorityEngines）
- 受抚清账：渠帅**得授讨来的官职**（非「溃散流亡」）、真人复原籍、占据解除归还

## 验证

- 新 `smoke-revolt-inference.js` **29 断言**（身份具象化/缓拍双轨/占府闸两拦一放/裹挟顶/建国记账/分裂合流/招抚三闸/受抚清账）——canned 决策直灌 `_applyActions`，不依赖真 AI
- 批一批二 smoke 全回归绿 · `ci-smokes` **780 PASS** · `lint-arch-all` **8/8** · 基线 `--check` PASS

## 批四候选（回桌）

地图真改色渲染（数据层本批已备）；渠帅个体记忆/问对接入（受抚入朝者可问对）；外患侵攻的 AI 化（同范式：敌国是否入寇交势力 AI，阈值 spawner 降兜底）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)