### PR TITLE
批四：外患侵攻 AI 化（入寇交敌国 AI·spawner 降兜底）+ 破京定命三态菜单（场景交 AI）

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -3596,8 +3596,8 @@
     },
     {
       "path": "tm-border-invasion.js",
-      "sha256": "be2854bcde32b8fc2680352e94ed40918893fb7950a76b1895c5a4f6f03590bc",
-      "size": 6689
+      "sha256": "c2607d0c9217340fae282df43032c1ec2e35856d590979b27dfbf65617dccdbf",
+      "size": 15371
     },
     {
       "path": "tm-border-risk.js",
@@ -5141,13 +5141,13 @@
     },
     {
       "path": "tm-revolt-entity.js",
-      "sha256": "18f109069e10568e6ec18c172e86a452c756053322cc4b31eb09f6850c0c07d1",
-      "size": 15100
+      "sha256": "b3e285b3a7b9848469da1b7b7a9f0da86cf6f09dd469039df31fc5dc79623602",
+      "size": 16925
     },
     {
       "path": "tm-revolt-inference.js",
-      "sha256": "3d3b33ecd1a96a612657c839f6bc45cade00e04246d18c8c4ab201766af214b0",
-      "size": 21008
+      "sha256": "f24cd79f0d32b9a2a2e993d1be2b8208728924399263380d0f3c74f8bd71e283",
+      "size": 23527
     },
     {
       "path": "tm-save-lifecycle.js",

--- a/web/scripts/smoke-breach-fate-menu.js
+++ b/web/scripts/smoke-breach-fate-menu.js
@@ -1,0 +1,87 @@
+// smoke-breach-fate-menu.js — 破京定命三态菜单（批四·2026-07-21·场景交AI·宪法验菜单）
+//
+// owner 范式：破京当回合的定命场景由 AI 演(殉国/被俘北狩/出走勤王)·引擎只验菜单落账——
+// death=仍只走裁决器(regicide·继统门生效)·captured=_captured 北狩态续玩(endturn
+// _capturedSovereign 段既有消费)·escaped=驻跸于外续玩·菜单外一律按 death 兜底。
+// AI 缺席回归=既有 smoke-revolt-breach(其沙箱无 RevoltInference·直落 death 旧行为)。
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var vm = require('vm');
+
+var ROOT = path.join(__dirname, '..');
+var failures = [];
+function assert(cond, msg) {
+  if (cond) { console.log('  PASS ' + msg); }
+  else { failures.push(msg); console.log('  FAIL ' + msg); }
+}
+
+function freshSandbox(adjImpl) {
+  var sb = { console: console };
+  sb.window = sb; sb.global = sb;
+  sb._ebs = [];
+  sb.addEB = function (cat, msg) { sb._ebs.push(cat + '·' + msg); };
+  if (adjImpl) sb.adjudicatePlayerDeath = adjImpl;
+  sb.GM = {
+    turn: 21,
+    facs: [], chars: [{ name: '朱由检', isPlayer: true, alive: true }], armies: [],
+    minxin: { revolts: [{ id: 'rvZ', region: '陕西', status: 'ongoing', level: 5, turn: 10, leader: '李闯' }] },
+    _chronicle: []
+  };
+  sb.P = { conf: { revoltEntityEnabled: true } };
+  vm.createContext(sb);
+  vm.runInContext(fs.readFileSync(path.join(ROOT, 'tm-revolt-entity.js'), 'utf8'), sb, { filename: 'tm-revolt-entity.js' });
+  return sb;
+}
+
+console.log('① captured → 北狩态续玩(不叫裁决器·不终局)');
+var adjCalls = [];
+var sb = freshSandbox(function () { adjCalls.push(1); return { outcome: 'gameover' }; });
+var r = sb.GM.minxin.revolts[0];
+sb.TM.RevoltEntity._applyBreachOutcome(sb.GM, r, { fate: 'captured', narrative: '乱军突入大内·君上为贼所执·幽于偏殿' });
+var player = sb.GM.chars[0];
+assert(player._captured === true && player._capturedBy === '陕西义军', '君上 _captured 竖旗·记执者(北狩态·推演既有消费)');
+assert(adjCalls.length === 0 && !sb.GM._gameOver && !sb.GM._playerDead, '被俘≠死·不叫裁决器·不终局·续玩');
+assert(sb.GM._dynastyFallInfo && sb.GM._dynastyFallInfo.fate === 'captured', '_dynastyFallInfo 记 captured');
+assert(sb.GM._chronicle.some(function (c) { return c.type === '国变' && c.text.indexOf('幽于偏殿') >= 0; }), 'AI 场景入史');
+assert(sb._ebs.some(function (e) { return e.indexOf('君上蒙尘') >= 0; }), '被俘落起居注');
+
+console.log('② escaped → 出走勤王续玩');
+var sb2 = freshSandbox(function () { failures.push('escaped 不应叫裁决器'); return {}; });
+sb2.TM.RevoltEntity._applyBreachOutcome(sb2.GM, sb2.GM.minxin.revolts[0], { fate: 'escaped' });
+assert(!sb2.GM.chars[0]._captured && !sb2.GM._gameOver && !sb2.GM._playerDead, '出走 → 自由身续玩');
+assert(sb2.GM._dynastyFallInfo.fate === 'escaped', '_dynastyFallInfo 记 escaped');
+assert(sb2._ebs.some(function (e) { return e.indexOf('勤王') >= 0; }), '出走落起居注(诏勤王)');
+
+console.log('③ death → 仍只走裁决器(继统门生效)');
+var adjCalls3 = [];
+var sb3 = freshSandbox(function (ch, cause, opts) { adjCalls3.push(opts && opts.kind); return { outcome: 'succession', heir: '太子' }; });
+sb3.TM.RevoltEntity._applyBreachOutcome(sb3.GM, sb3.GM.minxin.revolts[0], { fate: 'death' });
+assert(adjCalls3.length === 1 && adjCalls3[0] === 'regicide', '死亡唯一产地=裁决器·kind=regicide');
+assert(!sb3.GM._gameOver, 'succession → 续玩不终局');
+
+console.log('④ 菜单外值 → 按 death 兜底(宪法验菜单)');
+var adjCalls4 = [];
+var sb4 = freshSandbox(function () { adjCalls4.push(1); return { outcome: 'gameover' }; });
+sb4.GM._playerDead = false;
+sb4.TM.RevoltEntity._applyBreachOutcome(sb4.GM, sb4.GM.minxin.revolts[0], { fate: '登仙' });
+assert(adjCalls4.length === 1, '「登仙」不在菜单 → 按 death 走裁决器(禁玄幻)');
+
+console.log('⑤ 拍2·AI 在场 → 排定命场景 job·不立即裁决');
+var sched = [];
+var sb5 = freshSandbox(function () { failures.push('AI 排程路径不应立即裁决'); return {}; });
+sb5.TM.RevoltInference = { aiOn: function () { return true; }, scheduleBreachScene: function (G, rr) { sched.push(rr.id); } };
+var r5 = sb5.GM.minxin.revolts[0];
+r5._breachMarch = { started: 20, marched: 20 };
+sb5.TM.RevoltEntity.sync(sb5.GM);  // turn 21 → 拍2
+assert(r5._breachDone === true && sb5.GM._capitalFallen === true, '拍2 破京落账照常');
+assert(sched.length === 1 && sched[0] === 'rvZ', '定命交 AI 场景 job·引擎不抢戏');
+assert(!sb5.GM._gameOver && !sb5.GM._playerDead, '等 AI 场景期间不终局');
+
+console.log('');
+if (failures.length) {
+  console.log('FAIL smoke-breach-fate-menu: ' + failures.length + ' 处失败');
+  failures.forEach(function (f) { console.log('  - ' + f); });
+  process.exit(1);
+}
+console.log('PASS smoke-breach-fate-menu (北狩续玩/出走续玩/死亡唯一产地裁决器/菜单外兜底/AI排程不抢戏)');

--- a/web/scripts/smoke-invasion-ai.js
+++ b/web/scripts/smoke-invasion-ai.js
@@ -1,0 +1,101 @@
+// smoke-invasion-ai.js — 外患演绎层（批四·2026-07-21·AI 主导·spawner 降兜底）
+//
+// owner 范式：入不入寇/打多大/什么名义交敌国 AI·引擎只当宪法闸。本 smoke 不经真 AI：
+// canned moves 直灌 _applyInvasionActions·验闸——非敌对不得入寇/义军排除/无真边压不得
+// 凭空入寇/兵额封顶/一国一军/冷却/press·withdraw·demand 落账。兜底轨回归=既有
+// smoke-border-invasion(其沙箱无 callAI·确定性路径字节级未动)。
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var vm = require('vm');
+
+var ROOT = path.join(__dirname, '..');
+var failures = [];
+function assert(cond, msg) {
+  if (cond) { console.log('  PASS ' + msg); }
+  else { failures.push(msg); console.log('  FAIL ' + msg); }
+}
+
+var leaves = [
+  { name: '蓟州', borderRisk: 80 },
+  { name: '大同', borderRisk: 20 }
+];
+var sandbox = { console: console };
+sandbox.window = sandbox;
+sandbox.global = sandbox;
+sandbox._ebs = [];
+sandbox.addEB = function (cat, msg) { sandbox._ebs.push(cat + '·' + msg); };
+sandbox.IntegrationBridge = { getLeafDivisions: function () { return leaves; } };
+sandbox.GM = {
+  turn: 40,
+  adminHierarchy: { player: {} },
+  facs: [
+    { id: 'f_hj', name: '后金', strength: 80, playerRelation: -90 },
+    { id: 'f_cx', name: '朝鲜', strength: 40, playerRelation: 60 },
+    { id: 'f_rev', name: '闯字营', strength: 60, playerRelation: -85, _revoltEntity: true, sourceRevoltId: 'rvX' }
+  ],
+  armies: [],
+  chars: [],
+  _edictTracker: [{ turn: 39, category: '外交', content: '许后金岁币十万两·以息兵锋' }]
+};
+sandbox.P = { conf: { borderInvasionEnabled: true } };
+vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync(path.join(ROOT, 'tm-border-invasion.js'), 'utf8'), sandbox, { filename: 'tm-border-invasion.js' });
+
+var GM = sandbox.GM;
+var BI = sandbox.TM.BorderInvasion;
+
+console.log('① 入寇宪法闸：非敌对/义军/无边压全拦·合规才成军(兵额封顶)');
+var r1 = BI._applyInvasionActions(GM, { moves: [{ type: 'invade', fac: '朝鲜', target: '蓟州', soldiers: 30000 }] });
+assert(r1.blocked === 1 && GM.armies.length === 0, '朝鲜(关系+60·非敌对) → 不得入寇');
+var r2 = BI._applyInvasionActions(GM, { moves: [{ type: 'invade', fac: '闯字营', target: '蓟州' }] });
+assert(r2.blocked === 1 && GM.armies.length === 0, '义军(_revoltEntity) → 排除·民变不走边患链');
+var r3 = BI._applyInvasionActions(GM, { moves: [{ type: 'invade', fac: '后金', target: '大同', soldiers: 30000 }] });
+assert(r3.blocked === 1 && GM.armies.length === 0, '大同边警仅20(<40) → 无真边压不得凭空入寇');
+var r4 = BI._applyInvasionActions(GM, { moves: [{ type: 'invade', fac: '后金', target: '蓟州', soldiers: 999999, pretext: '七大恨告天' }] });
+var inv = GM.armies.find(function (a) { return a._borderInvasion; });
+assert(!!inv && inv.faction === '后金' && inv.location === '蓟州', '后金入寇蓟州(边警80) → 成军');
+assert(inv.soldiers === 20000 + 80 * 800, 'AI 报兵 999999 → 宪法封顶 84000');
+assert(sandbox._ebs.some(function (e) { return e.indexOf('七大恨告天') >= 0; }), '入寇名义(pretext)入起居注');
+
+console.log('② 一国一军');
+var r5 = BI._applyInvasionActions(GM, { moves: [{ type: 'invade', fac: '后金', target: '蓟州' }] });
+assert(r5.blocked === 1 && GM.armies.filter(function (a) { return !a.disbanded; }).length === 1, '已有在场军 → 再入寇拦');
+
+console.log('③ press 深入');
+BI._applyInvasionActions(GM, { moves: [{ type: 'press', fac: '后金', target: '大同' }] });
+assert(inv.location === '大同', '铁骑深入 → 移驻大同');
+assert(sandbox._ebs.some(function (e) { return e.indexOf('铁骑深入') >= 0; }), '深入落起居注');
+
+console.log('④ demand 要挟落账');
+BI._applyInvasionActions(GM, { moves: [{ type: 'demand', fac: '后金', terms: '岁币二十万·开边市' }] });
+assert(sandbox._ebs.some(function (e) { return e.indexOf('要挟') >= 0 && e.indexOf('岁币二十万') >= 0; }), '要挟条款入起居注');
+assert(Array.isArray(GM._chronicle) && GM._chronicle.some(function (c) { return c.type === '边患'; }), '要挟入史(玩家可据以下旨回应)');
+
+console.log('⑤ withdraw 退兵+冷却');
+BI._applyInvasionActions(GM, { moves: [{ type: 'withdraw', fac: '后金', reason: '朝廷许以岁币' }] });
+assert(inv.disbanded === true, 'AI 决断退兵 → 散档');
+var hj = GM.facs.find(function (f) { return f.name === '后金'; });
+assert((hj._invCooldownUntil || 0) > GM.turn, '退后冷却');
+assert(sandbox._ebs.some(function (e) { return e.indexOf('朝廷许以岁币') >= 0; }), '退兵缘由落起居注');
+
+console.log('⑥ 冷却期再入寇拦');
+var r6 = BI._applyInvasionActions(GM, { moves: [{ type: 'invade', fac: '后金', target: '蓟州' }] });
+assert(r6.blocked === 1, '冷却中 → 拦');
+
+console.log('⑦ AI 轨排程门：有敌有压才排·回合戳幂等');
+sandbox.callAI = function () { return new Promise(function () {}); };  // 挂起的假 AI·只验排程不验执行
+GM.turn = 60;
+BI.tick(GM);
+assert(GM._invInferTurn === 60, '有敌有压 → 排 AI 演绎(回合戳)');
+var stamp = GM._invInferTurn;
+BI.tick(GM);
+assert(GM._invInferTurn === stamp, '同回合重 tick → 幂等不重排');
+
+console.log('');
+if (failures.length) {
+  console.log('FAIL smoke-invasion-ai: ' + failures.length + ' 处失败');
+  failures.forEach(function (f) { console.log('  - ' + f); });
+  process.exit(1);
+}
+console.log('PASS smoke-invasion-ai (非敌对拦/义军排除/边压闸/兵额顶/一国一军/press·demand·withdraw/冷却/排程幂等)');

--- a/web/tm-border-invasion.js
+++ b/web/tm-border-invasion.js
@@ -69,10 +69,11 @@
       if (leaf._invRiskStreak >= STREAK_NEED && (!worst || risk > (Number(worst.borderRisk) || 0))) worst = leaf;
     });
 
-    // ② 在场入侵军去留（风险回落/被打散）
+    // ② 覆没恒常清账（宪法：被打散=真散·与 AI/兜底轨无关）+ 兜底轨的风险回落退兵
     G.armies.forEach(function (a) {
       if (!a || !a._borderInvasion || a.disbanded) return;
       if ((a.soldiers || 0) <= 0) { _withdraw(G, a, 'destroyed'); return; }
+      if (_aiOn()) return;  // AI 轨：去留归敌国 AI 决断(批四)
       var leaf = leaves.find(function (l) { return l && (l.name === a.location || l.name === a.garrison); });
       var risk = leaf ? (Number(leaf.borderRisk) || 0) : 0;
       if (risk < RISK_LOW) {
@@ -83,7 +84,21 @@
       }
     });
 
-    // ③ 出兵（每回合至多一支·最险 leaf·最强合格敌对势力）
+    // ③ AI 轨（批四·owner范式「入不入寇交敌国AI」）：有敌有压才排演绎·每回合一次·post-turn job
+    if (_aiOn()) {
+      if (G._invInferTurn === turn) return;
+      var hostiles0 = _hostilesOf(G);
+      var hasActive0 = G.armies.some(function (a) { return a && a._borderInvasion && !a.disbanded; });
+      var anyPressure0 = leaves.some(function (l) { return l && (Number(l.borderRisk) || 0) >= RISK_LOW; });
+      if (!hostiles0.length || (!hasActive0 && !anyPressure0)) return;  // 无敌无压·不空转调用
+      G._invInferTurn = turn;  // arch-ok 边患演绎回合戳·幂等(与 _wtAuditTurn 同范式)
+      var _aiJob = function () { return tickAI(G); };
+      if (typeof global._enqueuePostTurnJob === 'function') global._enqueuePostTurnJob('borderInvasionAI', _aiJob);
+      else _aiJob();
+      return;
+    }
+
+    // ④ 兜底轨出兵（AI 缺席·确定性 spawner=双轨·每回合至多一支·最险 leaf·最强合格敌对势力）
     if (!worst) return;
     var attacker = null;
     _hostilesOf(G).forEach(function (f) {
@@ -112,7 +127,123 @@
     _eb('边警告急！「' + attacker.name + '」大举犯边·兵锋直指' + (worst.name || '边地') + '·号称 ' + Math.round(soldiers / 10000) + ' 万之众');
   }
 
-  var API = { tick: tick, enabled: enabled, RISK_HIGH: RISK_HIGH, STREAK_NEED: STREAK_NEED, RISK_LOW: RISK_LOW, COOLDOWN_TURNS: COOLDOWN_TURNS };
+  // ═══ 批四·外患演绎层（AI 主导·owner重批落地「入不入寇交敌国AI」·阈值 spawner 降兜底）═══
+  function _aiOn() {
+    try { return typeof global.callAI === 'function'; } catch (_) { return false; }
+  }
+  function _relevantEdicts(G, hostiles) {
+    var names = hostiles.map(function (f) { return f.name; });
+    var kw = ['和议', '岁币', '封贡', '互市', '纳贡', '议和'];
+    return (Array.isArray(G._edictTracker) ? G._edictTracker.slice(-8) : []).map(function (e) {
+      return String((e && (e.content || e.title)) || '');
+    }).filter(function (t) {
+      if (!t) return false;
+      return names.some(function (n) { return t.indexOf(n) >= 0; }) || kw.some(function (k) { return t.indexOf(k) >= 0; });
+    }).map(function (t) { return t.slice(0, 100); });
+  }
+  // 动作落账（独立导出·smoke 不经真 AI 直验宪法闸）
+  function _applyInvasionActions(G, parsed) {
+    if (!parsed || !Array.isArray(parsed.moves)) return { applied: 0, blocked: 0 };
+    var turn = G.turn || 0, applied = 0, blocked = 0;
+    var IB = global.IntegrationBridge;
+    var leaves = (IB && typeof IB.getLeafDivisions === 'function' && G.adminHierarchy) ? (IB.getLeafDivisions(G.adminHierarchy, 'player') || []) : [];
+    function leafByName(n) {
+      n = String(n || '').trim();
+      if (!n) return null;
+      return leaves.find(function (l) { return l && (l.name === n || String(l.name).indexOf(n) >= 0 || n.indexOf(String(l.name)) >= 0); }) || null;
+    }
+    parsed.moves.slice(0, 6).forEach(function (mv) {
+      if (!mv || !mv.type) return;
+      try {
+        var fac = (G.facs || []).find(function (f) { return f && f.name === mv.fac && !f._revoltEntity; });
+        switch (String(mv.type)) {
+          case 'invade': {
+            if (!fac || (Number(fac.playerRelation) || 0) >= -50) { blocked++; return; }  // 宪法：非敌对不得入寇
+            if (_activeInvasionOf(G, fac.name)) { blocked++; return; }                     // 一国一军
+            if ((fac._invCooldownUntil || 0) > turn) { blocked++; return; }                // 冷却
+            var leaf = leafByName(mv.target);
+            if (!leaf || (Number(leaf.borderRisk) || 0) < RISK_LOW) { blocked++; return; } // 宪法：无真边压不得凭空入寇
+            var cap = BASE_SOLDIERS + Math.round(Math.max(0, Math.min(100, Number(fac.strength) || 50)) * PER_STRENGTH);
+            var soldiers = Math.max(5000, Math.min(cap, Math.round(Number(mv.soldiers) || cap)));
+            G.armies.push({  // arch-ok 边患入侵军唯一写口(owners)·AI 轨与兜底轨同形状
+              id: 'army_inv_' + (fac.id || fac.name) + '_' + turn,
+              name: fac.name + '犯边之师',
+              faction: fac.name,
+              branch: '边军', type: '边军', armyType: '边军',
+              soldiers: soldiers, size: soldiers, strength: soldiers,
+              morale: 70, supply: 60, training: 65, loyalty: 85, control: 75, controlLevel: 75,
+              location: leaf.name || '', garrison: leaf.name || '',
+              commander: String(mv.commander || '').slice(0, 12),
+              equipment: [], quality: '劲旅',
+              composition: [{ type: '边军', count: soldiers }],
+              state: 'field',
+              source: 'border.invasion.ai',
+              sourceFacName: fac.name, _borderInvasion: true, _createdTurn: turn
+            });
+            _eb('边警告急！「' + fac.name + '」' + (mv.pretext ? '以「' + String(mv.pretext).slice(0, 24) + '」为名·' : '') + '大举犯边·兵锋直指' + leaf.name + '·号称 ' + Math.round(soldiers / 10000) + ' 万之众');
+            applied++; return;
+          }
+          case 'press': {
+            var a2 = fac && _activeInvasionOf(G, fac.name);
+            if (!a2) { blocked++; return; }
+            var lf2 = leafByName(mv.target);
+            if (!lf2) { blocked++; return; }
+            a2.location = lf2.name; a2.garrison = lf2.name;
+            _eb('「' + fac.name + '」铁骑深入·进逼' + lf2.name); applied++; return;
+          }
+          case 'withdraw': {
+            var a3 = fac && _activeInvasionOf(G, fac.name);
+            if (!a3) { blocked++; return; }
+            _withdraw(G, a3, 'retreat');
+            if (mv.reason) _eb('「' + fac.name + '」退兵·' + String(mv.reason).slice(0, 30));
+            applied++; return;
+          }
+          case 'demand': {
+            if (!fac) { blocked++; return; }
+            _eb('「' + fac.name + '」遣使要挟：' + String(mv.terms || '').slice(0, 50) + '·和战之权在庙堂');
+            try {
+              if (!Array.isArray(G._chronicle)) G._chronicle = [];
+              G._chronicle.push({ turn: turn, date: G._gameDate || '', type: '边患', text: '「' + fac.name + '」要挟：' + String(mv.terms || '').slice(0, 60), tags: ['边患', 'AI演绎'] });
+            } catch (_eC) {}
+            applied++; return;
+          }
+          default: blocked++;
+        }
+      } catch (_eM) { blocked++; }
+    });
+    return { applied: applied, blocked: blocked };
+  }
+  async function tickAI(G) {
+    if (!_aiOn() || !G) return null;
+    var IB = global.IntegrationBridge;
+    var leaves = (IB && typeof IB.getLeafDivisions === 'function' && G.adminHierarchy) ? (IB.getLeafDivisions(G.adminHierarchy, 'player') || []) : [];
+    var hostiles = _hostilesOf(G);
+    if (!hostiles.length) return null;
+    var hot = leaves.filter(function (l) { return l && (Number(l.borderRisk) || 0) > 0; })
+      .sort(function (a, b) { return (b.borderRisk || 0) - (a.borderRisk || 0); }).slice(0, 5);
+    var lines = ['你是天命推演引擎的外患演绎官。以下敌国各有心思——你为每国决断本回合边事(可按兵不动·宁少勿滥)。',
+      '【朝廷】' + (G.eraName || '') + '·T' + (G.turn || 0) + '·皇威' + ((G.huangwei && G.huangwei.index) || '?')];
+    hostiles.forEach(function (f) {
+      var act = _activeInvasionOf(G, f.name);
+      lines.push('【' + f.name + '】强' + (f.strength || '?') + '·与朝廷关系' + (f.playerRelation || '?')
+        + ((f._invCooldownUntil || 0) > (G.turn || 0) ? '·新败方归(冷却)' : '')
+        + (act ? ('·已有犯边之师驻' + act.location + '(兵' + act.soldiers + ')') : ''));
+    });
+    lines.push('【边地虚实】' + (hot.length ? hot.map(function (l) { return l.name + '(警' + l.borderRisk + ')'; }).join('·') : '边备尚固'));
+    var eds = _relevantEdicts(G, hostiles);
+    if (eds.length) lines.push('【朝廷近旨(涉边/涉和议·可据以定和战)】' + eds.join('｜'));
+    lines.push('【可用动作】invade(fac/target=边警之府/soldiers/pretext=名义)·press(fac/target=深入之府)·withdraw(fac/reason)·demand(fac/terms=要挟条款)。');
+    lines.push('【铁则】边备无警不得凭空入寇(引擎验)·兵额有顶·一国同时一军·师老无功或朝廷许以厚利可退可挟。');
+    lines.push('只返回 JSON：{"moves":[{"type":"...","fac":"","target":"","soldiers":0,"pretext":"","reason":"","terms":""}]}');
+    try {
+      var resp = await global.callAI(lines.join('\n'), 900, null, (typeof global._useSecondaryTier === 'function' && global._useSecondaryTier()) ? 'secondary' : undefined, { id: 'border-invasion-ai' });
+      var text = (resp && typeof resp === 'object') ? (resp.text || resp.content || '') : String(resp || '');
+      var j = (typeof global.robustParseJSON === 'function') ? global.robustParseJSON(text) : JSON.parse(text);
+      return _applyInvasionActions(G, j);
+    } catch (_eT2) { return null; }
+  }
+
+  var API = { tick: tick, tickAI: tickAI, _applyInvasionActions: _applyInvasionActions, enabled: enabled, RISK_HIGH: RISK_HIGH, STREAK_NEED: STREAK_NEED, RISK_LOW: RISK_LOW, COOLDOWN_TURNS: COOLDOWN_TURNS };
   global.TM = global.TM || {};
   global.TM.BorderInvasion = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;

--- a/web/tm-revolt-entity.js
+++ b/web/tm-revolt-entity.js
@@ -213,10 +213,51 @@ function _tickBreach(G, r) {
   r._breachDone = true;
   G._capitalFallen = true;  // 破京链首个真写入者·皇威 capitalFall 信号端(tm-authority-complete)既有消费
   _eb('京师陷落！「' + facName + '」入据宫阙·社稷倾覆在即');
+  // 批四·定命场景交 AI（殉国/被俘北狩/出走勤王·场景与抉择由演绎层 subcall 定·AI 缺席=兜底旧行为死亡裁决）
+  var RI2 = global.TM && global.TM.RevoltInference;
+  if (RI2 && typeof RI2.scheduleBreachScene === 'function' && typeof RI2.aiOn === 'function' && RI2.aiOn()) {
+    RI2.scheduleBreachScene(G, r);
+    return;
+  }
+  _applyBreachOutcome(G, r, { fate: 'death' });
+}
+
+// ── 批四·破京定命落账（宪法层：三态菜单·菜单外一律按 death 兜底·死亡仍只走裁决器）──
+// fate: 'death'(殉国/城破被弑→裁决器 regicide·有储君继统) | 'captured'(被俘北狩·_captured 续玩·
+//   endturn _capturedSovereign 段既有消费) | 'escaped'(乘乱出走·驻跸于外续玩·勤王残局)。
+function _applyBreachOutcome(G, r, o) {
+  o = o || {};
+  var turn = G.turn || 0;
+  var facName = (function () { var f = _findBySource(G.facs, r.id); return (f && f.name) || ((r.region || '') + '义军'); })();
+  if (o.narrative) {
+    try {
+      if (!Array.isArray(G._chronicle)) G._chronicle = [];
+      G._chronicle.push({ turn: turn, date: G._gameDate || '', type: '国变', text: String(o.narrative).slice(0, 160), tags: ['破京', 'AI演绎'] });
+    } catch (_eN) {}
+  }
   var player = null;
   for (var i = 0; i < (G.chars || []).length; i++) {
     var ch = G.chars[i];
     if (ch && ch.isPlayer && ch.alive !== false) { player = ch; break; }
+  }
+  function fallInfo(fateStr) {
+    G._dynastyFallInfo = {  // 终局富屏/本纪增强(新字段·无旧消费端契约风险)
+      revolt: r.id, turn: turn, region: r.region || '',
+      leader: r.leader || r.leaderName || r._entityLeaderName || '',
+      facName: facName, breach: true, fate: fateStr
+    };
+  }
+  var f0 = String(o.fate || 'death');
+  if (player && f0 === 'captured') {
+    player._captured = true; player._capturedBy = facName;  // 北狩态·花名册/推演既有 _captured 消费
+    fallInfo('captured');
+    _eb('君上蒙尘·为「' + facName + '」所执·社稷存亡悬于一线');
+    return;
+  }
+  if (player && f0 === 'escaped') {
+    fallInfo('escaped');
+    _eb('君上乘乱出走·驻跸于外·诏天下兵马勤王');
+    return;
   }
   var fate = null;
   try {
@@ -224,12 +265,7 @@ function _tickBreach(G, r) {
       fate = global.adjudicatePlayerDeath(player, '京师陷落·殁于社稷', { kind: 'regicide', deadReason: '京师陷落·殁于社稷' });
     }
   } catch (_eA) {}
-  G._dynastyFallInfo = {  // 终局富屏/本纪增强(新字段·无旧消费端契约风险)
-    revolt: r.id, turn: turn, region: r.region || '',
-    leader: r.leader || r.leaderName || r._entityLeaderName || '',
-    facName: facName, breach: true,
-    fate: fate ? fate.outcome : 'no-adjudicator'
-  };
+  fallInfo(fate ? fate.outcome : 'no-adjudicator');
   if (fate && fate.outcome === 'succession') {
     _eb('嗣君于乱军之外继统·社稷不绝如线·天下事犹未可知');
     return;  // 续玩残局：实体留场·_capitalFallen 持续·爬梯照走
@@ -280,6 +316,7 @@ function _tickBreach(G, r) {
   var API = {
     sync: sync,
     enabled: enabled,
+    _applyBreachOutcome: _applyBreachOutcome,
     SOLDIERS_BY_LEVEL: SOLDIERS_BY_LEVEL,
     STRENGTH_BY_LEVEL: STRENGTH_BY_LEVEL
   };

--- a/web/tm-revolt-inference.js
+++ b/web/tm-revolt-inference.js
@@ -313,7 +313,40 @@
     } catch (_eB) {}
   }
 
-  var API = { schedule: schedule, forgeIdentity: forgeIdentity, tickInference: tickInference, _applyActions: _applyActions, _recentPacifyEdicts: _recentPacifyEdicts, _spendSilver: _spendSilver, enabled: enabled, MAX_STOCKS: MAX_STOCKS };
+  // ── 批四·破京定命场景（AI 演场景+择命·结构化结果喂宪法层 _applyBreachOutcome·死亡仍只走裁决器）──
+  async function breachScene(G, r) {
+    var RE = global.TM && global.TM.RevoltEntity;
+    if (!RE || typeof RE._applyBreachOutcome !== 'function') return;
+    var idy = r._identity || {};
+    var facName = (idy.banner) || ((r.region || '') + '义军');
+    var player = null;
+    for (var i = 0; i < (G.chars || []).length; i++) { var c = G.chars[i]; if (c && c.isPlayer && c.alive !== false) { player = c; break; } }
+    var prompt = '你是天命推演引擎的国变演绎官。京师已陷——「' + facName + '」(渠帅' + (idy.leaderName || r.leader || '?') + '·纲领「' + (idy.creed || '?') + '」)入据宫阙。'
+      + '君上' + ((player && player.name) || '?') + '身在城中·' + (G.eraName || '') + '。\n'
+      + '按该股纲领性情与君上处境·演绎君上定命一幕(乱军之中何去何从·义军如何处置)。三择其一：\n'
+      + 'death=殉国或城破被弑；captured=被执北狩(受辱而生·社稷仍悬)；escaped=乘乱出走·驻跸于外诏勤王。\n'
+      + '只返回 JSON：{"fate":"death|captured|escaped","scene":"定命场景≤120字·据实而书如史笔"}';
+    var outcome = { fate: 'death' };
+    try {
+      var resp = await global.callAI(prompt, 500, null, (typeof global._useSecondaryTier === 'function' && global._useSecondaryTier()) ? 'secondary' : undefined, { id: 'breach-scene' });
+      var text = (resp && typeof resp === 'object') ? (resp.text || resp.content || '') : String(resp || '');
+      var j = (typeof global.robustParseJSON === 'function') ? global.robustParseJSON(text) : JSON.parse(text);
+      if (j && (j.fate === 'death' || j.fate === 'captured' || j.fate === 'escaped')) {
+        outcome = { fate: j.fate, narrative: String(j.scene || '').slice(0, 160) };
+      }
+    } catch (_eBS) {}
+    try { RE._applyBreachOutcome(G, r, outcome); } catch (_eAO) { try { RE._applyBreachOutcome(G, r, { fate: 'death' }); } catch (_eF) {} }
+  }
+  function scheduleBreachScene(G, r) {
+    if (!r || r._breachScenePending != null) return;
+    r._breachScenePending = (G.turn || 0);
+    var job = function () { return breachScene(G, r); };
+    if (typeof global._enqueuePostTurnJob === 'function') global._enqueuePostTurnJob('breachScene_' + r.id, job);
+    else job();
+  }
+  function aiOn() { return _aiOn(); }
+
+  var API = { schedule: schedule, forgeIdentity: forgeIdentity, tickInference: tickInference, breachScene: breachScene, scheduleBreachScene: scheduleBreachScene, aiOn: aiOn, _applyActions: _applyActions, _recentPacifyEdicts: _recentPacifyEdicts, _spendSilver: _spendSilver, enabled: enabled, MAX_STOCKS: MAX_STOCKS };
   global.TM = global.TM || {};
   global.TM.RevoltInference = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;


### PR DESCRIPTION
## 范式纠偏续刀

把「实体化≠模板化」贯彻到外患与终局——批二那个阈值 spawner 犯的是与民变模板同样的罪，本批赎清。

## 刀A 外患演绎层（`tm-border-invasion.js`）

**入不入寇、打多大、以什么名义、何时退兵——交敌国 AI**：每回合一次 `tickAI`（post-turn job·回合戳幂等·有敌有压才排，不空转烧调用）。prompt 供给：各敌国强弱/关系/冷却/在场军、边地虚实 top5、**朝廷近旨**（和议/岁币/封贡关键词或点名——你下旨议和，敌国 AI 真会掂量）。动词：`invade`（带入寇名义，如「七大恨告天」）/`press` 深入/`withdraw` 退兵（带缘由）/`demand` **要挟**（条款入史，你可下旨回应——岁币外交的雏形）。

**宪法闸**（`_applyInvasionActions` 独立导出·smoke 直验）：非敌对不得入寇 · 义军排除（民变走破京链）· **无真边压（目标边警<40）不得凭空入寇** · 兵额封顶 · 一国一军 · 冷却。覆没恒常清账留宪法层；确定性 spawner 降为 AI 缺席兜底轨——既有 smoke 沙箱无 callAI，**字节级回归绿证明双轨成立**。

## 刀B 破京定命三态菜单

拍2破京后的定命场景交 AI（`breachScene` subcall）：**death 殉国 / captured 被俘北狩 / escaped 出走勤王**三择 + 史笔场景入史。宪法层 `_applyBreachOutcome` 验菜单：

- `death` → 仍只走玩家之死裁决器（regicide·继统门生效）——死亡唯一产地不变
- `captured` → `_captured` 北狩态**续玩**（endturn 的 `_capturedSovereign` 段既有消费——被俘君主的推演叙事现成）
- `escaped` → 驻跸于外**续玩**（勤王残局）
- 菜单外值（AI 若答「登仙」）一律按 death 兜底——禁玄幻
- AI 缺席 = 直落 death 旧行为（既有破京 smoke 回归绿）

## 验证

新 `smoke-invasion-ai`（17 断言）+ `smoke-breach-fate-menu`（15 断言）；批一至批三 4 个 smoke 全回归绿；`ci-smokes` **782 PASS** · `lint-arch-all` **8/8** · 基线 `--check` PASS。

## 批五回桌候选

地图真改色渲染（数据层已备）· 受抚渠帅接问对/记忆 · 北狩残局专项（摄政/赎驾/夺门线）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)