### PR TITLE
批五：占据真改色（渲染层）+ 赎驾链（北狩最小闭环）+ 受抚渠帅入问对/记忆

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -4661,8 +4661,8 @@
     },
     {
       "path": "tm-map-system.js",
-      "sha256": "1fab78c94f6f395a6855b9cb12e826625865223b3c21c55d1c3bbf455a3399d1",
-      "size": 81036
+      "sha256": "9b15f6b966591253138e5b47b3606e8ad8d2cd61e5e6bc65fd73d69664f92895",
+      "size": 82555
     },
     {
       "path": "tm-mapeditor-fit.js",
@@ -5141,13 +5141,13 @@
     },
     {
       "path": "tm-revolt-entity.js",
-      "sha256": "b3e285b3a7b9848469da1b7b7a9f0da86cf6f09dd469039df31fc5dc79623602",
-      "size": 16925
+      "sha256": "327cf67891d9248c6942dd063b9f487e781364216719275bde0f5268583592f0",
+      "size": 17935
     },
     {
       "path": "tm-revolt-inference.js",
-      "sha256": "f24cd79f0d32b9a2a2e993d1be2b8208728924399263380d0f3c74f8bd71e283",
-      "size": 23527
+      "sha256": "daa6440d37eb1a52e2e711eb090208aac4fffe2720a6403c230908eabcfc962e",
+      "size": 27168
     },
     {
       "path": "tm-save-lifecycle.js",

--- a/web/scripts/smoke-ransom-recolor-wendui.js
+++ b/web/scripts/smoke-ransom-recolor-wendui.js
@@ -1,0 +1,113 @@
+// smoke-ransom-recolor-wendui.js — 批五三刀（2026-07-21·赎驾链/占据覆色/受抚渠帅入问对）
+//
+// 刀A 占据覆色：factionColors 条目须为 {main,...} 对象(裸字符串被 updateMapColors 取 .main
+//   渲成灰=批三真bug已修)·渲染层 updateMapColors 挂 occupiedBy 走表+压轴覆色(静态契约验)。
+// 刀C 赎驾链(北狩残局最小闭环)：ransom_demand 须真挟君·release_captive 三闸(挟君+赎驾旨+
+//   帑廪真扣)·放还真放(_captured 清)。
+// 刀B 受抚渠帅：授官落位京师(问对在京判定可召对)·举旗往事入 NpcMemorySystem(召对有据)。
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var vm = require('vm');
+
+var ROOT = path.join(__dirname, '..');
+var failures = [];
+function assert(cond, msg) {
+  if (cond) { console.log('  PASS ' + msg); }
+  else { failures.push(msg); console.log('  FAIL ' + msg); }
+}
+
+var memSeeds = [];
+var DIVS = { '凤阳府': { name: '凤阳府', militaryRecruits: 3000, minxin: 20 } };
+var sandbox = { console: console };
+sandbox.window = sandbox;
+sandbox.global = sandbox;
+sandbox._ebs = [];
+sandbox.addEB = function (cat, msg) { sandbox._ebs.push(cat + '·' + msg); };
+sandbox.NpcMemorySystem = { addMemory: function (name, text, w, catg) { memSeeds.push({ name: name, text: text, catg: catg }); } };
+sandbox.TM = { AIChange: { PathUtils: { findDivisionByNameFuzzy: function (G, n) { return DIVS[String(n || '').trim()] || null; } } } };
+sandbox.GM = {
+  turn: 30,
+  eraName: '社稷倾危',
+  _capital: '顺天府',
+  mapData: {},
+  guoku: { balance: 400000, ledgers: { money: { stock: 400000 } } },
+  facs: [{ id: 'f1', name: '大明', strength: 60, playerRelation: 100 }],
+  chars: [{ name: '朱由检', isPlayer: true, alive: true }],
+  armies: [],
+  minxin: {
+    trueIndex: 25,
+    revolts: [{ id: 'rvR', region: '凤阳', status: 'ongoing', level: 5, scale: 1000000, turn: 20,
+      _identity: { banner: '闯字营', leaderName: '高闯王', leaderFrom: 'new', creed: '均田免赋', stance: '挟众自重', agenda: '问鼎' } }]
+  },
+  _edictTracker: [],
+  _chronicle: []
+};
+sandbox.P = { conf: { revoltEntityEnabled: true } };
+vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync(path.join(ROOT, 'tm-revolt-entity.js'), 'utf8'), sandbox, { filename: 'tm-revolt-entity.js' });
+vm.runInContext(fs.readFileSync(path.join(ROOT, 'tm-revolt-inference.js'), 'utf8'), sandbox, { filename: 'tm-revolt-inference.js' });
+
+var GM = sandbox.GM;
+var RE = sandbox.TM.RevoltEntity;
+var RI = sandbox.TM.RevoltInference;
+
+console.log('① 覆色数据层：factionColors 条目=对象形状(裸字符串致灰之 bug 已修)');
+RE.sync(GM);
+var army = GM.armies.find(function (a) { return a._revoltEntity; });
+RI._applyActions(GM, { stocks: [{ id: 'rvR', actions: [{ type: 'move', target: '凤阳府' }] }] });
+RI._applyActions(GM, { stocks: [{ id: 'rvR', actions: [{ type: 'occupy', target: '凤阳府' }] }] });
+var cEntry = GM.mapData.factionColors['闯字营'];
+assert(DIVS['凤阳府'].occupiedBy === '闯字营', '占据落账(前提)');
+assert(cEntry && typeof cEntry === 'object' && /^#/.test(cEntry.main || ''), '色条目={main:#hex,...} 对象·updateMapColors 可取 .main');
+assert(/^rgba\(/.test(cEntry.alpha || ''), 'alpha=rgba 串(与剧本色派生形状同构)');
+
+console.log('② 渲染层静态契约：updateMapColors 挂 occupiedBy 走表+压轴覆色');
+var mapSrc = fs.readFileSync(path.join(ROOT, 'tm-map-system.js'), 'utf8');
+assert(/_regionOccupiedMap/.test(mapSrc) && /d\.occupiedBy && Array\.isArray\(d\.mappedRegions\)/.test(mapSrc), '占据走表(division.occupiedBy→region.id)已挂');
+assert(/义军占据覆色压轴/.test(mapSrc) && /region\.occupiedBy = _occ/.test(mapSrc), '压轴覆色+region.occupiedBy 标记已挂(退据自动还色)');
+
+console.log('③ 挟君索赎：不挟君不得挟');
+var r3 = RI._applyActions(GM, { stocks: [{ id: 'rvR', actions: [{ type: 'ransom_demand', silverDemand: 500000 }] }] });
+assert(r3.blocked === 1, '未挟君 → ransom_demand 拦');
+// 破京被俘(批四菜单)→挟君成立
+RE._applyBreachOutcome(GM, GM.minxin.revolts[0], { fate: 'captured' });
+var player = GM.chars[0];
+assert(player._captured === true && player._capturedBy === '闯字营', '君上被执于「闯字营」');
+assert(player._capturedLocation === '闯字营军中', '_capturedLocation 落位(endturn 社稷悬议段消费)');
+var r3b = RI._applyActions(GM, { stocks: [{ id: 'rvR', actions: [{ type: 'ransom_demand', silverDemand: 500000, terms: '并索割凤阳为质' }] }] });
+assert(r3b.applied === 1 && sandbox._ebs.some(function (e) { return e.indexOf('挟君上以令朝廷') >= 0; }), '挟君索赎落起居注');
+assert(GM._chronicle.some(function (c) { return String(c.text).indexOf('挟君索赎') >= 0; }), '要挟入史(玩家可据以下旨)');
+
+console.log('④ 放还三闸：无赎驾旨拦·帑廪不足败局·银足真放');
+var r4 = RI._applyActions(GM, { stocks: [{ id: 'rvR', actions: [{ type: 'release_captive', silverDemand: 300000 }] }] });
+assert(r4.blocked === 1 && player._captured === true, '无赎驾旨 → 不得放还(宪法)');
+GM._edictTracker.push({ turn: 31, category: '国变', content: '倾内帑以赎圣驾·着有司速办迎銮' });
+var r4b = RI._applyActions(GM, { stocks: [{ id: 'rvR', actions: [{ type: 'release_captive', silverDemand: 500000 }] }] });
+assert(r4b.blocked === 1 && player._captured === true && GM.guoku.balance === 400000, '索赎50万>帑廪40万 → 赎局败·分文未动·君仍在贼营');
+assert(sandbox._ebs.some(function (e) { return e.indexOf('赎局遂败') >= 0; }), '败局有诚实叙事');
+var r4c = RI._applyActions(GM, { stocks: [{ id: 'rvR', actions: [{ type: 'release_captive', silverDemand: 350000 }] }] });
+assert(player._captured === false && !player._capturedBy && !player._capturedLocation, '银足 → 銮驾真还(_captured 全清)');
+assert(GM.guoku.balance === 50000 && GM.guoku.ledgers.money.stock === 50000, '赎银 35 万真扣+stock 同步');
+assert(sandbox._ebs.some(function (e) { return e.indexOf('銮驾得还') >= 0; }), '还驾落起居注');
+
+console.log('⑤ 受抚渠帅入朝：落位京师(可召对)+往事入记忆');
+GM._edictTracker.push({ turn: 32, category: '政事', content: '招抚凤阳流贼·许以官爵' });
+RI._applyActions(GM, { stocks: [{ id: 'rvR', actions: [{ type: 'pacify_accept', silverDemand: 30000, officeTitle: '游击将军' }] }] });
+assert(GM.minxin.revolts[0].status === 'pacified', '受抚成局(前提)');
+RE.sync(GM);
+var leader = GM.chars.find(function (c) { return c.name === '高闯王'; });
+assert(leader && leader._revoltPacified === true && leader.officialTitle === '游击将军', '渠帅授官入朝');
+assert(leader.location === '顺天府', '落位 GM._capital(问对在京判定 → 可召对)');
+assert(leader._revoltPast && leader._revoltPast.banner === '闯字营', '_revoltPast 留档(banner/抚银/授官)');
+assert(memSeeds.some(function (m) { return m.name === '高闯王' && m.text.indexOf('闯字营') >= 0 && m.catg === 'career'; }), '举旗受抚往事入 NPC 记忆(career)');
+assert(memSeeds.some(function (m) { return m.name === '高闯王' && m.catg === 'political'; }), '居朝心态入 NPC 记忆(political·召对 AI 有据)');
+assert(!DIVS['凤阳府'].occupiedBy, '受抚 → 占据解除(覆色随 updateMapColors 自动还色)');
+
+console.log('');
+if (failures.length) {
+  console.log('FAIL smoke-ransom-recolor-wendui: ' + failures.length + ' 处失败');
+  failures.forEach(function (f) { console.log('  - ' + f); });
+  process.exit(1);
+}
+console.log('PASS smoke-ransom-recolor-wendui (色对象修形/渲染契约/挟君闸/赎驾三闸/真放人/受抚入朝记忆落位)');

--- a/web/tm-map-system.js
+++ b/web/tm-map-system.js
@@ -705,6 +705,27 @@ function updateMapColors() {
       })(fh.divisions);
     });
   }
+
+  // 批五·义军占据覆色：region.id → 占据者（民变演绎层写 div.occupiedBy·此处渲染层消费）。
+  // 双树防御走查：P 与 GM 的 adminHierarchy 通常同引用·若分叉则以任一侧有 occupiedBy 为准（占据只由
+  // tm-revolt-inference 写在 GM 叶上·P 侧缺失=静默无覆色·安全失效不破图）。
+  var _regionOccupiedMap = {};
+  [P.adminHierarchy, (typeof GM !== 'undefined' && GM && GM.adminHierarchy !== P.adminHierarchy) ? GM.adminHierarchy : null].forEach(function(ah) {
+    if (!ah) return;
+    Object.keys(ah).forEach(function(fk) {
+      var fh = ah[fk]; if (!fh || !fh.divisions) return;
+      (function _wOcc(ds) {
+        ds.forEach(function(d) {
+          if (!d) return;
+          if (d.occupiedBy && Array.isArray(d.mappedRegions)) {
+            d.mappedRegions.forEach(function(rid) { _regionOccupiedMap[rid] = d.occupiedBy; });
+          }
+          if (d.children) _wOcc(d.children);
+          if (d.divisions) _wOcc(d.divisions);
+        });
+      })(fh.divisions);
+    });
+  });
   // 按管辖类型给地块着色修正——直辖用势力主色；非直辖用"势力主色+autonomy类型色调"混合
   var _AUTONOMY_COLORS = { fanguo:'#9a7bd8', fanzhen:'#f87171', jimi:'#66bb6a', chaogong:'#f59e0b' };
 
@@ -737,6 +758,14 @@ function updateMapColors() {
       } else {
         region.color = baseColor;
         region.autonomyType = 'zhixia';
+      }
+      // 批五·义军占据覆色压轴（占据是既成军事事实·压过 autonomy 显示·退据即自动还色）
+      var _occ = _regionOccupiedMap[region.id];
+      if (_occ) {
+        var _occC = (GM.mapData && GM.mapData.factionColors && GM.mapData.factionColors[_occ]) || null;
+        if (_occC && _occC.main) { region.color = _occC.main; region.occupiedBy = _occ; }
+      } else if (region.occupiedBy) {
+        delete region.occupiedBy;
       }
       updateCount++;
     });

--- a/web/tm-revolt-entity.js
+++ b/web/tm-revolt-entity.js
@@ -162,6 +162,15 @@
         ch._revoltPacified = true;
         ch.officialTitle = pac.officeTitle || '受抚归顺';
         _setCharFaction(ch, ch._preRevoltFaction || '');  // 真人招安复原籍·草莽渠帅无所属
+        // 批五·受抚渠帅接问对/记忆：授官者落位京师(问对在京判定即可召对)·举旗往事入 NPC 记忆(召对 AI 有据可依)
+        if (pac.officeTitle) ch.location = (G._capital || '京师');
+        ch._revoltPast = { banner: fac.name, silver: pac.silver || 0, officeTitle: pac.officeTitle || '' };
+        try {
+          if (typeof global.NpcMemorySystem !== 'undefined' && typeof global.NpcMemorySystem.addMemory === 'function') {
+            global.NpcMemorySystem.addMemory(ch.name, '曾举「' + (fac.name || '义旗') + '」聚众抗命·后受抚归朝' + (pac.officeTitle ? '·得授' + pac.officeTitle : '') + (pac.silver ? '·抚银' + pac.silver + '两' : ''), 10, 'career');
+            global.NpcMemorySystem.addMemory(ch.name, '旧账与招安之恩并存·居朝如履薄冰·防猜忌亦存桀骜', 8, 'political');
+          }
+        } catch (_eMem) {}
       } else if (ch._revoltEntity) {
         ch._revoltDefeated = true; ch.officialTitle = '溃散流亡';
         _setCharFaction(ch, '');  // 退籍走正门
@@ -250,6 +259,7 @@ function _applyBreachOutcome(G, r, o) {
   var f0 = String(o.fate || 'death');
   if (player && f0 === 'captured') {
     player._captured = true; player._capturedBy = facName;  // 北狩态·花名册/推演既有 _captured 消费
+    player._capturedLocation = facName + '军中';  // 批五·endturn「社稷悬议」段读此落位
     fallInfo('captured');
     _eb('君上蒙尘·为「' + facName + '」所执·社稷存亡悬于一线');
     return;

--- a/web/tm-revolt-inference.js
+++ b/web/tm-revolt-inference.js
@@ -60,13 +60,19 @@
     try { if (typeof global.addEB === 'function') global.addEB('朝代', label + '·帑出 ' + amount + ' 两'); } catch (_) {}
     return true;
   }
+  function _hexRgb(h) {
+    h = String(h || '').replace('#', '');
+    return parseInt(h.slice(0, 2), 16) + ', ' + parseInt(h.slice(2, 4), 16) + ', ' + parseInt(h.slice(4, 6), 16);
+  }
   function _ensureColor(G, facName) {
     try {
       if (!G.mapData) return;
       if (!G.mapData.factionColors) G.mapData.factionColors = {};
       if (!G.mapData.factionColors[facName]) {
         var used = Object.keys(G.mapData.factionColors).length;
-        G.mapData.factionColors[facName] = REBEL_COLORS[used % REBEL_COLORS.length];
+        var c = REBEL_COLORS[used % REBEL_COLORS.length];
+        // 形状对齐 updateMapColors 消费端({main/highlight/dark/alpha}·裸字符串取 .main 会渲成灰)
+        G.mapData.factionColors[facName] = { main: c, highlight: c, dark: c, alpha: 'rgba(' + _hexRgb(c) + ', 0.7)' };
       }
     } catch (_) {}
   }
@@ -100,6 +106,23 @@
       if (hit || t.indexOf('流贼') >= 0 || t.indexOf('义军') >= 0 || t.indexOf('乱民') >= 0) out.push(t.slice(0, 120));
     });
     return out;
+  }
+  // 批五·赎驾旨匹配（北狩残局：迎归/迎銮/赎驾类旨意）
+  function _recentRansomEdicts(G) {
+    var kw = ['赎', '迎归', '迎銮', '迎驾', '奉还', '还驾'];
+    return (Array.isArray(G._edictTracker) ? G._edictTracker.slice(-8) : []).map(function (e) {
+      return String((e && (e.content || e.title)) || '');
+    }).filter(function (t) {
+      return t && kw.some(function (k) { return t.indexOf(k) >= 0; });
+    }).map(function (t) { return t.slice(0, 120); });
+  }
+  // 该股是否挟有被俘君上（批四破京 captured 态·_capturedBy=股旗号）
+  function _capturedPlayerOf(G, facName) {
+    for (var i = 0; i < (G.chars || []).length; i++) {
+      var c = G.chars[i];
+      if (c && c.isPlayer && c._captured && c._capturedBy === facName) return c;
+    }
+    return null;
   }
 
   // ── subcall A·起号立领袖（具象化时一次·owner 拍板①）────────────────────────
@@ -148,11 +171,18 @@
         + '·已据：' + occ + '·声势级「' + (s.r ? (s.r.level || '?') : '?') + '」');
       var eds = _recentPacifyEdicts(G, s);
       if (eds.length) lines.push('  ↳朝廷近旨(与本股相关·据 stance/agenda 决定受抚/拒抚/讨价·亦可诈许)：' + eds.join('｜'));
+      // 批五·挟君在营：赎驾博弈段（北狩残局）
+      if (_capturedPlayerOf(G, s.fac.name)) {
+        lines.push('  ↳★本股挟被俘君上在营——奇货可居：可 ransom_demand 索赎要挟·朝廷下赎驾旨且银足可 release_captive 放还·亦可继续奇货自重。');
+        var reds = _recentRansomEdicts(G);
+        if (reds.length) lines.push('  ↳朝廷赎驾近旨：' + reds.join('｜'));
+      }
     });
     lines.push('【可用动作】move(target=府县名)·occupy(target=府县名·须军已至且兵力足)·recruit(delta=裹挟人数)·'
       + 'split(banner/leaderName/creed/target=分裂新股)·merge(target=并入的股id)·proclaim(stateName=国号·僭号建国·时机自断)·'
-      + 'pacify_accept(silverDemand=受抚索银·officeTitle=讨的官职)·pacify_refuse(reason)·pacify_counter(silverDemand/officeTitle=还价)。');
-    lines.push('【铁则】没有朝廷招抚旨不得 pacify_*；占府会被引擎验兵力·虚占无效；裹挟有上限；行动须合乎各股纲领与处境·宁少勿滥(每股1-3个)。');
+      + 'pacify_accept(silverDemand=受抚索银·officeTitle=讨的官职)·pacify_refuse(reason)·pacify_counter(silverDemand/officeTitle=还价)·'
+      + 'ransom_demand(silverDemand/terms=挟君索赎·须真挟有君上)·release_captive(silverDemand=放还君上·须朝廷有赎驾旨且银足)。');
+    lines.push('【铁则】没有朝廷招抚旨不得 pacify_*；没有赎驾旨不得 release_captive；不挟君不得 ransom_*；占府会被引擎验兵力·虚占无效；裹挟有上限；行动须合乎各股纲领与处境·宁少勿滥(每股1-3个)。');
     lines.push('只返回 JSON：{"stocks":[{"id":"股id","narrative":"本回合作为叙事≤60字","actions":[{"type":"...","target":"","delta":0,"banner":"","leaderName":"","creed":"","silverDemand":0,"officeTitle":"","stateName":"","reason":""}]}]}');
     return lines.join('\n');
   }
@@ -258,6 +288,31 @@
               if (!_recentPacifyEdicts(G, s).length) { blocked++; return; }
               _eb('「' + s.fac.name + '」讨价：索银 ' + (Number(act.silverDemand) || 0) + ' 两' + (act.officeTitle ? '·求授' + act.officeTitle : '') + '·抚局未定'); applied++;
               return;
+            }
+            case 'ransom_demand': {
+              // 批五·挟君索赎（宪法：真挟有被俘君上才可挟）
+              var cap1 = _capturedPlayerOf(G, s.fac.name);
+              if (!cap1) { blocked++; return; }
+              _eb('「' + s.fac.name + '」挟君上以令朝廷：索赎银 ' + (Number(act.silverDemand) || 0) + ' 两' + (act.terms ? '·' + String(act.terms).slice(0, 40) : '') + '·社稷之重悬于贼手');
+              _chron(G, '「' + s.fac.name + '」挟君索赎：' + (Number(act.silverDemand) || 0) + ' 两' + (act.terms ? '·' + String(act.terms).slice(0, 50) : ''));
+              applied++; return;
+            }
+            case 'release_captive': {
+              // 批五·放还君上（宪法三闸：真挟有君上+朝廷真有赎驾旨+帑廪真拿得出银）
+              var cap2 = _capturedPlayerOf(G, s.fac.name);
+              if (!cap2) { blocked++; return; }
+              if (!_recentRansomEdicts(G).length) { blocked++; return; }
+              var ask2 = Math.max(0, Math.round(Number(act.silverDemand) || 0));
+              if (ask2 > 0 && !_spendSilver(G, ask2, '赎驾于「' + s.fac.name + '」')) {
+                _eb('「' + s.fac.name + '」许还驾而帑廪不给·赎局遂败·君上仍陷贼营'); blocked++;
+                return;
+              }
+              cap2._captured = false;
+              delete cap2._capturedBy;
+              delete cap2._capturedLocation;
+              _eb('★銮驾得还！' + (cap2.name || '君上') + '自「' + s.fac.name + '」营中归' + (ask2 ? '·赎银 ' + ask2 + ' 两' : ''));
+              _chron(G, '銮驾自贼营得还·天下额手·' + (ask2 ? '赎银' + ask2 + '两' : '未费一金'));
+              applied++; return;
             }
             default: blocked++;
           }


### PR DESCRIPTION
## 刀A 地图占据真改色

`updateMapColors` 挂占据走表（`division.occupiedBy` → `mappedRegions` → region.id，P/GM 双树防御走查，分叉侧缺失=静默不破图）+ **压轴覆色**——占据是既成军事事实，压过 autonomy 显示色；退据/被剿/受抚后自动还色。region 挂 `occupiedBy` 标记供 tooltip/面板后用。**顺修批三真 bug**：`_ensureColor` 原来写裸字符串进 `factionColors`，而消费端取 `.main`——会渲成灰；已改为 `{main/highlight/dark/alpha}` 对象（形状对齐剧本色派生）。

## 刀B 受抚渠帅入问对/记忆

受抚授官者**落位京师**（问对的在京判定即可召对）；`_revoltPast` 留档；「曾举某旗聚众抗命·受抚归朝」与「居朝如履薄冰·防猜忌亦存桀骜」两条入 `NpcMemorySystem`（career+political）——召对时 AI 有据可依，**后患伏笔自然生长**（你当年要的「招安给官=好戏」在这落地）。

## 刀C 赎驾链（北狩残局最小闭环）

演绎层新增两动词：
- `ransom_demand`——**挟君索赎**（宪法：真挟有被俘君上才可挟；条款入史，你可下旨回应）
- `release_captive`——放还君上，**三闸**：挟君 + 朝廷真有赎驾旨（赎/迎归/迎銮关键词匹配 `_edictTracker`）+ 帑廪真扣；银足则 `_captured` 全清、**銮驾真还**

prompt 加挟君段（「奇货可居·放不放亦由尔断」——AI 可以拒赎继续挟）；破京 captured 态补 `_capturedLocation`（endturn「社稷悬议」段既有消费）。**摄政/立新君/夺门大戏 = 后续专项摊桌**，本批只做钱货两讫的最小闭环。

## 验证

新 `smoke-ransom-recolor-wendui` **20 断言**；批一至批四 **6 个 smoke 全回归绿**；`ci-smokes` **783 PASS** · `lint-arch-all` **8/8** · 基线 `--check` PASS。

⚠️ 地图覆色的**视觉效果**需真机验证（smoke 只能验数据与源码契约）——开一局把民变闹到占府，看舆图上那块地变不变色。

🤖 Generated with [Claude Code](https://claude.com/claude-code)