### PR TITLE
批七：悬朝演绎层（北狩残局朝廷侧）——立新君交 AI·玩家演太上皇·复辟旨即夺门谋划

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2111,8 +2111,8 @@
     },
     {
       "path": "index.html",
-      "sha256": "6eebaf6dc0c1c35a2ea44405854179062e5b09f18a535575fccde1c30ed765c2",
-      "size": 64844
+      "sha256": "58a628fe259345a8a4f307faa33ac1399a78a4de8746c3046828dbb56ec7ef26",
+      "size": 65072
     },
     {
       "path": "INDEX.md",
@@ -3613,6 +3613,11 @@
       "path": "tm-capacitor-boot.js",
       "sha256": "3e53de57f04cd152aada0e4955cd8765502b9f30cb7d3a72d0cc746c43e93b2e",
       "size": 23148
+    },
+    {
+      "path": "tm-captive-court.js",
+      "sha256": "adc9f61623e844cf5d2bbd5a4421e3ba0e94ee911fb17fb91f01d6dc9d4f9313",
+      "size": 13324
     },
     {
       "path": "tm-ceming.js",

--- a/web/index.html
+++ b/web/index.html
@@ -858,6 +858,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-authority-complete.js?v=20260623-ledgerflow"></script>
 <script src="tm-revolt-entity.js?v=20260721"></script><!-- R2民变实体镜像·flag revoltEntityEnabled 默认OFF·爬梯level≥3具象化势力/渠帅/军队三件套 -->
 <script src="tm-revolt-inference.js?v=20260721b"></script><!-- 批三·民变演绎层(AI主导)·起号立领袖subcall+逐回合行为subcall(打/占/分合/建国/招抚谈判)·宪法闸落账·AI缺席模板兜底 -->
+<script src="tm-captive-court.js?v=20260721"></script><!-- 批七·悬朝演绎层(北狩残局朝廷侧)·君被虏朝廷AI当一等演员(观望/监国/立新君)·归銮后复辟旨即夺门谋划·随revoltEntityEnabled -->
 <script src="tm-historical-presets.js?v=2026042816"></script>
 <script src="tm-prophecy.js?v=20260709"></script>
 <script src="tm-region-enrich.js?v=2026042714"></script>

--- a/web/scripts/arch-baselines/gm-writes.json
+++ b/web/scripts/arch-baselines/gm-writes.json
@@ -2,6 +2,7 @@
   "config": {
     "owners": [
       "tm-border-invasion.js",
+      "tm-captive-court.js",
       "tm-indices.js",
       "tm-revolt-entity.js",
       "tm-revolt-inference.js",

--- a/web/scripts/smoke-captive-court.js
+++ b/web/scripts/smoke-captive-court.js
@@ -1,0 +1,126 @@
+// smoke-captive-court.js — 悬朝演绎层·北狩残局朝廷侧（批七·2026-07-21）
+//
+// owner 三拍板：①立新君交 AI(朝臣自行酝酿·玩家失控才是北狩之痛) ②玩家继续演太上皇
+// ③夺门=复辟旨即谋划(诏令管线·AI 断成败)。本 smoke 不经真 AI：canned 决断直灌
+// _applyCourtOutcome 验宪法闸——立新君三验(须真被虏/人选活人非俘非玩家/不重复立)·
+// 太上皇称号迁转·夺门三闸(君已归+新君在位+真有复辟旨)·谋泄冷却·兜底轨(被虏6回合自立储君)。
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var vm = require('vm');
+
+var ROOT = path.join(__dirname, '..');
+var failures = [];
+function assert(cond, msg) {
+  if (cond) { console.log('  PASS ' + msg); }
+  else { failures.push(msg); console.log('  FAIL ' + msg); }
+}
+
+function freshSandbox() {
+  var sb = { console: console };
+  sb.window = sb; sb.global = sb;
+  sb._ebs = [];
+  sb.addEB = function (cat, msg) { sb._ebs.push(cat + '·' + msg); };
+  sb.GM = {
+    turn: 30,
+    eraName: '社稷非常',
+    huangwei: { index: 40 },
+    chars: [
+      { name: '朱祁镇', isPlayer: true, alive: true, officialTitle: '大明皇帝', family: '朱', childrenIds: ['朱见深'] },
+      { name: '朱见深', alive: true, family: '朱', officialTitle: '皇太子' },
+      { name: '朱祁钰', alive: true, family: '朱', officialTitle: '亲王' },
+      { name: '于谦', alive: true, faction: '朝廷', officialTitle: '兵部尚书', loyalty: 90 }
+    ],
+    _edictTracker: [],
+    _chronicle: []
+  };
+  sb.P = { conf: { revoltEntityEnabled: true } };
+  vm.createContext(sb);
+  vm.runInContext(fs.readFileSync(path.join(ROOT, 'tm-captive-court.js'), 'utf8'), sb, { filename: 'tm-captive-court.js' });
+  return sb;
+}
+
+console.log('① 立新君宪法三验');
+var sb = freshSandbox();
+var CC = sb.TM.CaptiveCourt;
+var GM = sb.GM;
+var player = GM.chars[0];
+var r0 = CC._applyCourtOutcome(GM, { type: 'proclaim_new', name: '朱祁钰' });
+assert(r0.ok === false, '君上未被虏 → 不得另立(闸)');
+player._captured = true; player._capturedBy = '瓦剌'; player._capturedLocation = '瓦剌军中';
+assert(CC._applyCourtOutcome(GM, { type: 'proclaim_new', name: '不存在的人' }).ok === false, '人选不在档 → 拦');
+assert(CC._applyCourtOutcome(GM, { type: 'proclaim_new', name: '朱祁镇' }).ok === false, '不得立被虏的玩家自己');
+var r1 = CC._applyCourtOutcome(GM, { type: 'proclaim_new', name: '朱祁钰', narrative: '主战派定策·奉亲王践祚' });
+assert(r1.ok === true && GM._rivalEmperor && GM._rivalEmperor.name === '朱祁钰', '立新君落账 _rivalEmperor');
+assert(GM.chars[2]._enthroned === true, '新君 _enthroned 竖旗');
+assert(player.officialTitle === '太上皇' && player._preCaptureTitle === '大明皇帝', '拍板②：玩家尊为太上皇·原号留档');
+assert(CC._applyCourtOutcome(GM, { type: 'proclaim_new', name: '朱见深' }).ok === false, '已立新君 → 不重复立');
+assert(sb._ebs.some(function (e) { return e.indexOf('一朝二主') >= 0; }), '立新君落起居注');
+assert(GM._chronicle.some(function (c) { return c.text.indexOf('主战派定策') >= 0; }), 'AI 叙事入史');
+
+console.log('② 夺门三闸：君在虏营拦·无复辟旨拦·齐备则复位');
+assert(CC._applyCourtOutcome(GM, { type: 'restoration' }).ok === false, '君犹被虏 → 夺门无从谈起');
+player._captured = false; delete player._capturedBy; delete player._capturedLocation;  // 赎驾归銮
+assert(CC._applyCourtOutcome(GM, { type: 'restoration' }).ok === false, '无复辟旨 → 未见其谋(须玩家真下旨)');
+GM._edictTracker.push({ turn: 31, category: '密', content: '密结旧臣·图谋复辟正位' });
+GM.turn = 32;
+var r2 = CC._applyCourtOutcome(GM, { type: 'restoration', demotedTitle: '郕王' });
+assert(r2.ok === true && !GM._rivalEmperor, '夺门成 → 新君清位');
+assert(GM.chars[2]._enthroned === false && GM.chars[2]._dethroned === true && GM.chars[2].officialTitle === '郕王', '逊位降号(AI 定号)');
+assert(player.officialTitle === '大明皇帝' && player._preCaptureTitle === undefined, '太上皇复位·原号复还');
+assert(sb._ebs.some(function (e) { return e.indexOf('夺门之变成') >= 0; }), '复辟落起居注');
+
+console.log('③ 谋泄冷却');
+var sb3 = freshSandbox();
+var GM3 = sb3.GM, CC3 = sb3.TM.CaptiveCourt;
+GM3.chars[0]._captured = true;
+CC3._applyCourtOutcome(GM3, { type: 'proclaim_new', name: '朱祁钰' });
+GM3.chars[0]._captured = false;
+GM3._edictTracker.push({ turn: 31, content: '谋夺门复位' });
+GM3.turn = 32;
+assert(CC3._applyCourtOutcome(GM3, { type: 'crackdown' }).ok === true, '谋泄落账');
+assert(CC3._applyCourtOutcome(GM3, { type: 'restoration' }).ok === false, '冷却内 → 夺门拦(党羽星散须蛰伏)');
+GM3.turn = 32 + CC3.CRACKDOWN_COOLDOWN;
+assert(CC3._applyCourtOutcome(GM3, { type: 'restoration' }).ok === true, '冷却满 → 可再谋(蛰伏待时)');
+
+console.log('④ 监国');
+var sb4 = freshSandbox();
+sb4.GM.chars[0]._captured = true;
+assert(sb4.TM.CaptiveCourt._applyCourtOutcome(sb4.GM, { type: 'regent', name: '于谦' }).ok === true && sb4.GM._regent.name === '于谦', '立监国落账');
+assert(sb4.TM.CaptiveCourt._applyCourtOutcome(sb4.GM, { type: 'regent', name: '朱祁钰' }).ok === false, '已有监国 → 不重复');
+
+console.log('⑤ 兜底轨(双轨)：无 AI·被虏满 6 回合朝廷自立储君');
+var sb5 = freshSandbox();
+var GM5 = sb5.GM, CC5 = sb5.TM.CaptiveCourt;
+GM5.chars[0]._captured = true;
+GM5.turn = 40;
+CC5.tick(GM5);
+assert(!GM5._rivalEmperor && GM5.chars[0]._capturedSince === 40, '首 tick 记被虏起点·不立即立');
+GM5.turn = 43; CC5.tick(GM5);
+assert(!GM5._rivalEmperor, '未满 6 回合 → 观望');
+GM5.turn = 46; CC5.tick(GM5);
+assert(GM5._rivalEmperor && GM5._rivalEmperor.name === '朱见深', '满 6 回合 → 自立储君(childrenIds 候选优先)');
+assert(GM5.chars[0].officialTitle === '太上皇', '兜底轨同走宪法落账(太上皇)');
+
+console.log('⑥ flag OFF / 常态朝局零行为');
+var sb6 = freshSandbox();
+sb6.P.conf.revoltEntityEnabled = false;
+sb6.GM.chars[0]._captured = true;
+sb6.GM.turn = 99; sb6.TM.CaptiveCourt.tick(sb6.GM);
+assert(!sb6.GM._rivalEmperor && !sb6.GM.chars[0]._capturedSince, 'flag 关 → 零行为');
+var sb7 = freshSandbox();
+sb7.TM.CaptiveCourt.tick(sb7.GM);
+assert(!sb7.GM._courtInferTurn && !sb7.GM._rivalEmperor, '君安在位 → 本层不插手');
+
+console.log('⑦ 复辟旨匹配器');
+var sb8 = freshSandbox();
+sb8.GM._edictTracker.push({ turn: 1, content: '着人暗通南宫·候机反正' });
+assert(sb8.TM.CaptiveCourt._recentRestorationEdicts(sb8.GM).length === 1, '「反正」关键词命中');
+
+console.log('');
+if (failures.length) {
+  console.log('FAIL smoke-captive-court: ' + failures.length + ' 处失败');
+  failures.forEach(function (f) { console.log('  - ' + f); });
+  process.exit(1);
+}
+console.log('PASS smoke-captive-court (立新君三验/太上皇迁转/夺门三闸/谋泄冷却/监国/兜底轨/flag门/常态零行为)');

--- a/web/tm-captive-court.js
+++ b/web/tm-captive-court.js
@@ -1,0 +1,221 @@
+// ============================================================
+//  tm-captive-court.js — 悬朝演绎层·北狩残局朝廷侧（批七·2026-07-21·AI 主导）
+//
+//  owner 三拍板：①立新君交回合演绎 AI(朝臣自行酝酿·玩家在贼营收到消息=失控才是北狩之痛)
+//  ②新君立后玩家继续演太上皇(与裁决器「有储君继统」语义正交·夺门是翻盘牌)
+//  ③夺门照范式：玩家复辟诏令即谋划(走诏令管线·无独立UI)·AI 权衡朝局定成败。
+//
+//  君上 _captured(批四破京 captured 态)期间·朝廷由本层当一等演员：每回合悬朝 subcall——
+//  hold(观望·迎归/主战之争叙事)/regent(立监国)/proclaim_new(立新君·君上尊为太上皇)。
+//  君上归(赎驾链 release_captive)而新君在位=一朝二主：复辟旨(复辟/夺门/复位/正位关键词)
+//  喂入 subcall·AI 断 restoration(夺门成·太上皇复位)/crackdown(谋泄·蛰伏冷却)/hold。
+//
+//  宪法闸(只验不产)：人选须在档活人非俘非玩家·夺门须君已归+真有复辟旨+不在谋泄冷却·
+//  复位真复位(称号账本双清)。双轨：AI 缺席=被虏 6 回合朝廷自立储君(resolveHeir)兜底·
+//  兜底无监国无夺门(夺门之变非机械可断)。随 revoltEntityEnabled(破京链同族)。
+//  本文件为 _regent/_rivalEmperor/称号迁转的唯一写口(已登记 gm-writes owners)。
+// ============================================================
+(function (global) {
+  'use strict';
+
+  var FALLBACK_PROCLAIM_TURNS = 6;   // 兜底轨：被虏满 N 回合朝廷自立储君
+  var CRACKDOWN_COOLDOWN = 4;        // 谋泄后 N 回合内不再断夺门
+
+  function enabled() {
+    try { return !!(global.P && global.P.conf && global.P.conf.revoltEntityEnabled === true); }
+    catch (_) { return false; }
+  }
+  function _aiOn() {
+    try { return typeof global.callAI === 'function'; } catch (_) { return false; }
+  }
+  function _eb(msg) {
+    try { if (typeof global.addEB === 'function') global.addEB('国变', msg); } catch (_) {}
+  }
+  function _chron(G, text) {
+    try {
+      if (!Array.isArray(G._chronicle)) G._chronicle = [];
+      G._chronicle.push({ turn: G.turn || 0, date: G._gameDate || '', type: '国变', text: String(text).slice(0, 160), tags: ['悬朝', 'AI演绎'] });
+    } catch (_) {}
+  }
+  function _player(G) {
+    for (var i = 0; i < (G.chars || []).length; i++) {
+      var c = G.chars[i];
+      if (c && c.isPlayer && c.alive !== false) return c;
+    }
+    return null;
+  }
+  function _findChar(G, name) {
+    name = String(name || '').trim();
+    if (!name) return null;
+    for (var i = 0; i < (G.chars || []).length; i++) {
+      var c = G.chars[i];
+      if (c && String(c.name || '') === name) return c;
+    }
+    return null;
+  }
+  // 嗣位候选：储君(resolveHeir)优先·血胤/同族/高品阶补齐(供 prompt 与宪法验人)
+  function _heirCandidates(G, player) {
+    var out = [], seen = {};
+    function push(c) {
+      if (!c || !c.name || seen[c.name]) return;
+      if (c.isPlayer || c.alive === false || c._captured) return;
+      seen[c.name] = 1; out.push(c);
+    }
+    try { if (typeof global.resolveHeir === 'function') push(global.resolveHeir(player)); } catch (_) {}
+    (G.chars || []).forEach(function (c) {
+      if (out.length >= 4 || !c) return;
+      if (player && Array.isArray(player.childrenIds) && (player.childrenIds.indexOf(c.name) >= 0 || player.childrenIds.indexOf(c.id) >= 0)) push(c);
+    });
+    (G.chars || []).forEach(function (c) {
+      if (out.length >= 4 || !c) return;
+      if (player && c.family && player.family && c.family === player.family) push(c);
+    });
+    return out.slice(0, 4);
+  }
+  function _recentRestorationEdicts(G) {
+    var kw = ['复辟', '夺门', '复位', '正位', '反正'];
+    return (Array.isArray(G._edictTracker) ? G._edictTracker.slice(-8) : []).map(function (e) {
+      return String((e && (e.content || e.title)) || '');
+    }).filter(function (t) {
+      return t && kw.some(function (k) { return t.indexOf(k) >= 0; });
+    }).map(function (t) { return t.slice(0, 120); });
+  }
+
+  // ── 宪法闸落账（独立导出·smoke 不经真 AI 直验）──────────────────────────────
+  function _applyCourtOutcome(G, o) {
+    o = o || {};
+    var turn = G.turn || 0;
+    var player = _player(G);
+    var type = String(o.type || 'hold');
+    if (o.narrative) _chron(G, o.narrative);
+    switch (type) {
+      case 'regent': {
+        if (!player || !player._captured) return { ok: false, why: '君未蒙尘·无监国之设' };
+        if (G._regent && G._regent.name) return { ok: false, why: '已有监国' };
+        var rc = _findChar(G, o.name);
+        if (!rc || rc.isPlayer || rc.alive === false || rc._captured) return { ok: false, why: '监国人选不在档/不可任' };
+        G._regent = { name: rc.name, sinceTurn: turn };  // arch-ok 悬朝唯一写口·监国登记
+        rc._regent = true;
+        _eb('国不可一日无主·' + rc.name + '受命监国·摄行国政');
+        return { ok: true };
+      }
+      case 'proclaim_new': {
+        // 宪法：只在君上真被虏时可立·人选在档活人非俘非玩家
+        if (!player || !player._captured) return { ok: false, why: '君上未陷·不得另立' };
+        if (G._rivalEmperor && G._rivalEmperor.name) return { ok: false, why: '已立新君' };
+        var nc = _findChar(G, o.name);
+        if (!nc || nc.isPlayer || nc.alive === false || nc._captured) return { ok: false, why: '嗣君人选不在档/不可立' };
+        G._rivalEmperor = { name: nc.name, sinceTurn: turn };  // arch-ok 悬朝唯一写口·新君登记
+        nc._enthroned = true;
+        player._preCaptureTitle = player.officialTitle || '';
+        player.officialTitle = '太上皇';  // 拍板②：玩家继续演太上皇·遥尊虚号
+        if (G._regent && G._regent.name === nc.name) G._regent = null;  // arch-ok 同上·监国转正清位
+        _eb('★★社稷定策！朝廷奉 ' + nc.name + ' 践祚·遥尊蒙尘君上为太上皇——一朝二主·名分自此多事');
+        _chron(G, nc.name + '受群臣拥立即皇帝位·尊陷虏之君为太上皇');
+        try {
+          if (typeof global.NpcMemorySystem !== 'undefined' && typeof global.NpcMemorySystem.addMemory === 'function') {
+            global.NpcMemorySystem.addMemory(nc.name, '国难之际受群臣拥立践祚·旧主尚在敌营·此位得之非常', 10, 'career');
+          }
+        } catch (_) {}
+        return { ok: true };
+      }
+      case 'restoration': {
+        // 宪法三闸：君已归(非俘)+新君在位+真有复辟旨·且不在谋泄冷却
+        if (!player || player._captured) return { ok: false, why: '君犹在虏营·夺门无从谈起' };
+        if (!G._rivalEmperor || !G._rivalEmperor.name) return { ok: false, why: '并无新君·无门可夺' };
+        if (!_recentRestorationEdicts(G).length) return { ok: false, why: '未见复辟之谋(须玩家真下旨谋划)' };
+        if (G._restorationSetback && turn - (G._restorationSetback.turn || 0) < CRACKDOWN_COOLDOWN) return { ok: false, why: '谋泄未久·党羽星散·须蛰伏' };
+        var re = _findChar(G, G._rivalEmperor.name);
+        if (re) { re._enthroned = false; re._dethroned = true; re.officialTitle = String(o.demotedTitle || '逊位亲王').slice(0, 12); }
+        G._rivalEmperor = null;  // arch-ok 悬朝唯一写口·夺门复辟清位
+        G._restorationSetback = null;  // arch-ok 同上
+        if (player._preCaptureTitle != null) { player.officialTitle = player._preCaptureTitle; delete player._preCaptureTitle; }
+        _eb('★★夺门之变成！太上皇复即帝位·中外肃然·从龙者俱进·附新君者惴惴');
+        _chron(G, '太上皇复辟·' + (re ? re.name + '逊位' : '新君逊位') + '·朝局翻覆');
+        return { ok: true };
+      }
+      case 'crackdown': {
+        if (!player || player._captured || !G._rivalEmperor) return { ok: false, why: '无谋可泄' };
+        G._restorationSetback = { turn: turn };  // arch-ok 悬朝唯一写口·谋泄冷却
+        _eb('复辟之谋事泄！党羽被逮·太上皇门庭冷落·唯忍辱待时');
+        return { ok: true };
+      }
+      default:
+        return { ok: true, hold: true };
+    }
+  }
+
+  // ── 悬朝 subcall（AI 演朝廷）─────────────────────────────────────────────
+  async function courtScene(G) {
+    var player = _player(G);
+    if (!player) return null;
+    var captive = !!player._captured;
+    var rival = (G._rivalEmperor && G._rivalEmperor.name) || '';
+    var cands = _heirCandidates(G, player);
+    var lines = ['你是天命推演引擎的悬朝演绎官。' + (G.eraName || '') + '·T' + (G.turn || 0) + '·社稷非常之局——你替满朝文武定本回合走向(宁稳勿滥·一回合一动)。'];
+    if (captive) {
+      lines.push('【局面】君上' + player.name + '陷于「' + (player._capturedBy || '敌') + '」(' + (player._capturedLocation || '敌营') + ')·皇威' + ((G.huangwei && G.huangwei.index) || '?')
+        + (G._regent ? '·现监国=' + G._regent.name : '·尚无监国') + (rival ? '·已立新君=' + rival : '·未另立'));
+      if (cands.length) lines.push('【嗣位候选】' + cands.map(function (c) { return c.name + '(' + (c.officialTitle || '宗室') + ')'; }).join('·'));
+      lines.push('【可断】hold(观望·迎归论与另立论相争·narrative记之)·regent(name=立监国)·proclaim_new(name=立新君·尊君上为太上皇·主战派得势/虏势要挟日甚时之决)。');
+    } else if (rival) {
+      lines.push('【局面】太上皇' + player.name + '已归而新君' + rival + '在位——一朝二主·名分多事·皇威' + ((G.huangwei && G.huangwei.index) || '?'));
+      var reds = _recentRestorationEdicts(G);
+      if (reds.length) lines.push('【太上皇密谋(其诏即其谋)】' + reds.join('｜'));
+      else lines.push('【太上皇未见有谋】无复辟旨意·朝局维持。');
+      lines.push('【可断】hold(两宫相安或暗流·narrative记之)·restoration(夺门成·须太上皇真有其谋且朝中人心可用)·crackdown(谋泄被破·须真有其谋才谈得上泄)。');
+    } else {
+      return null;
+    }
+    lines.push('只返回 JSON：{"type":"hold|regent|proclaim_new|restoration|crackdown","name":"人选(regent/proclaim_new必填)","demotedTitle":"复辟后新君降号(restoration可选)","narrative":"本回合朝局一幕≤100字·史笔"}');
+    try {
+      var resp = await global.callAI(lines.join('\n'), 600, null, (typeof global._useSecondaryTier === 'function' && global._useSecondaryTier()) ? 'secondary' : undefined, { id: 'captive-court' });
+      var text = (resp && typeof resp === 'object') ? (resp.text || resp.content || '') : String(resp || '');
+      var j = (typeof global.robustParseJSON === 'function') ? global.robustParseJSON(text) : JSON.parse(text);
+      if (j && j.type) return _applyCourtOutcome(G, j);
+    } catch (_eC) {}
+    return null;
+  }
+
+  // ── 每回合 tick（SettlementPipeline·AI 排 job·无 AI 走兜底轨）────────────────
+  function tick(G) {
+    if (!enabled()) return;
+    G = G || global.GM;
+    if (!G) return;
+    var player = _player(G);
+    if (!player) return;
+    var captive = !!player._captured;
+    var rival = !!(G._rivalEmperor && G._rivalEmperor.name);
+    if (!captive && !rival) return;  // 常态朝局·本层不插手
+    var turn = G.turn || 0;
+    if (_aiOn()) {
+      if (G._courtInferTurn === turn) return;
+      G._courtInferTurn = turn;  // arch-ok 悬朝演绎回合戳·幂等(与 _wtAuditTurn 同范式)
+      var job = function () { return courtScene(G); };
+      if (typeof global._enqueuePostTurnJob === 'function') global._enqueuePostTurnJob('captiveCourt', job);
+      else job();
+      return;
+    }
+    // 兜底轨(双轨)：被虏满 N 回合·朝廷自立储君·此外不机械断(监国/夺门非机械可断)
+    if (captive && !rival) {
+      if (!player._capturedSince) player._capturedSince = turn;
+      if (turn - player._capturedSince >= FALLBACK_PROCLAIM_TURNS) {
+        var cands = _heirCandidates(G, player);
+        if (cands.length) _applyCourtOutcome(G, { type: 'proclaim_new', name: cands[0].name, narrative: '君上陷虏日久·群臣定策立新君以安社稷' });
+      }
+    }
+  }
+
+  var API = { tick: tick, courtScene: courtScene, _applyCourtOutcome: _applyCourtOutcome, _heirCandidates: _heirCandidates, _recentRestorationEdicts: _recentRestorationEdicts, enabled: enabled, FALLBACK_PROCLAIM_TURNS: FALLBACK_PROCLAIM_TURNS, CRACKDOWN_COOLDOWN: CRACKDOWN_COOLDOWN };
+  global.TM = global.TM || {};
+  global.TM.CaptiveCourt = API;
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+
+  try {
+    if (global.SettlementPipeline && typeof global.SettlementPipeline.register === 'function') {
+      global.SettlementPipeline.register('captiveCourt', '悬朝演绎', function () {
+        try { tick(global.GM); } catch (_eT) {}
+      }, 92, 'perturn');
+    }
+  } catch (_eR) {}
+})(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## owner 三拍板落地

①**立新君交回合演绎 AI**——朝臣自行酝酿，你在贼营里收到消息（失控才是北狩之痛）②**新君立后你继续演太上皇**（与裁决器继统语义正交，夺门是你的翻盘牌）③**夺门照范式**——复辟旨即谋划，走诏令管线，无独立 UI。

## 悬朝演绎层（`tm-captive-court.js`·随 `revoltEntityEnabled`·结算序 92）

**君被虏期间**：朝廷由悬朝 subcall 当一等演员——`hold`（迎归论 vs 另立论之争入史）/ `regent`（立监国）/ `proclaim_new`（**立新君**·尊你为太上皇·原号留档）。嗣位候选=储君(resolveHeir)→血胤→同族，供 AI 拣择。

**你归銮后（赎驾链）而新君在位=一朝二主**：你的**复辟旨**（复辟/夺门/复位/正位/反正）喂进 subcall——AI 权衡「太上皇真有其谋 + 朝中人心」断 `restoration`（夺门成·新君逊位**降号由 AI 定**·你复位原号复还）/ `crackdown`（谋泄·党羽被逮·4 回合冷却蛰伏）/ `hold`（两宫暗流）。

## 宪法闸（`_applyCourtOutcome` 独立导出·smoke 直验）

立新君三验（须真被虏/人选在档活人非俘非玩家/不重复立）· 夺门三闸（君已归+新君在位+**真有复辟旨**）+谋泄冷却 · 新君得位记忆入 NpcMemorySystem（「此位得之非常」——后患伏笔自然生长）。**双轨兜底**：无 AI 时被虏满 6 回合朝廷自立储君；监国与夺门不机械断（政变非公式可断）。

## 验证

新 `smoke-captive-court` **24 断言**——**土木堡全剧本在 smoke 里走通**：朱祁镇被虏 → 立朱祁钰 → 尊太上皇 → 密旨反正 → 夺门 → 复位、郕王降号。`ci-smokes` **784 PASS** · `lint-arch-all` **8/8** · 基线 `--check` PASS。

🤖 Generated with [Claude Code](https://claude.com/claude-code)