### PR TITLE
设衙章程批二·批红修改：廷议前御笔改品级/编制/职权（同一宪法闸再验）

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -4066,8 +4066,8 @@
     },
     {
       "path": "tm-endturn-prompt.js",
-      "sha256": "700cb2aad80ab96bc0a64130f191400d4cae301cbaabfe586bef64183e5f721a",
-      "size": 363839
+      "sha256": "3b5e2337d834a86b95ef4ad684ba9a32adaf36a776565c6192e935aa4f31e91a",
+      "size": 363925
     },
     {
       "path": "tm-endturn-province.js",
@@ -4886,8 +4886,8 @@
     },
     {
       "path": "tm-office-charter.js",
-      "sha256": "7395954a6bc6d3b5489dc01a1f67da831472ad03ba35e5c90b2fd6a36e537815",
-      "size": 11724
+      "sha256": "70dd02506895a805798ce920dad85ee89158419188fc4176de769ca201d29746",
+      "size": 17936
     },
     {
       "path": "tm-office-dutystate.js",
@@ -5336,8 +5336,8 @@
     },
     {
       "path": "tm-var-drawers.js",
-      "sha256": "a98ba1af93cc0819cc97f09a9fa6d63506f8f3136c468c9e63a0e34d3ebc7e14",
-      "size": 118201
+      "sha256": "364ee0f6e5d27f83eca3226e19875de6ded5be524b38adcefd7a753b76909d31",
+      "size": 118591
     },
     {
       "path": "tm-wendui-persona-views.js",

--- a/web/scripts/smoke-office-charter-review.js
+++ b/web/scripts/smoke-office-charter-review.js
@@ -1,0 +1,149 @@
+// smoke-office-charter-review.js — 设衙章程批红修改（批二·2026-07-21）
+//
+// owner 拍板：AI 拟好的章程·进廷议裁定前玩家可批红修改（品级/编制/职权）。
+// 批红走 _applyCharterRevision → 整章重过 _validateCharter=同一宪法闸：换品级则月俸随新品级俸
+// band 重夹取·员额照夹·职权照滤野键·品级出表的职黜落·荐单过滤到幸存职位·开办费照旧案不可改。
+// 已决之议不可批·全职皆废不收(原章程保全)。批红后落树=改定后的结构。
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var vm = require('vm');
+
+var ROOT = path.join(__dirname, '..');
+var failures = [];
+function assert(cond, msg) {
+  if (cond) { console.log('  PASS ' + msg); }
+  else { failures.push(msg); console.log('  FAIL ' + msg); }
+}
+
+var RANKS = [
+  { id: 'z3', label: '正三品', level: 5, salary: 65 },
+  { id: 'z5', label: '正五品', level: 9, salary: 38 },
+  { id: 'z7', label: '正七品', level: 13, salary: 20 }
+];
+
+function freshSandbox() {
+  var sb = { console: console };
+  sb.window = sb; sb.global = sb;
+  sb._ebs = [];
+  sb.addEB = function (cat, msg) { sb._ebs.push(cat + '·' + msg); };
+  sb.SettlementPipeline = { register: function () {} };
+  sb._activeRankHierarchy = function () { return RANKS; };
+  sb.officeFlagOn = function () { return true; };
+  sb.GM = {
+    turn: 10,
+    huangwei: { index: 50 }, huangquan: { index: 50 },
+    guoku: { balance: 100000, ledgers: { money: { stock: 100000 } } },
+    officeTree: [{ name: '户部', desc: '掌钱谷', positions: [], subs: [], functions: [] }],
+    chars: [
+      { name: '天子', isPlayer: true, alive: true },
+      { name: '钱谷才', alive: true, loyalty: 80, administration: 85 },
+      { name: '干吏乙', alive: true, loyalty: 60, administration: 70 }
+    ],
+    _pendingReforms: []
+  };
+  sb.findCharByName = function (n) {
+    for (var i = 0; i < sb.GM.chars.length; i++) if (sb.GM.chars[i].name === n) return sb.GM.chars[i];
+    return null;
+  };
+  sb.P = { conf: {} };
+  vm.createContext(sb);
+  ['tm-office-reform.js', 'tm-office-charter.js'].forEach(function (f) {
+    vm.runInContext(fs.readFileSync(path.join(ROOT, f), 'utf8'), sb, { filename: f });
+  });
+  return sb;
+}
+
+function mkCharter() {
+  return {
+    name: '市舶提举司', desc: '掌番舶抽解', setupCost: 8000,
+    positions: [
+      { name: '提举', rank: '正五品', count: 8, powers: ['taxCollect', 'supervise'], authority: 'decision', salary: 76, duties: '总司抽解' },
+      { name: '吏目', rank: '正七品', count: 2, powers: [], authority: 'execution', salary: 20, duties: '掌文牍' }
+    ],
+    heads: [
+      { position: '提举', name: '钱谷才', reason: '晓畅钱谷' },
+      { position: '吏目', name: '干吏乙', reason: '干练' }
+    ]
+  };
+}
+function mkItem(ch) {
+  return { _key: 'kR', reformDetail: '增设', dept: '市舶司', status: '拟制中', proposedTurn: 8, stalls: 0, _charter: ch };
+}
+
+console.log('① 批红改品级·月俸随新品自正');
+var sb = freshSandbox();
+var OC = sb.TM.OfficeCharter;
+var it = mkItem(mkCharter());
+sb.GM._pendingReforms.push(it);
+var r1 = OC._applyCharterRevision(sb.GM, it, { positions: [{ name: '提举', rank: '正七品', count: 3, powers: ['taxCollect', 'bogus'] }] });
+assert(r1.ok === true, '批红收下');
+var p1 = it._charter.positions[0];
+assert(p1.rank === '正七品', '品级改定 正五品→正七品');
+assert(p1.salary === 40, '月俸 76 越新品级(20)band→重夹取到 40(=20×2)');
+assert(p1.count === 3, '员额改定 8→3');
+assert(p1.powers.length === 1 && p1.powers[0] === 'taxCollect', '职权照滤野键');
+assert(it._charter.positions[1].rank === '正七品' && it._charter.positions[1].count === 2, '未批之职(吏目)原样保全');
+assert(it._charterRevised === true, '御笔批红旗竖起');
+assert(it._charter.setupCost === 8000, '开办费照旧案(批红不改钱)');
+assert(sb._ebs.some(function (e) { return e.indexOf('御笔批红改定') >= 0; }), '批红入起居注');
+
+console.log('② 批红把职改出品级表·该职黜落·荐单随之过滤');
+var sb2 = freshSandbox();
+var it2 = mkItem(mkCharter());
+sb2.GM._pendingReforms.push(it2);
+var r2 = OC2ap(sb2, it2, { positions: [{ name: '吏目', rank: '正十三品', count: 2, powers: [] }] });
+function OC2ap(s, i, e) { return s.TM.OfficeCharter._applyCharterRevision(s.GM, i, e); }
+assert(r2.ok === true && it2._charter.positions.length === 1, '出表之职(吏目)黜落·余职存');
+assert(it2._charter.heads.length === 1 && it2._charter.heads[0].name === '钱谷才', '被黜之职的荐单(干吏乙)随之过滤');
+
+console.log('③ 全职皆废不收·原章程保全');
+var sb3 = freshSandbox();
+var ch3 = mkCharter(); ch3.positions = [ch3.positions[0]];
+var it3 = mkItem(ch3);
+sb3.GM._pendingReforms.push(it3);
+var r3 = sb3.TM.OfficeCharter._applyCharterRevision(sb3.GM, it3, { positions: [{ name: '提举', rank: '正十三品', count: 1, powers: [] }] });
+assert(r3.ok === false, '批红后无一职合式→不收');
+assert(it3._charter.positions[0].rank === '正五品' && !it3._charterRevised, '原章程保全·批红旗不竖');
+
+console.log('④ 已决之议不可批·无章程不可批');
+var sb4 = freshSandbox();
+var it4 = mkItem(mkCharter()); it4.status = '准';
+assert(sb4.TM.OfficeCharter._applyCharterRevision(sb4.GM, it4, { positions: [] }).ok === false, '已决之议→拒批');
+var it4b = { _key: 'x', status: '拟制中' };
+assert(sb4.TM.OfficeCharter._applyCharterRevision(sb4.GM, it4b, { positions: [] }).ok === false, '无章程→拒批');
+
+console.log('⑤ 批红后落树=改定结构(全链)');
+var sb5 = freshSandbox();
+var it5 = mkItem(mkCharter());
+sb5.GM._pendingReforms.push(it5);
+sb5.TM.OfficeCharter._applyCharterRevision(sb5.GM, it5, { positions: [{ name: '提举', rank: '正三品', count: 1, powers: ['taxCollect', 'supervise', 'judicial'] }] });
+var res5 = sb5.adjudicatePendingReforms(sb5.GM, { authority: 100 });
+var node5 = sb5.GM.officeTree.filter(function (n) { return n.name === '市舶提举司'; })[0];
+assert(res5[0].band === '准' && node5 && node5.positions.length === 2, '批红改定后照准落树');
+assert(node5.positions[0].rank === '正三品' && node5.positions[0].establishedCount === 1, '落的是御笔改定之品级与员额');
+assert(node5.positions[0].powers && node5.positions[0].powers.judicial === true, '批红增补之职权随树落地');
+assert(sb5.GM.guoku.balance === 92000, '开办费仍按旧案 8000 实扣');
+
+console.log('⑥ 陌生职名之批·忽略不炸');
+var sb6 = freshSandbox();
+var it6 = mkItem(mkCharter());
+sb6.GM._pendingReforms.push(it6);
+var r6 = sb6.TM.OfficeCharter._applyCharterRevision(sb6.GM, it6, { positions: [{ name: '不存在之职', rank: '正三品', count: 1, powers: [] }] });
+assert(r6.ok === true && it6._charter.positions.length === 2 && it6._charter.positions[0].rank === '正五品', '陌生职名忽略·原职原样');
+
+console.log('⑦ 静态契约·接线到位');
+var drawers = fs.readFileSync(path.join(ROOT, 'tm-var-drawers.js'), 'utf8');
+assert(drawers.indexOf('_charterReviewOpen') >= 0 && drawers.indexOf('批红修改') >= 0, '拟制中抽屉有批红修改钮');
+var prompt = fs.readFileSync(path.join(ROOT, 'tm-endturn-prompt.js'), 'utf8');
+assert(prompt.indexOf('_charterRevised') >= 0, '廷议裁定段标注御笔批红改定');
+var charterSrc = fs.readFileSync(path.join(ROOT, 'tm-office-charter.js'), 'utf8');
+assert(charterSrc.indexOf('_applyCharterRevision') >= 0 && charterSrc.indexOf('_charterReviewOpen') >= 0, '批红逻辑与弹窗俱在演绎层模块');
+
+console.log('');
+if (failures.length) {
+  console.log('FAILURES (' + failures.length + '):');
+  failures.forEach(function (f) { console.log('  - ' + f); });
+  process.exit(1);
+}
+console.log('smoke-office-charter-review: ALL PASS');

--- a/web/tm-endturn-prompt.js
+++ b/web/tm-endturn-prompt.js
@@ -1737,7 +1737,7 @@
             tp += '  · ' + (it.reformDetail || '') + ' ' + it.dept + (it.position ? ('·' + it.position) : '') + '：机械抵抗' + _rr.resistance + '·威权' + Math.round(_raAuth) + ' → 机械band【' + _rr.band + '】' + (_rw ? ('·触动' + _rw) : '·无人失权') + '\n';
             // 设衙章程已拟(officeCharterEnabled·演绎层产)→廷议裁定可参酌章程职权之侵夺(占何权·几职几员·糜几两)
             if (it._charter && Array.isArray(it._charter.positions)) {
-              tp += '    ↳章程已拟：«' + (it._charter.name || it.dept) + '»' + it._charter.positions.map(function (cp) { return cp.name + '(' + cp.rank + '×' + cp.count + (cp.powers && cp.powers.length ? '·权' + cp.powers.length + '项' : '') + ')'; }).join('·') + '·开办约' + it._charter.setupCost + '两——所侵之权谁家旧掌·裁定时并叙\n';
+              tp += '    ↳章程已拟' + (it._charterRevised ? '(御笔批红改定·天心已属·抗之弥重)' : '') + '：«' + (it._charter.name || it.dept) + '»' + it._charter.positions.map(function (cp) { return cp.name + '(' + cp.rank + '×' + cp.count + (cp.powers && cp.powers.length ? '·权' + cp.powers.length + '项' : '') + ')'; }).join('·') + '·开办约' + it._charter.setupCost + '两——所侵之权谁家旧掌·裁定时并叙\n';
             }
           });
           tp += '  格式：reform_verdicts:[{dept,position?,verdict,reason}]\n';

--- a/web/tm-office-charter.js
+++ b/web/tm-office-charter.js
@@ -161,6 +161,90 @@
     return null;
   }
 
+  // ── 批红修改（批二·owner 拍板：章程进廷议前玩家可改品级/编制/职权）────────────
+  // edits.positions=[{name(锚·不可改),rank,count,powers[]}]·改后整章重过 _validateCharter=同一宪法闸
+  // (换品级→月俸自动随新品级俸 band 重夹取·野键照滤·员额照夹)·首任荐单过滤到幸存职位·开办费不动。
+  function _applyCharterRevision(G, item, edits) {
+    if (!item || item.status !== '拟制中' || !item._charter) return { ok: false, reason: '此议已决或无章程可批' };
+    var ch = item._charter;
+    var byName = {};
+    (Array.isArray(edits && edits.positions) ? edits.positions : []).forEach(function (e) { if (e && e.name) byName[e.name] = e; });
+    var raw = {
+      name: ch.name, desc: ch.desc, setupCost: ch.setupCost,
+      heads: (ch.heads || []).map(function (h) { return { position: h.position, name: h.name, reason: h.reason }; }),
+      positions: (ch.positions || []).map(function (p) {
+        var e = byName[p.name] || {};
+        return {
+          name: p.name,
+          rank: (e.rank != null ? e.rank : p.rank),
+          count: (e.count != null ? e.count : p.count),
+          powers: (Array.isArray(e.powers) ? e.powers : p.powers),
+          authority: p.authority, salary: p.salary, duties: p.duties
+        };
+      })
+    };
+    var v = _validateCharter(G, raw, item);
+    if (!v) return { ok: false, reason: '批红后章程无一职合式(品级须在本朝品级表)·未收' };
+    v.setupCost = ch.setupCost;   // 开办费照旧案(批红不改钱·防边改边压价)
+    item._charter = v;
+    item._charterRevised = true;
+    _eb('«' + v.name + '»章程御笔批红改定：' + v.positions.map(function (p) { return p.name + '(' + p.rank + '×' + p.count + ')'; }).join('·') + '·仍待廷议裁定');
+    return { ok: true, charter: v };
+  }
+
+  // 批红弹窗（浏览器侧·smoke 不走 DOM 只验 _applyCharterRevision）
+  function _charterReviewOpen(itemKey) {
+    if (typeof document === 'undefined') return;
+    var G = global.GM;
+    if (!G || !Array.isArray(G._pendingReforms)) return;
+    var item = null;
+    for (var i = 0; i < G._pendingReforms.length; i++) {
+      var it = G._pendingReforms[i];
+      if (it && it._key === itemKey && it.status === '拟制中' && it._charter) { item = it; break; }
+    }
+    if (!item) { try { if (typeof global.toast === 'function') global.toast('此议已决或章程未拟'); } catch (_) {} return; }
+    var ch = item._charter;
+    var H = _rankTable() || [];
+    var esc = (typeof global.escHtml === 'function') ? global.escHtml : function (s) { return String(s).replace(/</g, '&lt;'); };
+    var bg = document.createElement('div');
+    bg.style.cssText = 'position:fixed;inset:0;z-index:1200;background:rgba(0,0,0,0.7);display:flex;align-items:center;justify-content:center;';
+    var html = '<div style="background:var(--color-surface,#1c1917);border:1px solid var(--gold-500,#b08d3f);border-radius:8px;padding:1.1rem 1.3rem;max-width:560px;max-height:82vh;overflow-y:auto;">';
+    html += '<div style="font-size:0.95rem;color:var(--gold,#c9a227);letter-spacing:0.08em;margin-bottom:0.35rem;">批红·«' + esc(ch.name) + '»开衙章程</div>';
+    html += '<div style="font-size:0.7rem;color:var(--txt-d,#8a8378);margin-bottom:0.6rem;">' + esc(ch.desc || '') + ' · 开办 ' + ch.setupCost + ' 两（批红不改）· 改品级则月俸随品自正</div>';
+    ch.positions.forEach(function (p, pi) {
+      html += '<div data-pos="' + esc(p.name) + '" style="border-top:1px dotted var(--bdr,#3a352d);padding:0.45rem 0;">';
+      html += '<b style="font-size:0.8rem;color:var(--gold,#c9a227);">' + esc(p.name) + '</b> ';
+      html += '<select data-f="rank" style="font-size:0.72rem;background:transparent;color:inherit;border:1px solid var(--bdr,#3a352d);">';
+      H.forEach(function (r) { html += '<option value="' + esc(r.label) + '"' + (p.rank.indexOf(r.label) >= 0 ? ' selected' : '') + '>' + esc(r.label) + '</option>'; });
+      html += '</select> 员额<input data-f="count" type="number" min="1" max="' + MAX_HEADCOUNT + '" value="' + p.count + '" style="width:3em;font-size:0.72rem;background:transparent;color:inherit;border:1px solid var(--bdr,#3a352d);">';
+      html += '<div style="margin-top:0.25rem;font-size:0.7rem;">';
+      POWER_KEYS.forEach(function (k) {
+        html += '<label style="margin-right:0.55rem;white-space:nowrap;cursor:pointer;"><input data-f="pw" data-k="' + k + '" type="checkbox"' + (p.powers.indexOf(k) >= 0 ? ' checked' : '') + ' style="vertical-align:-2px;">' + POWER_CN[k] + '</label>';
+      });
+      html += '</div></div>';
+    });
+    html += '<div style="text-align:right;margin-top:0.7rem;"><button class="bt" data-act="ok">批红定案</button> <button class="bt" data-act="close">罢</button></div>';
+    html += '</div>';
+    bg.innerHTML = html;
+    bg.addEventListener('click', function (ev) {
+      var t = ev.target;
+      if (t === bg || (t && t.getAttribute && t.getAttribute('data-act') === 'close')) { bg.remove(); return; }
+      if (t && t.getAttribute && t.getAttribute('data-act') === 'ok') {
+        var edits = { positions: [] };
+        bg.querySelectorAll('[data-pos]').forEach(function (row) {
+          var powers = [];
+          row.querySelectorAll('[data-f="pw"]').forEach(function (cb) { if (cb.checked) powers.push(cb.getAttribute('data-k')); });
+          var cntEl = row.querySelector('[data-f="count"]'), rkEl = row.querySelector('[data-f="rank"]');
+          edits.positions.push({ name: row.getAttribute('data-pos'), rank: rkEl ? rkEl.value : '', count: cntEl ? parseInt(cntEl.value, 10) : 1, powers: powers });
+        });
+        var r = _applyCharterRevision(G, item, edits);
+        try { if (typeof global.toast === 'function') global.toast(r.ok ? '章程批红已定·仍待廷议' : ('未收：' + r.reason)); } catch (_) {}
+        if (r.ok) { bg.remove(); try { if (typeof global.renderVarDrawers === 'function') global.renderVarDrawers(); } catch (_) {} }
+      }
+    });
+    document.body.appendChild(bg);
+  }
+
   // ── 每回合 tick：给拟制中的衙门级增设派章程锻造(一次·幂等) ──────────────────
   function tick(G) {
     if (!enabled()) return;
@@ -177,7 +261,8 @@
     });
   }
 
-  var API = { tick: tick, forgeCharter: forgeCharter, _validateCharter: _validateCharter, _buildPrompt: _buildPrompt, enabled: enabled, POWER_KEYS: POWER_KEYS, MAX_POSITIONS: MAX_POSITIONS, SETUP_COST_MIN: SETUP_COST_MIN, SETUP_COST_MAX: SETUP_COST_MAX };
+  var API = { tick: tick, forgeCharter: forgeCharter, _validateCharter: _validateCharter, _applyCharterRevision: _applyCharterRevision, _buildPrompt: _buildPrompt, enabled: enabled, POWER_KEYS: POWER_KEYS, MAX_POSITIONS: MAX_POSITIONS, SETUP_COST_MIN: SETUP_COST_MIN, SETUP_COST_MAX: SETUP_COST_MAX };
+  global._charterReviewOpen = _charterReviewOpen;
   global.TM = global.TM || {};
   global.TM.OfficeCharter = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;

--- a/web/tm-var-drawers.js
+++ b/web/tm-var-drawers.js
@@ -824,11 +824,14 @@
         dh += '<div style="padding:5px 8px;background:var(--bg-2);border-left:3px dashed var(--gold);margin-bottom:3px;font-size:0.74rem;">';
         dh += '<b style="color:var(--gold);">' + _esc((it.reformDetail || '改制') + ' ' + (it.dept || '')) + '</b> · <span style="color:var(--txt-d);">待廷议裁定</span>';
         if (it.reason) dh += '<br><span style="font-size:0.7rem;color:var(--txt-d);">' + _esc(String(it.reason).slice(0,40)) + '</span>';
-        // 设衙章程御览(officeCharterEnabled·演绎层已拟·批二再做批红修改)
+        // 设衙章程御览(officeCharterEnabled·演绎层已拟)·批二：批红修改钮(改品级/编制/职权·同一宪法闸再验)
         if (it._charter && Array.isArray(it._charter.positions)) {
-          dh += '<br><span style="font-size:0.7rem;color:var(--gold);">章程已拟·«' + _esc(it._charter.name || it.dept || '') + '»</span>';
+          dh += '<br><span style="font-size:0.7rem;color:var(--gold);">章程已拟' + (it._charterRevised ? '·御笔批红改定' : '') + '·«' + _esc(it._charter.name || it.dept || '') + '»</span>';
           if (it._charter.desc) dh += '<span style="font-size:0.7rem;color:var(--txt-d);"> · ' + _esc(it._charter.desc) + '</span>';
           dh += '<br><span style="font-size:0.7rem;color:var(--txt-d);">' + _esc(it._charter.positions.map(function(cp){ return cp.name + '(' + cp.rank + '×' + cp.count + ')'; }).join('·')) + ' · 开办 ' + _fmt(it._charter.setupCost || 0) + ' 两</span>';
+          if (typeof _charterReviewOpen === 'function' && it._key) {
+            dh += ' <button class="bt" style="font-size:0.66rem;padding:0.1rem 0.45rem;" onclick="_charterReviewOpen(decodeURIComponent(\'' + encodeURIComponent(it._key) + '\'))">批红修改</button>';
+          }
         }
         dh += '</div>';
       });


### PR DESCRIPTION
## 摘要
批一摊桌 owner 拍板分叉②=「可批红修改」。AI 拟好的开衙章程，进廷议裁定前玩家可批红：

- **改什么**：各职品级（下拉·限本朝品级表）、编制员额、职权（九权勾选）。职名/开办费不可改（防边改边压价）。
- **怎么守宪法**：批红后整章重过 `_validateCharter` 同一道闸——换品级则月俸随新品级俸 band 自动重夹取，员额照夹，职权照滤野键，品级改出表的职直接黜落、其荐单随之过滤；批红后无一职合式则不收、原章程保全；已决之议拒批。
- **廷议知情**：prompt 标「御笔批红改定·天心已属·抗之弥重」，AI 裁定可参酌；拟制中抽屉显批红旗。
- 弹窗为浏览器侧薄壳，逻辑全在 `_applyCharterRevision`（导出·smoke 直验）。

## 验证
smoke-office-charter-review 23 断言（重夹取/黜落过滤/拒批闸/批红后落树全链/陌生职名不炸/静态契约）·全量 ci-smokes 789 绿·lint-arch-all 8/8·热更基线 --check 绿。

后续：批三=增设抵抗重构（职权重叠夺权者具名）·批四=dynamicInstitutions 迁树。

🤖 Generated with [Claude Code](https://claude.com/claude-code)