### PR TITLE
设衙章程演绎层批一：设新衙门AI拟章程·廷议裁定按章开衙（flag默认关）

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2111,8 +2111,8 @@
     },
     {
       "path": "index.html",
-      "sha256": "58a628fe259345a8a4f307faa33ac1399a78a4de8746c3046828dbb56ec7ef26",
-      "size": 65072
+      "sha256": "a12f9c6682347f98e0505c4b01960a2d4e8f330cfad997790921d1f278634868",
+      "size": 65296
     },
     {
       "path": "INDEX.md",
@@ -4066,8 +4066,8 @@
     },
     {
       "path": "tm-endturn-prompt.js",
-      "sha256": "7df93589397da04131f2b1d8be158c9426b96264b7837ab8a18d355bf967235d",
-      "size": 363225
+      "sha256": "700cb2aad80ab96bc0a64130f191400d4cae301cbaabfe586bef64183e5f721a",
+      "size": 363839
     },
     {
       "path": "tm-endturn-province.js",
@@ -4885,6 +4885,11 @@
       "size": 5745
     },
     {
+      "path": "tm-office-charter.js",
+      "sha256": "7395954a6bc6d3b5489dc01a1f67da831472ad03ba35e5c90b2fd6a36e537815",
+      "size": 11724
+    },
+    {
       "path": "tm-office-dutystate.js",
       "sha256": "6ca7979f02960b305d4e7f9a24d881978d5b5fb16366083a86f437cc09e5dd42",
       "size": 9336
@@ -4901,8 +4906,8 @@
     },
     {
       "path": "tm-office-flags.js",
-      "sha256": "6044838abd3de9ffd07fadc44916691e6126dd5a1b63de84a051d1fb2871d295",
-      "size": 2935
+      "sha256": "b13474c9e809ccb7e01679adeddaf5fe525391a645170ffe1028c283458b5dda",
+      "size": 3119
     },
     {
       "path": "tm-office-panel.js",
@@ -4921,8 +4926,8 @@
     },
     {
       "path": "tm-office-reform.js",
-      "sha256": "5315e7434cb0b06058b8c4e5593ca212f2b985c9e06b6064941244e1ce999bb0",
-      "size": 19588
+      "sha256": "4d7343619e9c7aece2adf66347c47f3694962265cd2f74fc3d4d75dd46b5e68a",
+      "size": 25351
     },
     {
       "path": "tm-office-runtime-summary-appoint.js",
@@ -5016,8 +5021,8 @@
     },
     {
       "path": "tm-patches.js",
-      "sha256": "b93cfb9c109cc359655c543d16b6a2b8a2c3b3780c480edda9ac07d52f09e624",
-      "size": 181944
+      "sha256": "18172bbb50fc2292d0b5470098d537ffb32fcb06f51e1f8ad233f2def4327bb3",
+      "size": 182246
     },
     {
       "path": "tm-pause-fab.js",
@@ -5331,8 +5336,8 @@
     },
     {
       "path": "tm-var-drawers.js",
-      "sha256": "f1d699eff1344eef2f4cfed54378d27e1013671bba09986519d8f9fa2fffb63e",
-      "size": 117489
+      "sha256": "a98ba1af93cc0819cc97f09a9fa6d63506f8f3136c468c9e63a0e34d3ebc7e14",
+      "size": 118201
     },
     {
       "path": "tm-wendui-persona-views.js",

--- a/web/index.html
+++ b/web/index.html
@@ -568,6 +568,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-office-dutystate.js?v=20260620-officeact"></script>
 <script src="tm-office-authority.js?v=20260620-officeact"></script>
 <script src="tm-office-reform.js?v=20260620-officeact"></script>
+<script src="tm-office-charter.js?v=20260721"></script><!-- 设衙门批一·设衙章程演绎层(拟制期AI拟正名/职掌/官职表/首任荐单/开办费·裁定准落全结构·flag officeCharterEnabled默认关) -->
 <script src="tm-office-recall-agent.js?v=20260620-officeact"></script>
 <!-- R133 (2026-04-25) tm-npc-engine 拆分 → engine + decision -->
 <script src="tm-npc-engine.js?v=2026050701"></script>

--- a/web/scripts/smoke-office-charter.js
+++ b/web/scripts/smoke-office-charter.js
@@ -1,0 +1,219 @@
+// smoke-office-charter.js — 设衙章程演绎层（设新衙门批一·2026-07-21）
+//
+// 不经真 AI：canned 章程原料直灌 _validateCharter 验宪法闸（品级须在表/职权⊆九权且≤3/
+// 员额与俸禄夹取/首任只荐在档活人/重名回退玩家原名/开办费夹取），再走 adjudicatePendingReforms
+// 验落树全结构（准=按章开衙·部分=打折·国库不支=改拖拖满则寝·荐单入诏书建议库只荐不任）。
+// 双轨：无章程→裸壳落树(原行为)。tick 闸：flag 关/无 AI 不拟·幂等不重派·单官职增设不拟章。
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var vm = require('vm');
+
+var ROOT = path.join(__dirname, '..');
+var failures = [];
+function assert(cond, msg) {
+  if (cond) { console.log('  PASS ' + msg); }
+  else { failures.push(msg); console.log('  FAIL ' + msg); }
+}
+
+var RANKS = [
+  { id: 'z3', label: '正三品', level: 5, salary: 65 },
+  { id: 'z5', label: '正五品', level: 9, salary: 38 },
+  { id: 'z7', label: '正七品', level: 13, salary: 20 }
+];
+
+function freshSandbox(opts) {
+  opts = opts || {};
+  var sb = { console: console };
+  sb.window = sb; sb.global = sb;
+  sb._ebs = [];
+  sb.addEB = function (cat, msg) { sb._ebs.push(cat + '·' + msg); };
+  sb._jobs = [];
+  sb._enqueuePostTurnJob = function (id, fn) { sb._jobs.push({ id: id, fn: fn }); };
+  sb.SettlementPipeline = { register: function () {} };
+  sb._activeRankHierarchy = function () { return RANKS; };
+  sb._flags = { officeCharterEnabled: !!opts.charterOn };
+  sb.officeFlagOn = function (n) { return !!sb._flags[n]; };
+  if (opts.callAI) sb.callAI = opts.callAI;
+  sb.GM = {
+    turn: 10,
+    huangwei: { index: 50 }, huangquan: { index: 50 },
+    guoku: { balance: (opts.balance != null ? opts.balance : 100000), ledgers: { money: { stock: (opts.balance != null ? opts.balance : 100000) } } },
+    officeTree: [
+      { name: '户部', desc: '掌钱谷', positions: [{ name: '尚书', rank: '正三品', holder: '钱谷才', headCount: 1, actualCount: 1, additionalHolders: [], establishedCount: 1, vacancyCount: 0, actualHolders: [{ name: '钱谷才', generated: true }] }], subs: [], functions: [] }
+    ],
+    chars: [
+      { name: '天子', isPlayer: true, alive: true },
+      { name: '钱谷才', alive: true, loyalty: 80, administration: 85, officialTitle: '户部尚书' },
+      { name: '干吏乙', alive: true, loyalty: 60, administration: 70 },
+      { name: '已故者', alive: false, loyalty: 60, administration: 90 }
+    ],
+    _pendingReforms: []
+  };
+  sb.findCharByName = function (n) {
+    for (var i = 0; i < sb.GM.chars.length; i++) if (sb.GM.chars[i].name === n) return sb.GM.chars[i];
+    return null;
+  };
+  sb.P = { conf: {} };
+  vm.createContext(sb);
+  ['tm-office-reform.js', 'tm-office-charter.js'].forEach(function (f) {
+    vm.runInContext(fs.readFileSync(path.join(ROOT, f), 'utf8'), sb, { filename: f });
+  });
+  return sb;
+}
+
+var RAW = {
+  name: '市舶提举司',
+  desc: '掌番舶抽解博买·通海贸之利以裕国用·兼稽奸私（此句超长部分应被截断到四十字以内）',
+  positions: [
+    { name: '提举', rank: '正五品', count: 20, powers: ['taxCollect', 'bogusPower', 'supervise', 'judicial', 'works'], authority: 'bogus', salary: 999, duties: '总司抽解博买' },
+    { name: '副提举', rank: '正十三品', count: 1, powers: ['taxCollect'], salary: 30 },
+    { name: 'X', rank: '正七品', count: 1 },
+    { name: '吏目', rank: '正七品', count: 2, powers: [], authority: 'execution', salary: 10, duties: '掌文牍' }
+  ],
+  heads: [
+    { position: '提举', name: '钱谷才', reason: '晓畅钱谷·可当此任' },
+    { position: '不存在职', name: '干吏乙' },
+    { position: '吏目', name: '已故者' },
+    { position: '吏目', name: '天子' }
+  ],
+  setupCost: 999999
+};
+
+console.log('① _validateCharter 宪法闸');
+var sb = freshSandbox();
+var OC = sb.TM.OfficeCharter;
+var item0 = { reformDetail: '增设', dept: '市舶司' };
+var v = OC._validateCharter(sb.GM, JSON.parse(JSON.stringify(RAW)), item0);
+assert(!!v, '合规章程通过验闸');
+assert(v.name === '市舶提举司', '正名收下(不与现有衙门重名)');
+assert(v.desc.length <= 40, '职掌截断≤40');
+assert(v.positions.length === 2, '四职进两职：品级不在表(正十三品)与名过短(X)皆黜落');
+var p0 = v.positions[0];
+assert(p0.count === 8, '员额 20→夹取封顶 8');
+assert(p0.salary === 76, '月俸 999→夹取品级俸×2(38×2=76)');
+assert(p0.powers.length === 3 && p0.powers.indexOf('bogusPower') < 0, '职权滤野键·封顶3项');
+assert(p0.authority === '', '非法 authority 置空');
+assert(v.positions[1].salary === 10, '月俸 10=正七品俸(20)×0.5 下限·恰在 band 内不动');
+assert(v.heads.length === 1 && v.heads[0].name === '钱谷才', '荐单只留在档活人非玩家且职位实存者');
+assert(v.setupCost === 30000, '开办费 999999→夹取上限 30000');
+var vDup = OC._validateCharter(sb.GM, Object.assign(JSON.parse(JSON.stringify(RAW)), { name: '户部' }), item0);
+assert(vDup.name === '市舶司', '正名与现有衙门重名→回退玩家原名');
+var vBad = OC._validateCharter(sb.GM, { name: '空衙', positions: [{ name: '妄职', rank: '正十三品', count: 1 }] }, item0);
+assert(vBad === null, '全职位皆废→章程作废(裸壳双轨)');
+
+console.log('② tick 派单闸');
+var sbT = freshSandbox({ charterOn: false, callAI: function () { return Promise.resolve('{}'); } });
+sbT.GM._pendingReforms.push({ _key: 'k1', reformDetail: '增设', dept: '市舶司', status: '拟制中', proposedTurn: 10 });
+sbT.TM.OfficeCharter.tick(sbT.GM);
+assert(sbT._jobs.length === 0 && sbT.GM._pendingReforms[0]._charterPending == null, 'flag 关→不拟章');
+var sbT2 = freshSandbox({ charterOn: true });
+sbT2.GM._pendingReforms.push({ _key: 'k1', reformDetail: '增设', dept: '市舶司', status: '拟制中', proposedTurn: 10 });
+sbT2.TM.OfficeCharter.tick(sbT2.GM);
+assert(sbT2._jobs.length === 0, '无 callAI→不拟章(裁定时裸壳兜底=双轨)');
+var sbT3 = freshSandbox({ charterOn: true, callAI: function () { return Promise.resolve('{}'); } });
+sbT3.GM._pendingReforms.push({ _key: 'k1', reformDetail: '增设', dept: '市舶司', status: '拟制中', proposedTurn: 10 });
+sbT3.GM._pendingReforms.push({ _key: 'k2', reformDetail: '增设', dept: '户部', position: '主事', status: '拟制中', proposedTurn: 10 });
+sbT3.GM._pendingReforms.push({ _key: 'k3', reformDetail: '裁撤', dept: '户部', status: '拟制中', proposedTurn: 10 });
+sbT3.TM.OfficeCharter.tick(sbT3.GM);
+assert(sbT3._jobs.length === 1 && sbT3._jobs[0].id === 'officeCharter_k1', '只为衙门级增设拟章(单官职增设/裁撤不拟)');
+assert(sbT3.GM._pendingReforms[0]._charterPending === 10, '拟章戳落账');
+sbT3.TM.OfficeCharter.tick(sbT3.GM);
+assert(sbT3._jobs.length === 1, '幂等：已在拟不重派');
+
+console.log('③ forgeCharter 子调用(mock AI)');
+var sbF = freshSandbox({ charterOn: true, callAI: function (prompt) {
+  sbF._prompt = prompt;
+  return Promise.resolve({ text: JSON.stringify(RAW) });
+} });
+var itemF = { _key: 'kf', reformDetail: '增设', dept: '市舶司', reason: '通海贸', status: '拟制中', proposedTurn: 10, _charterPending: 10 };
+sbF.GM._pendingReforms.push(itemF);
+(async function () {
+  var got = await sbF.TM.OfficeCharter.forgeCharter(sbF.GM, itemF);
+  assert(!!got && itemF._charter && itemF._charter.name === '市舶提举司', '章程锻成落 item._charter');
+  assert(itemF._charterPending === undefined, '拟章戳清除');
+  assert(sbF._prompt.indexOf('taxCollect=征税') >= 0 && sbF._prompt.indexOf('正五品') >= 0, 'prompt 携九权词表与本朝品级表');
+  assert(sbF._prompt.indexOf('户部') >= 0, 'prompt 携现有衙门(防重名与职掌相侵失察)');
+  assert(sbF._ebs.some(function (e) { return e.indexOf('开衙章程已拟') >= 0; }), '章程既拟入起居注');
+
+  console.log('④ 准 band·按章开衙落全结构');
+  var sb4 = freshSandbox();
+  var GM4 = sb4.GM;
+  var it4 = { _key: 'k4', reformDetail: '增设', dept: '市舶司', status: '拟制中', proposedTurn: 8, stalls: 0, _charter: v };
+  GM4._pendingReforms.push(it4);
+  var res4 = sb4.adjudicatePendingReforms(GM4, { authority: 100 });
+  assert(res4.length === 1 && res4[0].band === '准' && res4[0].applied === true, '威权碾压→准行落树');
+  var node4 = GM4.officeTree.filter(function (n) { return n.name === '市舶提举司'; })[0];
+  assert(!!node4, '正名落定：树上是章程正名(item.dept 同步改)且 it4.dept=' + it4.dept);
+  assert(node4 && node4.positions.length === 2, '按章程落两职(非裸壳)');
+  var np = node4 && node4.positions[0];
+  assert(np && np.establishedCount === 8 && np.vacancyCount === 8 && np.holder === '' && Array.isArray(np.actualHolders), '双层编制模型字段齐全·虚位以待');
+  assert(np && np.powers && np.powers.taxCollect === true && np.salary === 76 && np.perPersonSalary.indexOf('76') >= 0, '职权与月俸随章落树(职权舆图/官俸结算自动接手)');
+  assert(GM4.guoku.balance === 100000 - 30000 && GM4.guoku.ledgers.money.stock === GM4.guoku.balance, '开办费国库真扣·账本同步');
+  assert(Array.isArray(GM4._edictSuggestions) && GM4._edictSuggestions.length === 1 && GM4._edictSuggestions[0].content.indexOf('授钱谷才为') >= 0, '首任荐单入诏书建议库(只荐不任·下旨方成任命)');
+  assert(sb4._ebs.some(function (e) { return e.indexOf('诏书建议库') >= 0; }), '荐单入起居注');
+
+  console.log('⑤ 部分 band·打折开衙');
+  var sb5 = freshSandbox();
+  var ch5 = { name: '织造局', desc: '掌织造', setupCost: 1000, heads: [{ position: '大使', name: '干吏乙', reason: '' }, { position: '织丞', name: '钱谷才', reason: '' }], positions: [
+    { name: '大使', rank: '正五品', count: 4, powers: ['works'], authority: 'execution', salary: 38, duties: '' },
+    { name: '副使', rank: '正七品', count: 4, powers: [], authority: '', salary: 20, duties: '' },
+    { name: '织丞', rank: '正七品', count: 4, powers: [], authority: '', salary: 20, duties: '' },
+    { name: '库子', rank: '正七品', count: 4, powers: [], authority: '', salary: 20, duties: '' }
+  ] };
+  var it5 = { _key: 'k5', reformDetail: '增设', dept: '织造局', status: '拟制中', proposedTurn: 8, stalls: 0, _charter: ch5 };
+  sb5.GM._pendingReforms.push(it5);
+  var res5 = sb5.adjudicatePendingReforms(sb5.GM, { authority: 0 });
+  assert(res5.length === 1 && res5[0].band === '部分' && res5[0].applied === true, '威权不足以碾压→勉强部分得行');
+  var node5 = sb5.GM.officeTree.filter(function (n) { return n.name === '织造局'; })[0];
+  assert(node5 && node5.positions.length === 2, '部分band：四职打折留两职(主官居首必留)');
+  assert(node5 && node5.positions[0].establishedCount === 2, '员额减半 4→2');
+  assert(sb5.GM._edictSuggestions && sb5.GM._edictSuggestions.length === 1 && sb5.GM._edictSuggestions[0].content.indexOf('干吏乙') >= 0, '被砍职位(织丞)之荐不入建议库·实落职位(大使)之荐仍入');
+
+  console.log('⑥ 国库闸·帑廪不支改拖·拖满则寝');
+  var sb6 = freshSandbox({ balance: 100 });
+  var it6 = { _key: 'k6', reformDetail: '增设', dept: '市舶司', status: '拟制中', proposedTurn: 8, stalls: 0, _charter: JSON.parse(JSON.stringify(v)) };
+  sb6.GM._pendingReforms.push(it6);
+  var res6 = sb6.adjudicatePendingReforms(sb6.GM, { authority: 100 });
+  assert(res6.length === 1 && res6[0].band === '拖' && res6[0].guokuShort === true, '裁定虽准·帑廪不支→改拖');
+  assert(sb6.GM.officeTree.length === 1 && sb6.GM.guoku.balance === 100, '树不动·银不扣');
+  assert(sb6.GM._pendingReforms.length === 1 && it6.stalls === 1, '议留拟制·记一拖');
+  assert(sb6._ebs.some(function (e) { return e.indexOf('帑廪不支而缓') >= 0; }), '有司执奏入起居注');
+  var res6b = sb6.adjudicatePendingReforms(sb6.GM, { authority: 100 });
+  assert(res6b.length === 1 && res6b[0].band === '驳' && it6.status === '驳', '再拖满(2)→其议遂寝');
+  assert(sb6.GM.officeTree.length === 1, '寝议不落树');
+  var sb6c = freshSandbox({ balance: 100000 });
+  var it6c = { _key: 'k6c', reformDetail: '增设', dept: '市舶司', status: '拟制中', proposedTurn: 8, stalls: 1, _charter: JSON.parse(JSON.stringify(v)) };
+  sb6c.GM._pendingReforms.push(it6c);
+  var res6c = sb6c.adjudicatePendingReforms(sb6c.GM, { authority: 100 });
+  assert(res6c[0].band === '准' && sb6c.GM.guoku.balance === 70000, '府库充盈后再裁→照准·开办费实扣');
+
+  console.log('⑦ 双轨·无章程=裸壳(原行为零回归)');
+  var sb7 = freshSandbox();
+  var it7 = { _key: 'k7', reformDetail: '增设', dept: '宣抚司', status: '拟制中', proposedTurn: 8, stalls: 0 };
+  sb7.GM._pendingReforms.push(it7);
+  var res7 = sb7.adjudicatePendingReforms(sb7.GM, { authority: 100 });
+  var node7 = sb7.GM.officeTree.filter(function (n) { return n.name === '宣抚司'; })[0];
+  assert(res7[0].band === '准' && node7 && node7.positions.length === 0, '无章程→裸壳落树(双轨)');
+  assert(sb7.GM.guoku.balance === 100000 && !sb7.GM._edictSuggestions, '无章程→不扣开办费·无荐单');
+
+  console.log('⑧ 静态契约·接线到位');
+  var idx = fs.readFileSync(path.join(ROOT, 'index.html'), 'utf8');
+  assert(idx.indexOf('tm-office-charter.js') >= 0, 'index.html 装载 tm-office-charter.js');
+  var flagsSrc = fs.readFileSync(path.join(ROOT, 'tm-office-flags.js'), 'utf8');
+  assert(flagsSrc.indexOf("'officeCharterEnabled'") >= 0, 'officeCharterEnabled 入 OfficeFlags.LIST');
+  var patches = fs.readFileSync(path.join(ROOT, 'tm-patches.js'), 'utf8');
+  assert(patches.indexOf("officeCharterEnabled") >= 0, '设置面板有设衙章程开关行');
+  var prompt = fs.readFileSync(path.join(ROOT, 'tm-endturn-prompt.js'), 'utf8');
+  assert(prompt.indexOf('_charter') >= 0, '廷议裁定段携章程供 AI 参酌');
+  var drawers = fs.readFileSync(path.join(ROOT, 'tm-var-drawers.js'), 'utf8');
+  assert(drawers.indexOf('_charter') >= 0, '拟制中抽屉可御览章程');
+
+  console.log('');
+  if (failures.length) {
+    console.log('FAILURES (' + failures.length + '):');
+    failures.forEach(function (f) { console.log('  - ' + f); });
+    process.exit(1);
+  }
+  console.log('smoke-office-charter: ALL PASS');
+})().catch(function (e) { console.error('SMOKE CRASH:', e); process.exit(1); });

--- a/web/tm-endturn-prompt.js
+++ b/web/tm-endturn-prompt.js
@@ -1735,6 +1735,10 @@
             var _rr = computeReformResistance(GM, it, { authority: _raAuth, difficulty: _raDiff });
             var _rw = _rr.affected.map(function (a) { return a.holder; }).join('、');
             tp += '  · ' + (it.reformDetail || '') + ' ' + it.dept + (it.position ? ('·' + it.position) : '') + '：机械抵抗' + _rr.resistance + '·威权' + Math.round(_raAuth) + ' → 机械band【' + _rr.band + '】' + (_rw ? ('·触动' + _rw) : '·无人失权') + '\n';
+            // 设衙章程已拟(officeCharterEnabled·演绎层产)→廷议裁定可参酌章程职权之侵夺(占何权·几职几员·糜几两)
+            if (it._charter && Array.isArray(it._charter.positions)) {
+              tp += '    ↳章程已拟：«' + (it._charter.name || it.dept) + '»' + it._charter.positions.map(function (cp) { return cp.name + '(' + cp.rank + '×' + cp.count + (cp.powers && cp.powers.length ? '·权' + cp.powers.length + '项' : '') + ')'; }).join('·') + '·开办约' + it._charter.setupCost + '两——所侵之权谁家旧掌·裁定时并叙\n';
+            }
           });
           tp += '  格式：reform_verdicts:[{dept,position?,verdict,reason}]\n';
         }

--- a/web/tm-office-charter.js
+++ b/web/tm-office-charter.js
@@ -1,0 +1,192 @@
+// ============================================================
+//  tm-office-charter.js — 设衙章程演绎层（设新衙门批一·2026-07-21）
+//
+//  实体化≠模板化：玩家下诏设新衙门后·拟制态期间由 AI 拟「开衙章程」——正名/职掌/
+//  官职表(名·品级·编制·职权·月俸)/首任荐单/开办费。廷议裁定仍走 tm-office-reform
+//  抵抗管线(宪法层)·准/部分落树时按章程落全结构；AI 缺席或章程验废→现行裸壳落树=双轨零回归。
+//
+//  宪法闸(_validateCharter·只验不产)：品级须在本朝品级表(_activeRankHierarchy·跨朝代)·
+//  职权⊆九权词表且每职≤3·职数≤6·员额1-8·月俸夹取品级俸×[0.5,2]·开办费夹取[500,30000]·
+//  首任只荐在档活人(非玩家·≤3)·重名正名回退玩家原名。开办费国库真扣在裁定落树侧(tm-office-reform)。
+//
+//  flag officeCharterEnabled(默认关·设置→官制活化细粒度)·只对「增设衙门级」拟章·
+//  增设单官职(oc.position)不拟章(照旧)。承载=_enqueuePostTurnJob·失败静默回裸壳。
+// ============================================================
+(function (global) {
+  'use strict';
+
+  var MAX_POSITIONS = 6;      // 一衙职数封顶(防 AI 开衙即造小朝廷)
+  var MAX_HEADCOUNT = 8;      // 单职员额封顶
+  var MAX_POWERS_PER_POS = 3; // 单职职权封顶
+  var SETUP_COST_MIN = 500, SETUP_COST_MAX = 30000;   // 开办费夹取带(两)
+  // 九权词表(镜像 tm-office-powermap POWER_LABEL·勿自造键)
+  var POWER_KEYS = ['taxCollect', 'militaryCommand', 'appointment', 'impeach', 'supervise', 'yinBu', 'judicial', 'works', 'drafting'];
+  var POWER_CN = { taxCollect: '征税', militaryCommand: '调兵', appointment: '辟署', impeach: '弹劾', supervise: '监察', yinBu: '荐荫', judicial: '刑狱', works: '营造', drafting: '票拟' };
+  var AUTH_SET = { decision: 1, execution: 1, advisory: 1, supervision: 1 };
+
+  function enabled() {
+    try { return typeof global.officeFlagOn === 'function' && global.officeFlagOn('officeCharterEnabled'); }
+    catch (_) { return false; }
+  }
+  function _aiOn() {
+    try { return typeof global.callAI === 'function'; } catch (_) { return false; }
+  }
+  function _eb(msg) {
+    try { if (typeof global.addEB === 'function') global.addEB('官制改革', msg); } catch (_) {}
+  }
+  function _rankTable() {
+    try { if (typeof global._activeRankHierarchy === 'function') return global._activeRankHierarchy() || null; } catch (_) {}
+    return null;
+  }
+  function _rankEntry(H, rankStr) {
+    if (!H || !rankStr) return null;
+    for (var i = 0; i < H.length; i++) { if (H[i] && H[i].label && String(rankStr).indexOf(H[i].label) >= 0) return H[i]; }
+    return null;
+  }
+  function _findChar(name) {
+    try { if (typeof global.findCharByName === 'function') return global.findCharByName(name); } catch (_) {}
+    return null;
+  }
+  // 衙门级增设判定(与 tm-office-reform._reformKind 的 add 语义对齐·但只认衙门级=无 position)
+  function _isDeptAdd(item) {
+    if (!item || item.position) return false;
+    return /增设|新设|增置|创设/.test(String(item.reformDetail || ''));
+  }
+  function _treeNames(G) {
+    var out = [];
+    (function walk(ns) {
+      (ns || []).forEach(function (n) { if (n && n.name) { out.push(n.name); if (n.subs) walk(n.subs); } });
+    })(G.officeTree);
+    return out;
+  }
+
+  // ── 宪法闸：AI 章程原料→合规章程(废则 null→裸壳双轨) ──────────────────────
+  function _validateCharter(G, j, item) {
+    if (!j || typeof j !== 'object') return null;
+    var H = _rankTable();
+    var existing = _treeNames(G);
+    // 目标名：顶层增设=dept·某部下增设子衙=newDept(AI 写端 office_changes 形态)
+    var playerName = item ? String(item.newDept || item.dept || '') : '';
+    // 正名：2-12字·与现有衙门重名→回退玩家原名(玩家原名即目标名·不算重名)
+    var name = String(j.name || '').trim().slice(0, 12);
+    if (!name || (name !== playerName && existing.indexOf(name) >= 0)) name = playerName;
+    if (!name) return null;
+    var positions = [];
+    (Array.isArray(j.positions) ? j.positions : []).slice(0, MAX_POSITIONS).forEach(function (p) {
+      if (!p || typeof p !== 'object') return;
+      var pn = String(p.name || '').trim().slice(0, 14);
+      if (pn.length < 2) return;
+      var re = H ? _rankEntry(H, p.rank) : null;
+      if (H && !re) return;                       // 有品级表则品级必须在表(宪法闸)·无表(裸跑)从宽
+      var rank = re ? (String(p.rank).trim() || re.label) : String(p.rank || '').slice(0, 10);
+      var baseSal = re ? (Number(re.salary) || 20) : 20;
+      var sal = Math.round(Number(p.salary));
+      if (!isFinite(sal) || sal <= 0) sal = baseSal;
+      sal = Math.max(Math.ceil(baseSal * 0.5), Math.min(baseSal * 2, sal));   // 月俸循品级俸 band
+      var cnt = Math.round(Number(p.count));
+      if (!isFinite(cnt) || cnt < 1) cnt = 1;
+      if (cnt > MAX_HEADCOUNT) cnt = MAX_HEADCOUNT;
+      var powers = (Array.isArray(p.powers) ? p.powers : []).filter(function (k) { return POWER_KEYS.indexOf(k) >= 0; }).slice(0, MAX_POWERS_PER_POS);
+      var authority = (p.authority && AUTH_SET[p.authority]) ? p.authority : '';
+      positions.push({
+        name: pn, rank: rank, count: cnt, salary: sal,
+        powers: powers, authority: authority,
+        duties: String(p.duties || '').slice(0, 30)
+      });
+    });
+    if (!positions.length) return null;
+    var heads = [];
+    var posNames = positions.map(function (p) { return p.name; });
+    (Array.isArray(j.heads) ? j.heads : []).forEach(function (h) {
+      if (heads.length >= 3 || !h || typeof h !== 'object') return;
+      var hp = String(h.position || '');
+      if (posNames.indexOf(hp) < 0) return;
+      var ch = _findChar(String(h.name || ''));
+      if (!ch || ch.alive === false || ch.isPlayer) return;
+      if (heads.some(function (x) { return x.name === ch.name; })) return;
+      heads.push({ position: hp, name: ch.name, reason: String(h.reason || '').slice(0, 30) });
+    });
+    var setup = Math.round(Number(j.setupCost));
+    if (!isFinite(setup) || setup <= 0) setup = 2000 * positions.length;
+    setup = Math.max(SETUP_COST_MIN, Math.min(SETUP_COST_MAX, setup));
+    return {
+      name: name, desc: String(j.desc || '').slice(0, 40),
+      positions: positions, heads: heads, setupCost: setup
+    };
+  }
+
+  // ── 章程 subcall(拟制态期间一次·失败静默→裸壳双轨) ────────────────────────
+  function _buildPrompt(G, item) {
+    var H = _rankTable();
+    var rankLine = H ? H.map(function (r) { return r.label; }).join('·') : '(依本朝常制)';
+    var tops = (G.officeTree || []).map(function (n) {
+      var subs = (n.subs || []).map(function (s) { return s.name; }).filter(Boolean);
+      return n.name + (subs.length ? ('(' + subs.slice(0, 6).join('/') + ')') : '');
+    }).slice(0, 14).join('·');
+    var cands = (G.chars || [])
+      .filter(function (c) { return c && c.alive !== false && !c.isPlayer && !c._revoltEntity && (Number(c.loyalty) || 50) >= 40; })
+      .sort(function (a, b) { return (Number(b.administration) || 0) - (Number(a.administration) || 0); })
+      .slice(0, 6)
+      .map(function (c) { return c.name + '(' + (c.officialTitle || '在野') + '·政' + (Number(c.administration) || 0) + '·忠' + (Number(c.loyalty) || 0) + ')'; });
+    var powerLine = POWER_KEYS.map(function (k) { return k + '=' + POWER_CN[k]; }).join('·');
+    var silver = (G.guoku && Number(G.guoku.balance)) || 0;
+    return '你是天命推演引擎的典制演绎官。君上下诏设立新衙门「' + (item.newDept || item.dept || '') + '」'
+      + (item.reason ? '(诏旨事由：' + String(item.reason).slice(0, 60) + ')' : '') + '·此议正在拟制·须为其拟定开衙章程。\n'
+      + '【本朝品级】' + rankLine + '\n'
+      + '【职权词表(键名=义)】' + powerLine + '\n'
+      + '【现有衙门】' + (tops || '无') + '（正名勿与现有重名·职掌与现有衙门之权相侵者·廷议抵抗必重）\n'
+      + (cands.length ? '【在档可用之才】' + cands.join('·') + '\n' : '')
+      + '【帑廪】余银约 ' + silver + ' 两\n'
+      + '要求：衙门正名须像真实官署名(2-8字·亦可沿用君上所命之名)·官职1-' + MAX_POSITIONS + '个(首列主官)·'
+      + '各职定品级(必须取自本朝品级表)·编制员额·职权(每职至多' + MAX_POWERS_PER_POS + '项·只用词表键名·无则空)·'
+      + '月俸(石·大体循品级)·职掌一句。首任可从在档之才中荐(至多3人·亦可不荐)。开办费(两)据规模实估。只返回 JSON：\n'
+      + '{"name":"正名","desc":"职掌≤40字","positions":[{"name":"职名","rank":"品级","count":1,"powers":["键名"],"authority":"decision|execution|advisory|supervision","salary":38,"duties":"≤30字"}],"heads":[{"position":"职名","name":"人名","reason":"≤30字"}],"setupCost":3000}';
+  }
+
+  async function forgeCharter(G, item) {
+    if (!_aiOn() || !item) return null;
+    try {
+      var resp = await global.callAI(_buildPrompt(G, item), 1200, null, (typeof global._useSecondaryTier === 'function' && global._useSecondaryTier()) ? 'secondary' : undefined, { id: 'office-charter' });
+      var text = (resp && typeof resp === 'object') ? (resp.text || resp.content || '') : String(resp || '');
+      var j = (typeof global.robustParseJSON === 'function') ? global.robustParseJSON(text) : JSON.parse(text);
+      var v = _validateCharter(G, j, item);
+      if (v) {
+        item._charter = v;
+        delete item._charterPending;
+        _eb('«' + v.name + '»开衙章程已拟：' + v.positions.map(function (p) { return p.name + '(' + p.rank + '×' + p.count + ')'; }).join('·') + '·开办约' + v.setupCost + '两·待廷议裁定');
+        return v;
+      }
+    } catch (_eF) {}
+    delete item._charterPending;   // 失败→裁定时裸壳落树(双轨)
+    return null;
+  }
+
+  // ── 每回合 tick：给拟制中的衙门级增设派章程锻造(一次·幂等) ──────────────────
+  function tick(G) {
+    if (!enabled()) return;
+    G = G || global.GM;
+    if (!G || !Array.isArray(G._pendingReforms) || !G._pendingReforms.length) return;
+    if (!_aiOn()) return;   // 无 AI→裁定时裸壳兜底(双轨)
+    G._pendingReforms.forEach(function (item) {
+      if (!item || item.status !== '拟制中' || !_isDeptAdd(item)) return;
+      if (item._charter || item._charterPending != null) return;
+      item._charterPending = G.turn || 0;
+      var job = function () { return forgeCharter(G, item); };
+      if (typeof global._enqueuePostTurnJob === 'function') global._enqueuePostTurnJob('officeCharter_' + (item._key || item.dept || ''), job);
+      else job();
+    });
+  }
+
+  var API = { tick: tick, forgeCharter: forgeCharter, _validateCharter: _validateCharter, _buildPrompt: _buildPrompt, enabled: enabled, POWER_KEYS: POWER_KEYS, MAX_POSITIONS: MAX_POSITIONS, SETUP_COST_MIN: SETUP_COST_MIN, SETUP_COST_MAX: SETUP_COST_MAX };
+  global.TM = global.TM || {};
+  global.TM.OfficeCharter = API;
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+
+  try {
+    if (global.SettlementPipeline && typeof global.SettlementPipeline.register === 'function') {
+      global.SettlementPipeline.register('officeCharter', '章程演绎', function () {
+        try { tick(global.GM); } catch (_eT) {}
+      }, 93, 'perturn');
+    }
+  } catch (_eR) {}
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/web/tm-office-flags.js
+++ b/web/tm-office-flags.js
@@ -8,6 +8,7 @@
 //   officeDutyStateEnabled          Slice② 履职度 + 失职衰减
 //   officeAuthorityGateEnabled      Slice③ 权限门控（接活 canPerformAction）
 //   officeReformAdjudicationEnabled Slice④ AI 裁定式改制闭环
+//   officeCharterEnabled            设衙门批一·拟制期 AI 拟开衙章程（职掌/官职表/首任荐单/开办费·须④开才有拟制态可拟）
 //   officeRecallAgentEnabled        #1 主推演 office-recall 子调用（按需取数·走次要 API）
 //
 // 语义：组闸 || 各独立开关。
@@ -38,7 +39,7 @@
   var TM = global.TM = global.TM || {};
   TM.OfficeFlags = {
     MASTER: 'officeActivationEnabled',
-    LIST: ['officePowerPerceptionEnabled', 'officeDutyStateEnabled', 'officeAuthorityGateEnabled', 'officeReformAdjudicationEnabled', 'officeRecallAgentEnabled'],
+    LIST: ['officePowerPerceptionEnabled', 'officeDutyStateEnabled', 'officeAuthorityGateEnabled', 'officeReformAdjudicationEnabled', 'officeCharterEnabled', 'officeRecallAgentEnabled'],
     on: officeFlagOn,
     setMaster: function (v) { var P = global.P; if (P) { P.conf = P.conf || {}; P.conf.officeActivationEnabled = !!v; } return !!v; },
     masterOn: function () { var P = global.P || {}; return !!((P.ai && P.ai.officeActivationEnabled) || (P.conf && P.conf.officeActivationEnabled)); },

--- a/web/tm-office-reform.js
+++ b/web/tm-office-reform.js
@@ -118,6 +118,38 @@
     else { ch.officialTitle = ''; ch.title = ''; }
   }
   function _walkTree(ns, fn) { (ns || []).forEach(function (n) { fn(n); if (n.subs) _walkTree(n.subs, fn); }); }
+  function _treeHasName(tree, name) { var hit = false; _walkTree(tree, function (n) { if (n.name === name) hit = true; }); return hit; }
+
+  // ── 章程落树三件套（设衙门批一·演绎层 tm-office-charter 拟的全结构·宪法侧只搬运不再产）──
+  // 开办费国库真扣（镜像 GuokuEngine.Actions.openGranary 范式：balance 直扣+money.stock 同步·不足=false）
+  function _spendGuoku(GM, amount, label) {
+    amount = Math.max(0, Math.round(Number(amount) || 0));
+    if (!amount) return true;
+    try { if (typeof global.GuokuEngine !== 'undefined' && typeof global.GuokuEngine.ensureModel === 'function') global.GuokuEngine.ensureModel(); } catch (e) {}
+    var g = GM.guoku;
+    if (!g || (Number(g.balance) || 0) < amount) return false;
+    g.balance -= amount;   // arch-ok 开办费国库真扣·镜像 GuokuEngine.Actions.openGranary 支出范式(与 tm-revolt-inference._spendSilver 同款裁定)
+    try { if (g.ledgers && g.ledgers.money) g.ledgers.money.stock = g.balance; } catch (e) {}   // arch-ok 同上·账本 stock 同步
+    try { if (typeof global.addEB === 'function') global.addEB('朝代', label + '·帑出 ' + amount + ' 两'); } catch (e) {}
+    return true;
+  }
+  // 章程官职表→officeTree position 形状（双层编制模型两套字段齐给·与 _offMigratePosition 约定对齐）。
+  // discounted=「部分」band 打折：职数减半(主官居首必留)·员额减半(至少1)。
+  function _charterPositions(charter, discounted) {
+    var list = charter.positions || [];
+    if (discounted && list.length > 1) list = list.slice(0, Math.ceil(list.length / 2));
+    return list.map(function (cp) {
+      var cnt = discounted ? Math.max(1, Math.floor(cp.count / 2)) : cp.count;
+      var pos = { name: cp.name, rank: cp.rank, holder: '', desc: cp.duties || '', headCount: cnt, actualCount: 0, additionalHolders: [], establishedCount: cnt, vacancyCount: cnt, actualHolders: [], salary: cp.salary, perPersonSalary: '月俸 ' + cp.salary + ' 石' };
+      if (cp.duties) pos.duties = cp.duties;
+      if (cp.powers && cp.powers.length) {
+        var pw = {}; cp.powers.forEach(function (k) { pw[k] = true; });
+        pos.powers = pw;
+        if (cp.authority) pos.authority = cp.authority;
+      }
+      return pos;
+    });
+  }
 
   /**
    * 把一项改制落到 GM.officeTree（镜像 3340 的增设/裁撤/改名/合并·但全类型可达）。
@@ -134,10 +166,24 @@
         if (added) _recordDz(GM, dept + '/' + pos, dept + '·' + pos);   // 增设职位→典章种子
         return { applied: added, summary: added ? (dept + '增设' + pos) : ('未找到部门' + dept) };
       }
-      if (newDept) { var ok = false; _walkTree(tree, function (n) { if (n.name === dept) { if (!n.subs) n.subs = []; n.subs.push({ name: newDept, desc: reform.reason || '', positions: [], subs: [], functions: [] }); ok = true; } }); if (ok) _recordDz(GM, newDept, newDept); return { applied: ok, summary: ok ? (dept + '下增设' + newDept) : ('未找到部门' + dept) }; }
-      tree.push({ name: dept || '新设部门', desc: reform.reason || '', positions: [], subs: [], functions: [] });
-      _recordDz(GM, dept || '新设部门', dept || '新设部门');   // 增设部门→典章种子
-      return { applied: true, summary: '增设' + (dept || '新设部门') };
+      // 衙门级增设：有章程(演绎层已拟)→按章落全结构；无章程→裸壳(双轨零回归)
+      var _ch = reform._charter || null;
+      var _disc = !!(reform._charterDiscount && _ch);
+      var _chPoss = _ch ? _charterPositions(_ch, _disc) : [];
+      if (_ch) reform._charterLanded = _chPoss.map(function (p) { return p.name; });   // 荐单按实落职位过滤(部分band砍掉的职不荐)
+      if (newDept) {
+        var _lnS = newDept;
+        if (_ch && _ch.name && _ch.name !== newDept && !_treeHasName(tree, _ch.name)) { _lnS = _ch.name; reform.newDept = _lnS; }   // 正名落定(重名回退玩家原名)
+        var ok = false;
+        _walkTree(tree, function (n) { if (n.name === dept) { if (!n.subs) n.subs = []; n.subs.push({ name: _lnS, desc: (_ch && _ch.desc) || reform.reason || '', positions: _chPoss, subs: [], functions: [] }); ok = true; } });
+        if (ok) _recordDz(GM, _lnS, _lnS);
+        return { applied: ok, summary: ok ? (dept + '下增设' + _lnS + (_ch ? ('·章程' + _chPoss.length + '职' + (_disc ? '(部分得行·打折开衙)' : '')) : '')) : ('未找到部门' + dept) };
+      }
+      var _lnT = dept || '新设部门';
+      if (_ch && _ch.name && _ch.name !== _lnT && !_treeHasName(tree, _ch.name)) { _lnT = _ch.name; reform.dept = _lnT; }   // 正名落定
+      tree.push({ name: _lnT, desc: (_ch && _ch.desc) || reform.reason || '', positions: _chPoss, subs: [], functions: [] });
+      _recordDz(GM, _lnT, _lnT);   // 增设部门→典章种子
+      return { applied: true, summary: '增设' + _lnT + (_ch ? ('·章程' + _chPoss.length + '职' + (_disc ? '(部分得行·打折开衙)' : '')) : '') };
     }
     if (kind === 'abolishPos') {
       var removed = false;
@@ -228,11 +274,37 @@
         else aiNote = '·廷议无异议';                                                                                                                                          // AI 更宽则被机械护栏吞(不放水)
       }
       var who = r.affected.map(function (a) { return a.holder; }).join('、');
+      // 章程开办费国库闸(设衙门批一)：裁定虽准·帑廪不支→按拖处置(有司执奏·拖满则寝)·树不动银不扣
+      if ((band === '准' || band === '部分') && item._charter && item._charter.setupCost && !_spendGuoku(GM, item._charter.setupCost, '开衙·' + (item._charter.name || item.dept))) {
+        item.stalls = (item.stalls || 0) + 1;
+        if (item.stalls >= maxStalls) {
+          item.status = '驳'; var cGk = Math.round(r.costHuangwei * 0.5); _applyHuangweiCost(GM, cGk);
+          if (addEB) addEB('官制改革', '开衙之议因帑廪不支而寝·' + item.dept + '（开办约需' + item._charter.setupCost + '两·有司执奏·耗皇威' + cGk + '）');
+          results.push({ item: item, band: '驳', applied: false, resistance: r.resistance, guokuShort: true });
+        } else {
+          if (addEB) addEB('官制改革', '开衙之议因帑廪不支而缓·' + item.dept + '（开办约需' + item._charter.setupCost + '两·有司执奏·俟府库稍充）');
+          keep.push(item); results.push({ item: item, band: '拖', applied: false, resistance: r.resistance, guokuShort: true });
+        }
+        return;
+      }
       if (band === '准' || band === '部分') {
+        if (band === '部分' && item._charter) item._charterDiscount = true;   // 章程打折开衙(职减半·员额减半)
         var ap = applyReformToTree(GM, item); item.status = band;
         var cost = Math.round(r.costHuangwei * (band === '部分' ? 1.5 : 1));
         _applyHuangweiCost(GM, cost);
         if (addEB) addEB('官制改革', '改制' + (band === '准' ? '准行' : '勉强部分得行') + '·' + ap.summary + '（抵抗' + r.resistance + '·威权' + Math.round(authority) + '·耗皇威' + cost + (who ? '·' + who + (band === '部分' ? '力阻' : '终见裁') : '') + aiNote + '）');
+        // 章程首任荐单→诏书建议库(玩家下旨才任命·守五渠道·部分band砍掉的职不荐)
+        if (ap.applied && item._charter && Array.isArray(item._charter.heads) && item._charter.heads.length) {
+          var _landed = item._charterLanded || [];
+          var _pushed = [];
+          if (!Array.isArray(GM._edictSuggestions)) GM._edictSuggestions = [];   // arch-ok 章程荐单入建议库·玩家操作仍走五渠道
+          item._charter.heads.forEach(function (h) {
+            if (_landed.length && _landed.indexOf(h.position) < 0) return;       // 部分band砍掉的职不荐
+            GM._edictSuggestions.push({ source: '章程', from: '铨曹', content: '授' + h.name + '为' + (item.dept || '') + h.position + (h.reason ? '（' + h.reason + '）' : ''), turn: GM.turn, used: false });   // arch-ok 同上·荐单只荐不任
+            _pushed.push(h.name);
+          });
+          if (addEB && _pushed.length) addEB('官制改革', '«' + (item.dept || '') + '»开衙·铨曹以章程所荐首任入诏书建议库（' + _pushed.join('、') + '）——下旨方成任命');
+        }
         results.push({ item: item, band: band, applied: ap.applied, resistance: r.resistance });
       } else if (band === '拖') {
         item.stalls = (item.stalls || 0) + 1;

--- a/web/tm-patches.js
+++ b/web/tm-patches.js
@@ -971,6 +971,7 @@ openSettings=function(){
               ['officeDutyStateEnabled','官员履职度','官员履职度(才+五常)·失职衰减·与主动行动耦合(影响 balance)。',false],
               ['officeAuthorityGateEnabled','权限门控','掌“征税”等权者出缺/失职→实征打折·腐败涨(影响 balance)。',false],
               ['officeReformAdjudicationEnabled','改制裁定','玩家自由改官制→官僚抵抗·拟制两回合·AI 裁定准驳。',false],
+              ['officeCharterEnabled','设衙章程','下诏设新衙门时 AI 拟开衙章程：正名·职掌·官职表(品级/编制/职权/月俸)·首任荐单·开办费(国库真扣)，廷议裁定后按章开衙。须同开「改制裁定」方有拟制态可拟(增 AI 子调用)。',false],
               ['officeRecallAgentEnabled','官署按需细查','主推演对焦点衙门发 agent 子调用取职责细节(走次要 API·增调用)。',false],
               ['officeVacancyEnabled','出缺补员（默认开）','官员亡故/致仕留缺→按建制走出缺·可被补员(关则不自动出缺)。',true]
             ];

--- a/web/tm-var-drawers.js
+++ b/web/tm-var-drawers.js
@@ -824,6 +824,12 @@
         dh += '<div style="padding:5px 8px;background:var(--bg-2);border-left:3px dashed var(--gold);margin-bottom:3px;font-size:0.74rem;">';
         dh += '<b style="color:var(--gold);">' + _esc((it.reformDetail || '改制') + ' ' + (it.dept || '')) + '</b> · <span style="color:var(--txt-d);">待廷议裁定</span>';
         if (it.reason) dh += '<br><span style="font-size:0.7rem;color:var(--txt-d);">' + _esc(String(it.reason).slice(0,40)) + '</span>';
+        // 设衙章程御览(officeCharterEnabled·演绎层已拟·批二再做批红修改)
+        if (it._charter && Array.isArray(it._charter.positions)) {
+          dh += '<br><span style="font-size:0.7rem;color:var(--gold);">章程已拟·«' + _esc(it._charter.name || it.dept || '') + '»</span>';
+          if (it._charter.desc) dh += '<span style="font-size:0.7rem;color:var(--txt-d);"> · ' + _esc(it._charter.desc) + '</span>';
+          dh += '<br><span style="font-size:0.7rem;color:var(--txt-d);">' + _esc(it._charter.positions.map(function(cp){ return cp.name + '(' + cp.rank + '×' + cp.count + ')'; }).join('·')) + ' · 开办 ' + _fmt(it._charter.setupCost || 0) + ' 两</span>';
+        }
         dh += '</div>';
       });
       html += _sec('动态机构 · 制度志', (_diList.length + _pendInst.length) + '', dh);


### PR DESCRIPTION
## 摘要
「设计新部门新官职」功能批一。此前下诏设衙门·裁定通过只落一个空壳节点（无职权无编制无俸禄=死家具）。本批把「设计」一步交给 AI 演绎（实体化≠模板化）：

- **章程 subcall**（新 `tm-office-charter.js`）：设衙门之议入拟制态后·AI 拟开衙章程——正名、职掌、官职表（品级/编制/职权/月俸）、首任荐单、开办费。挂 SettlementPipeline 序93·幂等·失败静默。
- **宪法闸只验不产**：品级须在本朝品级表（剧本 override 兼容·跨朝代）·职权⊆九权词表且每职≤3·职数≤6·员额1-8·月俸夹取品级俸×[0.5,2]·开办费夹取[500,30000]·首任只荐在档活人非玩家·正名重名回退玩家原名。
- **按章开衙**（`tm-office-reform.js` 落树侧）：准=落全结构（双层编制模型字段齐全→职权舆图/官俸结算/出缺补员自动接手）；部分=打折开衙（职减半·员额减半·被砍职不荐）；开办费国库真扣（镜像 openGranary 范式·帑廪不支改拖·拖满则寝）；首任荐单入诏书建议库——只荐不任·下旨方成任命（守玩家操作五渠道）。
- **可见性**：廷议裁定 prompt 携章程供 AI 参酌（所侵之权谁家旧掌）·拟制中抽屉御览章程全文（批二做批红修改）。
- **双轨**：flag `officeCharterEnabled` 默认关（设置→官制活化细粒度）·AI 缺席/章程验废→现行裸壳落树·字节级零回归。

## 验证
- 新 `smoke-office-charter.js` 48 断言：宪法闸逐项（品级黜落/职权滤野键/夹取带/荐单过滤/重名回退）·tick 派单闸（flag关/无AI/幂等/单官职不拟章）·mock AI 锻章·准/部分/国库闸三路落树·双轨裸壳回归·静态契约接线。
- 全量 ci-smokes 788 全绿（含既有 office 家族 32 个）·lint-arch-all 8/8·热更基线外科对齐 --check 绿。

## 后续批次（已与 owner 摊桌拍板）
批二=章程御览批红修改；批三=增设抵抗重构（职权重叠夺权者具名抵抗）；批四=dynamicInstitutions 旧账一次性迁入官制树。

🤖 Generated with [Claude Code](https://claude.com/claude-code)