### PR TITLE
设衙章程批三·增设抵抗重构：夺谁的权·谁具名抵抗（设西厂都察院必反）

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -4926,8 +4926,8 @@
     },
     {
       "path": "tm-office-reform.js",
-      "sha256": "5cb29fe03b27188e359454ca506458faed8971ec638cd681d4175e265d8b307d",
-      "size": 25487
+      "sha256": "1c17a2a40a235ad8a0f9a9e3472b8cc583283be56dcca17d5f3f4c0e35d90ebd",
+      "size": 27357
     },
     {
       "path": "tm-office-runtime-summary-appoint.js",

--- a/web/scripts/smoke-office-reform-add-overlap.js
+++ b/web/scripts/smoke-office-reform-add-overlap.js
@@ -1,0 +1,123 @@
+// smoke-office-reform-add-overlap.js — 增设抵抗重构·职权重叠具名（批三·2026-07-21）
+//
+// 此前增设的抵抗=死基础分5——设西厂分走监察权·都察院毫无反应。本批：新衙章程所掌之权
+// 与在任官旧掌重叠→旧掌其权者具名入 affected 抵抗(品级份量+重叠权数×perPower+忠诚增减·
+// ×addOverlapMul 0.6 摊薄系数·总加成封顶 addOverlapCap 60)。出缺之位无人可抵。
+// 双轨：无章程/章程无权→仍是基础分=字节级零回归。
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var vm = require('vm');
+
+var ROOT = path.join(__dirname, '..');
+var failures = [];
+function assert(cond, msg) {
+  if (cond) { console.log('  PASS ' + msg); }
+  else { failures.push(msg); console.log('  FAIL ' + msg); }
+}
+
+var LVL = { '正二品': 3, '正三品': 5, '正七品': 13 };
+
+function freshSandbox() {
+  var sb = { console: console };
+  sb.window = sb; sb.global = sb;
+  sb._ebs = [];
+  sb.addEB = function (cat, msg) { sb._ebs.push(cat + '·' + msg); };
+  sb.getRankLevel = function (r) { return LVL[r] || 99; };
+  sb.GM = {
+    turn: 10,
+    huangwei: { index: 50 }, huangquan: { index: 50 },
+    guoku: { balance: 100000, ledgers: { money: { stock: 100000 } } },
+    officeTree: [
+      { name: '户部', positions: [
+        { name: '尚书', rank: '正三品', holder: '钱谷才', powers: { taxCollect: true, works: true } },
+        { name: '主事', rank: '正七品', holder: '小吏', powers: { taxCollect: true } }
+      ], subs: [], functions: [] },
+      { name: '都察院', positions: [
+        { name: '都御史', rank: '正二品', holder: '铁面公', powers: { supervise: true, impeach: true } }
+      ], subs: [], functions: [] },
+      { name: '刑部', positions: [
+        { name: '侍郎', rank: '正三品', holder: '', powers: { judicial: true } }
+      ], subs: [], functions: [] }
+    ],
+    chars: [
+      { name: '钱谷才', alive: true, loyalty: 80 },
+      { name: '小吏', alive: true, loyalty: 50 },
+      { name: '铁面公', alive: true, loyalty: 30 }
+    ],
+    _pendingReforms: []
+  };
+  sb.findCharByName = function (n) {
+    for (var i = 0; i < sb.GM.chars.length; i++) if (sb.GM.chars[i].name === n) return sb.GM.chars[i];
+    return null;
+  };
+  sb.P = { conf: {} };
+  vm.createContext(sb);
+  vm.runInContext(fs.readFileSync(path.join(ROOT, 'tm-office-reform.js'), 'utf8'), sb, { filename: 'tm-office-reform.js' });
+  return sb;
+}
+function charterWith(powersLists) {
+  return { name: '新衙', desc: '', setupCost: 0, heads: [], positions: powersLists.map(function (pw, i) {
+    return { name: '职' + i, rank: '正五品', count: 1, powers: pw, authority: '', salary: 38, duties: '' };
+  }) };
+}
+
+console.log('① 夺征税之权·户部具名抵抗(都察院无涉)');
+var sb = freshSandbox();
+var rA = sb.computeReformResistance(sb.GM, { reformDetail: '增设', dept: '税课司', _charter: charterWith([['taxCollect']]) }, { authority: 0 });
+// 尚书(headMid15+1权10−忠高10=15→×0.6=9) + 主事(0+10=10→6) = +15 → 5+15=20
+assert(rA.resistance === 20, '抵抗=基础5+尚书9+主事6=20 (实得' + rA.resistance + ')');
+assert(rA.affected.length === 2 && rA.affected.every(function (a) { return a.holder === '钱谷才' || a.holder === '小吏'; }), '具名=旧掌征税者二人·都御史无涉');
+assert(rA.affected[0].powersTaken && rA.affected[0].powersTaken.indexOf('taxCollect') >= 0, '记明所夺何权');
+assert(rA.band === '拖', 'margin 20·恰入拖档(威权0)');
+
+console.log('② 夺监察之权·怨望重臣抵抗尤烈');
+var rB = sb.computeReformResistance(sb.GM, { reformDetail: '增设', dept: '西缉事厂', _charter: charterWith([['supervise']]) }, { authority: 0 });
+// 都御史(headHigh30+10+怨望20=60→×0.6=36) → 5+36=41
+assert(rB.resistance === 41, '正二品怨望都御史力抵→41 (实得' + rB.resistance + ')');
+assert(rB.affected.length === 1 && rB.affected[0].holder === '铁面公', '具名=铁面公一人');
+assert(rB.band === '驳', 'margin 41≥40→驳(威权0设西厂难如登天)');
+
+console.log('③ 多权并夺·抵抗累计');
+var rC = sb.computeReformResistance(sb.GM, { reformDetail: '增设', dept: '总宪司', _charter: charterWith([['taxCollect', 'supervise'], ['judicial']]) }, { authority: 0 });
+// 尚书9+主事6+都御史36=51(judicial 旧掌出缺无人抵) → 56
+assert(rC.resistance === 56, '三家并抵=56·出缺之权(刑狱)无人可抵 (实得' + rC.resistance + ')');
+
+console.log('④ 重叠加成封顶(addOverlapCap 60)');
+var sb4 = freshSandbox();
+for (var x = 0; x < 4; x++) {
+  sb4.GM.officeTree[1].positions.push({ name: '佥都御史' + x, rank: '正三品', holder: '怨官' + x, powers: { supervise: true } });
+  sb4.GM.chars.push({ name: '怨官' + x, alive: true, loyalty: 20 });
+}
+var rD = sb4.computeReformResistance(sb4.GM, { reformDetail: '增设', dept: '西缉事厂', _charter: charterWith([['supervise']]) }, { authority: 0 });
+// 都御史36+4×(15+10+20=45→27)=144 → 封顶60 → 65
+assert(rD.resistance === 65, '满朝御史皆抵仍封顶=5+60 (实得' + rD.resistance + ')');
+assert(rD.affected.length === 5, '具名仍全列(封顶只封分不封名)');
+
+console.log('⑤ 双轨零回归');
+var rE = sb.computeReformResistance(sb.GM, { reformDetail: '增设', dept: '无章衙门' }, { authority: 0 });
+assert(rE.resistance === 5 && rE.affected.length === 0, '无章程→死基础分5(原行为)');
+var rF = sb.computeReformResistance(sb.GM, { reformDetail: '增设', dept: '清水衙门', _charter: charterWith([[]]) }, { authority: 0 });
+assert(rF.resistance === 5 && rF.affected.length === 0, '章程无权→亦基础分5(不扰民者不遭抵)');
+
+console.log('⑥ 全链·裁定文案具名');
+var sb6 = freshSandbox();
+var it6 = { _key: 'k', reformDetail: '增设', dept: '西缉事厂', status: '拟制中', proposedTurn: 8, stalls: 0, _charter: charterWith([['supervise']]) };
+sb6.GM._pendingReforms.push(it6);
+var res6 = sb6.adjudicatePendingReforms(sb6.GM, { authority: 100 });
+assert(res6[0].band === '准' && res6[0].applied === true, '威权碾压(100)仍可强行开厂');
+assert(sb6._ebs.some(function (e) { return e.indexOf('铁面公') >= 0; }), '裁定起居注具名铁面公(终见裁)');
+var sb6b = freshSandbox();
+var it6b = { _key: 'k', reformDetail: '增设', dept: '西缉事厂', status: '拟制中', proposedTurn: 8, stalls: 0, _charter: charterWith([['supervise']]) };
+sb6b.GM._pendingReforms.push(it6b);
+var res6b = sb6b.adjudicatePendingReforms(sb6b.GM, { authority: 10 });
+assert(res6b[0].band === '拖' && it6b.status === '拟制中' && it6b.stalls === 1, '威权10→margin 31→拖(为群僚牵延·议留拟制)');
+assert(sb6b._ebs.some(function (e) { return e.indexOf('铁面公') >= 0; }), '受阻起居注亦具名铁面公');
+
+console.log('');
+if (failures.length) {
+  console.log('FAILURES (' + failures.length + '):');
+  failures.forEach(function (f) { console.log('  - ' + f); });
+  process.exit(1);
+}
+console.log('smoke-office-reform-add-overlap: ALL PASS');

--- a/web/tm-office-reform.js
+++ b/web/tm-office-reform.js
@@ -15,6 +15,7 @@
     headHigh: 30, headMid: 15, perPower: 10,
     disloyalBelow: 40, disloyalAdd: 20, loyalAbove: 70, loyalSub: 10,
     mergeMul: 0.5,                                  // 合并比裁撤温和(职位转移非清退)
+    addOverlapMul: 0.6, addOverlapCap: 60,          // 批三·增设分权比裁撤温和(权被摊薄非剥夺)·总加成封顶防满朝皆抵一切议废
     difficultyMul: { narrative: 0.7, standard: 1.0, hardcore: 1.3 },
     passBelow: 0, partialBelow: 20, delayBelow: 40,
     costFactor: 0.12, costCap: 8
@@ -71,6 +72,37 @@
     var kind = _reformKind(reform);
     var resistance = (F.base[kind] != null) ? F.base[kind] : F.base.other;
     var affected = [];
+    // 批三·增设的抵抗不再是死基础分：新衙章程所掌之权与在任官旧掌重叠→旧掌其权者具名抵抗
+    // (设西厂分监察之权·都察院与东厂岂能无声)。无章程/章程无权=原基础分·字节级零回归。
+    if (kind === 'add' && reform._charter && Array.isArray(reform._charter.positions) && GM && GM.officeTree) {
+      var newPw = {};
+      reform._charter.positions.forEach(function (cp) { (cp.powers || []).forEach(function (k) { newPw[k] = 1; }); });
+      var newKeys = Object.keys(newPw);
+      if (newKeys.length) {
+        var overlapSum = 0;
+        (function walkOv(ns) {
+          (ns || []).forEach(function (n) {
+            (n.positions || []).forEach(function (p) {
+              if (!p || !p.holder || !p.powers) return;
+              var taken = newKeys.filter(function (k) { return p.powers[k]; });
+              if (!taken.length) return;
+              var ch = _holderChar(GM, p.holder), w = 0;
+              var lvl = _rankLvl(p); if (lvl <= 3) w += F.headHigh; else if (lvl <= 6) w += F.headMid;
+              w += taken.length * F.perPower;
+              var loy = ch && ch.loyalty;
+              if (loy != null && loy < F.disloyalBelow) w += F.disloyalAdd;
+              else if (loy != null && loy > F.loyalAbove) w -= F.loyalSub;
+              w = Math.round(w * F.addOverlapMul);
+              if (w <= 0) return;
+              overlapSum += w;
+              affected.push({ dept: n.name, pos: p.name, holder: p.holder, weight: w, powersTaken: taken });
+            });
+            if (n.subs) walkOv(n.subs);
+          });
+        })(GM.officeTree);
+        resistance += Math.min(F.addOverlapCap, overlapSum);
+      }
+    }
     if (kind === 'abolishPos' || kind === 'abolishDept' || kind === 'merge') {
       var mul = (kind === 'merge') ? F.mergeMul : 1;
       _affectedHolders(GM, reform, kind).forEach(function (it) {


### PR DESCRIPTION
## 摘要
批一摊桌排定的批三。此前「增设」的廷议抵抗是死基础分 5——设西厂分走监察权，都察院和东厂毫无反应，违背「改制不免费」的硬核灵魂。本批：

- **职权重叠即具名抵抗**：新衙章程所掌之权与在任官旧掌重叠 → 逐人算份量（品级 headHigh/headMid + 重叠权数×perPower + 忠诚增减），×`addOverlapMul` 0.6（分权比裁撤温和——权被摊薄而非剥夺），总加成封顶 `addOverlapCap` 60（防满朝皆抵、一切议废）。抵抗者具名入 `affected`（带 `powersTaken` 记明所夺何权）。
- **出缺之权无人可抵**——虚位的旧掌不产生抵抗，缺员之弊自见。
- **可见性零成本**：廷议 prompt 的「触动X」与裁定起居注的「X力阻/牵延」走既有渠道，自动带出具名。
- **双轨**：无章程/章程无权 → 仍是基础分 5，字节级零回归（闸在 `reform._charter` 存在性上，随 officeCharterEnabled）。

实测口味：威权 0 时设「西缉事厂」遭正二品怨望都御史力抵（抵抗 41）直接被驳；威权碾压方能强行开厂，且史笔具名谁曾力阻。

## 验证
smoke-office-reform-add-overlap 16 断言（三家并抵累计/封顶只封分不封名/双轨零回归/全链具名）·全量 ci-smokes 789 绿·lint-arch-all 8/8·热更基线 --check 绿。

与 #27（批二批红）不同文件，可并行合；磁铁 manifest 改的是不同条目。后续：批四=dynamicInstitutions 旧账迁树。

🤖 Generated with [Claude Code](https://claude.com/claude-code)