### PR TITLE
问天二期：工单化（prompt 供奉+两回合核销·规则常青）+ 治理列

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -4061,8 +4061,8 @@
     },
     {
       "path": "tm-endturn-prompt.js",
-      "sha256": "4913ab0736cef49f1fa3676bfd4a3ddb864f0ce09f1941100f82e1c17a74d3da",
-      "size": 362120
+      "sha256": "7df93589397da04131f2b1d8be158c9426b96264b7837ab8a18d355bf967235d",
+      "size": 363225
     },
     {
       "path": "tm-endturn-province.js",
@@ -4301,13 +4301,13 @@
     },
     {
       "path": "tm-game-loop-wentian-hardchange.js",
-      "sha256": "11783df70d44dac8ea240f47313f8b2e8632d7773caf00e1940421a2568f5f9e",
-      "size": 66524
+      "sha256": "bc68b4ac4315c8dc0539c54b7ad8550c417bb7caf61010ea497764e2040ed5a2",
+      "size": 67074
     },
     {
       "path": "tm-game-loop.js",
-      "sha256": "dbb59c1ed1338d8d6fba32a9c620d49ccea50cbf516e6c231422cac01b5cd4da",
-      "size": 105049
+      "sha256": "5a335596705bc5fa7be6c593c7ac5b77a2f7c58390adb8aac9615d63840ba260",
+      "size": 106320
     },
     {
       "path": "tm-game-ui-shell.js",

--- a/web/scripts/smoke-wentian-workorder.js
+++ b/web/scripts/smoke-wentian-workorder.js
@@ -1,0 +1,88 @@
+// smoke-wentian-workorder.js — 问天二期·工单化+治理列（2026-07-21·随 wentianFulfillAudit）
+//
+// 方向三落地：plan/watch 从「给玩家看的一句话」升为一等工单——endturn prompt 单独供奉
+// 指标(⚖工单指标·引擎核验勿虚报·AI 确知怎样才算落实)·非规则类连续两回合全中→自动核销
+// (停止对账·徽章留档)·规则类常青恒审。方向五治理列：最近核验回合 T 标+久未遵裁撤提示+核销章。
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var vm = require('vm');
+
+var ROOT = path.join(__dirname, '..');
+var failures = [];
+function assert(cond, msg) {
+  if (cond) { console.log('  PASS ' + msg); }
+  else { failures.push(msg); console.log('  FAIL ' + msg); }
+}
+
+// 拆分家族契约序：先提及 tm-game-loop.js 再 tm-game-loop-wentian-hardchange.js（lint-smoke-family-order）
+var glSrc = fs.readFileSync(path.join(ROOT, 'tm-game-loop.js'), 'utf8');
+
+var sandbox = { console: console };
+sandbox.window = sandbox;
+sandbox.global = sandbox;
+sandbox.setTimeout = function () { return 0; };
+sandbox.clearTimeout = function () {};
+sandbox.GM = {
+  turn: 5,
+  chars: [{ name: '袁崇焕', loyalty: 55, alive: true }],
+  armies: [{ name: '关宁军', soldiers: 10000 }],
+  _playerDirectives: [],
+  _wentianHistory: []
+};
+sandbox.P = { conf: { wentianFulfillAudit: true } };
+vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync(path.join(ROOT, 'tm-game-loop-wentian-hardchange.js'), 'utf8'), sandbox, { filename: 'tm-game-loop-wentian-hardchange.js' });
+
+var GM = sandbox.GM;
+
+var regD = sandbox._wtRegisterWatch([{ path: 'chars[袁崇焕].loyalty', expect: 'gte', value: 80, note: '袁忠诚' }]);
+var regR = sandbox._wtRegisterWatch([{ path: 'armies[关宁军].soldiers', expect: 'gte', value: 15000, note: '关宁兵额' }]);
+var dirD = { id: 'wo1', content: '安抚袁崇焕', type: 'directive', _watch: regD };
+var dirR = { id: 'wo2', content: '保持关宁满编', type: 'rule', _watch: regR };
+GM._playerDirectives.push(dirD, dirR);
+
+console.log('① 达标第一回合：streak 记账·未核销');
+GM.turn = 6;
+GM.chars[0].loyalty = 85;
+GM.armies[0].soldiers = 16000;
+sandbox._wtRunFulfillAudit();
+assert(dirD._lastStatus === 'followed' && dirD._watch._streakOk === 1, 'directive 全中·streak=1');
+assert(!dirD._watchClosed, '一回合不核销(须连续两回合)');
+
+console.log('② 连续两回合达标：directive 核销·rule 常青');
+GM.turn = 7;
+sandbox._wtRunFulfillAudit();
+assert(dirD._watchClosed === true, 'directive 连中两回合 → 工单核销');
+assert(GM._wentianHistory.some(function (h) { return h.content.indexOf('工单核销·兑现毕') >= 0; }), '核销落问天历史');
+assert(dirR._lastStatus === 'followed' && !dirR._watchClosed, 'rule 同样连中 → 常青不核销(恒审)');
+
+console.log('③ 核销后停止对账（徽章留档）');
+GM.turn = 8;
+GM.chars[0].loyalty = 10;  // 若仍审会翻 ignored
+var histLen = GM._wentianHistory.length;
+sandbox._wtRunFulfillAudit();
+assert(dirD._lastStatus === 'followed', '已核销 → 不再翻账(留档定格)');
+assert(dirR._lastStatus === 'followed', 'rule 兵额仍达标 → 继续 followed');
+
+console.log('④ rule 失守 → 常青审计翻账·streak 清零');
+GM.turn = 9;
+GM.armies[0].soldiers = 8000;
+sandbox._wtRunFulfillAudit();
+assert(dirR._lastStatus === 'ignored' && dirR._watch._streakOk === 0, 'rule 失守 → ignored·streak 清零(常青价值)');
+
+console.log('⑤ 静态契约：prompt 工单供奉段+治理列 chips');
+var promptSrc = fs.readFileSync(path.join(ROOT, 'tm-endturn-prompt.js'), 'utf8');
+assert((promptSrc.match(/⚖工单指标\(引擎核验·勿虚报\)/g) || []).length === 2, 'endturn prompt 规则/指令两个循环各供奉工单指标');
+assert(/_watchClosed/.test(promptSrc), '已核销工单不再供奉');
+// 该文件中文按惯例存 \uXXXX 转义·契约锚 ASCII 标识符（glSrc 已按家族序在文件头预读）
+assert(/checkChip/.test(glSrc) && /adviceChip/.test(glSrc) && /d\._watchClosed/.test(glSrc) && /_ignoredCount \|\| 0\) >= 3/.test(glSrc), '治理列三件(核销章/裁撤提示/T标)已挂(ASCII锚)');
+assert(/statusChip \+ watchChip \+ checkChip \+ adviceChip/.test(glSrc), '四 chip 已并入指令行渲染');
+
+console.log('');
+if (failures.length) {
+  console.log('FAIL smoke-wentian-workorder: ' + failures.length + ' 处失败');
+  failures.forEach(function (f) { console.log('  - ' + f); });
+  process.exit(1);
+}
+console.log('PASS smoke-wentian-workorder (工单供奉/两回合核销/规则常青/核销停审/治理列契约)');

--- a/web/tm-endturn-prompt.js
+++ b/web/tm-endturn-prompt.js
@@ -300,6 +300,10 @@
           } else if (r._lastStatus === 'partial') {
             tp += '      ⚠️【上回合仅部分遵守·本回合须完整落实】\n';
           }
+          // 问天二期·工单供奉：兑现对账指标(回合末引擎按在档真值核验·非自报作业)——让 AI 确知「怎样才算落实」
+          if (r._watch && Array.isArray(r._watch.items) && r._watch.items.length && !r._watchClosed) {
+            tp += '      ⚖工单指标(引擎核验·勿虚报)：' + r._watch.items.map(function(w){ return (w.note || w.path) + '·' + w.expect + (w.value != null && w.value !== '' ? '·' + w.value : ''); }).join('；') + (r._watch.lastStatus ? '·上回合核验=' + r._watch.lastStatus : '') + '\n';
+          }
         });
       }
       if (_corrections.length > 0) {
@@ -316,6 +320,10 @@
         _others.forEach(function(o) {
           tp += '  · [id=' + o.id + '] ' + o.content + '\n';
           if (o.structured) tp += '      解析：' + JSON.stringify(o.structured).slice(0, 200) + '\n';
+          // 问天二期·工单供奉(同上·directive 类连续兑现两回合自动核销)
+          if (o._watch && Array.isArray(o._watch.items) && o._watch.items.length && !o._watchClosed) {
+            tp += '      ⚖工单指标(引擎核验·勿虚报)：' + o._watch.items.map(function(w){ return (w.note || w.path) + '·' + w.expect + (w.value != null && w.value !== '' ? '·' + w.value : ''); }).join('；') + (o._watch.lastStatus ? '·上回合核验=' + o._watch.lastStatus : '') + '\n';
+          }
         });
       }
       tp += '═══════════════════════════════════════════════════════════\n\n';

--- a/web/tm-game-loop-wentian-hardchange.js
+++ b/web/tm-game-loop-wentian-hardchange.js
@@ -1190,6 +1190,7 @@ function _wtRunFulfillAudit() {
     var stamps = [];
     GM._playerDirectives.forEach(function (d) {
       if (!d || !d._watch || !Array.isArray(d._watch.items) || !d._watch.items.length) return;
+      if (d._watchClosed) return;  // 问天二期·已核销工单不再对账（徽章留档）
       if (d._watch.registeredTurn === turn) return;  // 注册当回合不对账（推演还没跑）
       var met = 0, parts = [];
       d._watch.items.forEach(function (it) {
@@ -1207,6 +1208,13 @@ function _wtRunFulfillAudit() {
       if (prev !== status) {
         stamps.push('《' + String(d.content || '').slice(0, 18) + '》' + met + '/' + d._watch.items.length
           + (status === 'followed' ? ' 已兑现' : status === 'partial' ? ' 部分兑现' : ' 未见兑现'));
+      }
+      // 问天二期·工单核销：非规则类连续两回合全中→闭单(停止对账·规则类常青恒审)
+      if (status === 'followed') d._watch._streakOk = (d._watch._streakOk || 0) + 1;
+      else d._watch._streakOk = 0;
+      if (d.type !== 'rule' && d._watch._streakOk >= 2 && !d._watchClosed) {
+        d._watchClosed = true;
+        stamps.push('《' + String(d.content || '').slice(0, 18) + '》工单核销·兑现毕');
       }
     });
     if (stamps.length) {

--- a/web/tm-game-loop.js
+++ b/web/tm-game-loop.js
@@ -905,9 +905,15 @@ function _wtRenderHistory() {
       // \u5200A\u00B7\u5151\u73B0\u5BF9\u8D26\u5728\u518C\u6807\u8BB0\uFF08title \u5217\u6307\u6807\uFF09
       var watchChip = (d._watch && d._watch.items && d._watch.items.length)
         ? '<span style="display:inline-block;padding:1px 5px;background:rgba(126,160,200,0.16);color:var(--ink-200,#cbb);border-radius:2px;font-size:0.62rem;margin-left:4px;" title="' + escHtml(d._watch.items.map(function(w){return (w.note||w.path)+'\u00B7'+w.expect;}).join('\uFF1B')) + '">\u2696\u5BF9\u8D26' + d._watch.items.length + '</span>' : '';
+      // \u95EE\u5929\u4E8C\u671F\u00B7\u6CBB\u7406\u5217\uFF1A\u5DE5\u5355\u6838\u9500\u7AE0 / \u6700\u8FD1\u6838\u9A8C\u56DE\u5408 / \u4E45\u672A\u9075\u88C1\u64A4\u63D0\u793A
+      if (d._watchClosed) watchChip = '<span style="display:inline-block;padding:1px 5px;background:rgba(126,184,167,0.18);color:var(--celadon-400);border-radius:2px;font-size:0.62rem;margin-left:4px;" title="\u8FDE\u7EED\u4E24\u56DE\u5408\u5151\u73B0\u00B7\u5DE5\u5355\u5DF2\u6838\u9500">\u2696\u5DF2\u6838\u9500</span>';
+      var checkChip = (d._lastCheckTurn != null)
+        ? '<span style="display:inline-block;padding:1px 4px;color:var(--ink-300);font-size:0.6rem;margin-left:3px;" title="\u6700\u8FD1\u6838\u9A8C\u56DE\u5408">T' + d._lastCheckTurn + '</span>' : '';
+      var adviceChip = (d._lastStatus === 'ignored' && (d._ignoredCount || 0) >= 3)
+        ? '<span style="display:inline-block;padding:1px 5px;background:rgba(192,64,48,0.14);color:var(--vermillion-400);border:1px dotted rgba(192,64,48,0.4);border-radius:2px;font-size:0.6rem;margin-left:4px;" title="\u8FDE\u7EED\u591A\u56DE\u5408\u672A\u88AB\u9075\u5B88\u00B7\u6216\u5DF2\u4E0D\u5408\u65F6\u5B9C\u00B7\u53EF\u70B9\u2715\u88C1\u64A4">\u4E45\u672A\u9075\u00B7\u5B9C\u88C1\u64A4</span>' : '';
       html += '<div style="display:flex;justify-content:flex-end;margin-bottom:0.4rem;">';
       html += '<div style="max-width:85%;background:var(--color-accent-subtle);border-right:3px solid ' + borderCol + ';border-radius:var(--radius-md) 2px 2px var(--radius-md);padding:0.4rem 0.6rem;font-size:var(--text-xs);">';
-      html += '<div style="font-size:0.66rem;color:var(--gold-400);margin-bottom:2px;">T' + (d.turn||'?') + ' ' + (d.type === 'rule' ? '\u89C4\u5219' : d.type === 'correction' ? '\u7EA0\u6B63' : d.type === 'content' ? '\u5185\u5BB9' : '\u6307\u4EE4') + absChip + statusChip + watchChip + '</div>';
+      html += '<div style="font-size:0.66rem;color:var(--gold-400);margin-bottom:2px;">T' + (d.turn||'?') + ' ' + (d.type === 'rule' ? '\u89C4\u5219' : d.type === 'correction' ? '\u7EA0\u6B63' : d.type === 'content' ? '\u5185\u5BB9' : '\u6307\u4EE4') + absChip + statusChip + watchChip + checkChip + adviceChip + '</div>';
       html += escHtml(d.content);
       if (d.structured) {
         var sParts = [];


### PR DESCRIPTION
## 方向三·工单化（随 `wentianFulfillAudit`·吃一期账本数据）

一期的 watch 指标只在回合末对账——**AI 事前根本看不到指标**，落实全凭领会。本 PR 把工单升为一等公民：

- endturn prompt 的规则/指令两个循环各供奉「**⚖工单指标（引擎核验·勿虚报）**」：criteria + 上回合核验结果——AI 确知怎样才算落实，且知道自报会被账本戳穿
- **工单生命周期**：非规则类连续两回合全中 → 自动核销（停止对账·徽章留档·落问天历史）；规则类**常青恒审**——失守即翻账、streak 清零（「保持关宁满编」这类承诺永远有人查岗）；已核销不再占 prompt

## 方向五·治理列（活跃指令列表）

⚖已核销章 · T{最近核验回合} 标 · 连续忽略≥3 亮「**久未遵·宜裁撤**」提示（点✕即裁）——玩家一眼看清每条指令是活是死。

## 验证

新 `smoke-wentian-workorder` **12 断言**（供奉双段/两回合核销/规则常青/核销停审/治约 ASCII 锚）；问天一期 4 smoke 全回归绿；`ci-smokes` **784 PASS** · `lint-arch-all` **8/8**（中途踩了 lint-smoke-family-order 拆分家族序——smoke 提及 game-loop 须先于 hardchange，已按契约序重排）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)