### PR TITLE
设衙章程批四·旧账收口：权设台账衙门一次性迁入官制树（岁支停走·俸循官制）

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -3931,8 +3931,8 @@
     },
     {
       "path": "tm-edict-parser.js",
-      "sha256": "596b68ef69ecd6ce017c7d22ff22cb3372ed6b54ee5a39181cd52eeacc7e9aaa",
-      "size": 108531
+      "sha256": "de38adec81f94b9113d441b9fe4afbe0fe052628ef09c761b690c35e51dfe2ee",
+      "size": 108687
     },
     {
       "path": "tm-edict-thresholds.js",
@@ -4886,8 +4886,8 @@
     },
     {
       "path": "tm-office-charter.js",
-      "sha256": "70dd02506895a805798ce920dad85ee89158419188fc4176de769ca201d29746",
-      "size": 17936
+      "sha256": "a993a75c630cc63ac916ba7b709fb70db29e326def55b9af135886d828ecb9dd",
+      "size": 22821
     },
     {
       "path": "tm-office-dutystate.js",
@@ -4906,8 +4906,8 @@
     },
     {
       "path": "tm-office-flags.js",
-      "sha256": "b13474c9e809ccb7e01679adeddaf5fe525391a645170ffe1028c283458b5dda",
-      "size": 3119
+      "sha256": "7e11573471ff09ced006145a749c7fca3a6244116e60b9a0128202d0f6128f09",
+      "size": 3307
     },
     {
       "path": "tm-office-panel.js",
@@ -4926,8 +4926,8 @@
     },
     {
       "path": "tm-office-reform.js",
-      "sha256": "4d7343619e9c7aece2adf66347c47f3694962265cd2f74fc3d4d75dd46b5e68a",
-      "size": 25351
+      "sha256": "5cb29fe03b27188e359454ca506458faed8971ec638cd681d4175e265d8b307d",
+      "size": 25487
     },
     {
       "path": "tm-office-runtime-summary-appoint.js",
@@ -5021,8 +5021,8 @@
     },
     {
       "path": "tm-patches.js",
-      "sha256": "18172bbb50fc2292d0b5470098d537ffb32fcb06f51e1f8ad233f2def4327bb3",
-      "size": 182246
+      "sha256": "1a3b0fd63fd14848cec262e936ff32adaf01b541b86eb2a4c7c0b5b90b05f707",
+      "size": 182563
     },
     {
       "path": "tm-pause-fab.js",
@@ -5336,8 +5336,8 @@
     },
     {
       "path": "tm-var-drawers.js",
-      "sha256": "364ee0f6e5d27f83eca3226e19875de6ded5be524b38adcefd7a753b76909d31",
-      "size": 118591
+      "sha256": "6c653bf31ca901ae033f9a29bbdd047504653f92693ee5fe83cfd74b99622b2e",
+      "size": 119132
     },
     {
       "path": "tm-wendui-persona-views.js",

--- a/web/scripts/smoke-office-dyn-migration.js
+++ b/web/scripts/smoke-office-dyn-migration.js
@@ -1,0 +1,131 @@
+// smoke-office-dyn-migration.js — 旧账收口·dynamicInstitutions 一次性迁入官制树（批四·2026-07-21）
+//
+// owner 拍板分叉③：权设台账衙门(浅账·永长不成真衙)迁入 officeTree 著为定制。
+// 验：flag 闸/正门落树(applyReformToTree)/挂靠 subordinateTo/同名并账不重立/废衙与
+// _viaReform 不迁/岁支停走标记/旧掌其事荐正授/AI 补章程充实职官表(无 AI 留裸亦成体统)/幂等。
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var vm = require('vm');
+
+var ROOT = path.join(__dirname, '..');
+var failures = [];
+function assert(cond, msg) {
+  if (cond) { console.log('  PASS ' + msg); }
+  else { failures.push(msg); console.log('  FAIL ' + msg); }
+}
+
+var RANKS = [
+  { id: 'z5', label: '正五品', level: 9, salary: 38 },
+  { id: 'z7', label: '正七品', level: 13, salary: 20 }
+];
+var CANNED = JSON.stringify({
+  name: '别名衙', desc: '掌其事', setupCost: 3000,
+  positions: [{ name: '主官', rank: '正五品', count: 1, powers: ['works'], authority: 'execution', salary: 38, duties: '掌其事' }],
+  heads: [{ position: '主官', name: '干吏乙', reason: '干练' }]
+});
+
+function freshSandbox(opts) {
+  opts = opts || {};
+  var sb = { console: console };
+  sb.window = sb; sb.global = sb;
+  sb._ebs = [];
+  sb.addEB = function (cat, msg) { sb._ebs.push(cat + '·' + msg); };
+  sb._jobs = [];
+  sb._enqueuePostTurnJob = function (id, fn) { sb._jobs.push({ id: id, fn: fn }); };
+  sb.SettlementPipeline = { register: function () {} };
+  sb._activeRankHierarchy = function () { return RANKS; };
+  sb._flags = { officeDynMigrationEnabled: opts.migOn !== false };
+  sb.officeFlagOn = function (n) { return !!sb._flags[n]; };
+  if (opts.ai) sb.callAI = function () { return Promise.resolve(CANNED); };
+  sb.GM = {
+    turn: 20,
+    huangwei: { index: 50 }, huangquan: { index: 50 },
+    guoku: { balance: 100000, ledgers: { money: { stock: 100000 } } },
+    officeTree: [{ name: '户部', desc: '掌钱谷', positions: [], subs: [], functions: [] }],
+    chars: [
+      { name: '天子', isPlayer: true, alive: true },
+      { name: '老教头', alive: true, loyalty: 70, administration: 60 },
+      { name: '干吏乙', alive: true, loyalty: 60, administration: 70 }
+    ],
+    dynamicInstitutions: [
+      { name: '讲武堂', stage: 'running', duties: '练兵讲武', annualBudget: 5000, headOfficial: '老教头' },
+      { name: '废衙', stage: 'abolished' },
+      { name: '清吏司', stage: 'running', subordinateTo: '户部', duties: '稽核钱粮' },
+      { name: '拟制衙', stage: 'pendingReform', _viaReform: true },
+      { name: '户部', stage: 'running', duties: '与官制树同名' }
+    ],
+    _pendingReforms: []
+  };
+  sb.findCharByName = function (n) {
+    for (var i = 0; i < sb.GM.chars.length; i++) if (sb.GM.chars[i].name === n) return sb.GM.chars[i];
+    return null;
+  };
+  sb.P = { conf: {} };
+  vm.createContext(sb);
+  ['tm-office-reform.js', 'tm-office-charter.js'].forEach(function (f) {
+    vm.runInContext(fs.readFileSync(path.join(ROOT, f), 'utf8'), sb, { filename: f });
+  });
+  return sb;
+}
+function topNames(G) { return G.officeTree.map(function (n) { return n.name; }); }
+
+console.log('① flag 闸');
+var sb0 = freshSandbox({ migOn: false });
+sb0.TM.OfficeCharter.migrateDynInstitutions(sb0.GM);
+assert(topNames(sb0.GM).length === 1 && !sb0.GM.dynamicInstitutions[0]._migratedToTree, 'flag 关→分毫不动(零回归)');
+
+console.log('② 迁移正门落树');
+var sb1 = freshSandbox({});   // 无 AI
+sb1.TM.OfficeCharter.migrateDynInstitutions(sb1.GM);
+var G1 = sb1.GM;
+assert(topNames(G1).indexOf('讲武堂') >= 0, '讲武堂落顶层真节点');
+var hb = G1.officeTree.filter(function (n) { return n.name === '户部'; })[0];
+assert(hb.subs.length === 1 && hb.subs[0].name === '清吏司', '清吏司挂靠 subordinateTo 落户部之下');
+assert(G1.officeTree.filter(function (n) { return n.name === '户部'; }).length === 1, '同名(户部)并账不重立');
+assert(G1.dynamicInstitutions[0].stage === 'migrated' && G1.dynamicInstitutions[0]._migratedToTree === true, '讲武堂旧账标 migrated(岁支停走)');
+assert(G1.dynamicInstitutions[4]._migratedToTree === true, '同名并账者亦标停走');
+assert(!G1.dynamicInstitutions[1]._migratedToTree && topNames(G1).indexOf('废衙') < 0, '废衙不迁');
+assert(!G1.dynamicInstitutions[3]._migratedToTree && topNames(G1).indexOf('拟制衙') < 0, '_viaReform 拟制衙不迁(本就无实体)');
+assert(sb1._ebs.some(function (e) { return e.indexOf('归入官制树') >= 0; }), '迁制入起居注');
+assert(Array.isArray(G1._edictSuggestions) && G1._edictSuggestions.some(function (s) { return s.content.indexOf('老教头') >= 0 && s.content.indexOf('讲武堂') >= 0; }), '旧掌其事(老教头)荐正授入建议库');
+assert(sb1._jobs.length === 0, '无 AI→不派补章job·裸节点亦成体统');
+
+console.log('③ 幂等·再跑不重迁');
+var nodesBefore = JSON.stringify(topNames(sb1.GM));
+var sugBefore = sb1.GM._edictSuggestions.length;
+sb1.TM.OfficeCharter.migrateDynInstitutions(sb1.GM);
+assert(JSON.stringify(topNames(sb1.GM)) === nodesBefore && sb1.GM._edictSuggestions.length === sugBefore, '再跑零增量');
+
+console.log('④ AI 补章程充实职官表');
+var sb2 = freshSandbox({ ai: true });
+sb2.TM.OfficeCharter.migrateDynInstitutions(sb2.GM);
+assert(sb2._jobs.length === 2 && sb2._jobs.every(function (j) { return j.id.indexOf('officeDynMig_') === 0; }), '两新落节点各派一补章job(并账者不派)');
+(async function () {
+  for (var i = 0; i < sb2._jobs.length; i++) await sb2._jobs[i].fn();
+  var jw = sb2.GM.officeTree.filter(function (n) { return n.name === '讲武堂'; })[0];
+  assert(jw && jw.positions.length === 1 && jw.positions[0].rank === '正五品' && jw.positions[0].salary === 38, '补章落职官表(品级俸给循宪法闸)');
+  assert(jw.positions[0].powers && jw.positions[0].powers.works === true && jw.positions[0].establishedCount === 1, '职权与编制字段齐(职权舆图/官俸自动接手)');
+  assert(sb2._ebs.some(function (e) { return e.indexOf('迁制补章') >= 0; }), '补章入起居注');
+  assert(sb2.GM._edictSuggestions.some(function (s) { return s.content.indexOf('干吏乙') >= 0; }), '补章荐单(干吏乙)入建议库');
+  var qs = sb2.GM.officeTree.filter(function (n) { return n.name === '户部'; })[0].subs[0];
+  assert(qs && qs.positions.length === 1, '挂靠节点(清吏司)亦获补章');
+
+  console.log('⑤ 静态契约·接线到位');
+  var parser = fs.readFileSync(path.join(ROOT, 'tm-edict-parser.js'), 'utf8');
+  assert(parser.indexOf('_migratedToTree') >= 0, '岁支 tick 见 _migratedToTree 即跳(旧账停走)');
+  var drawers = fs.readFileSync(path.join(ROOT, 'tm-var-drawers.js'), 'utf8');
+  assert(drawers.indexOf('已归官制树') >= 0, '制度志抽屉标注已归树(留痕不隐)');
+  var flagsSrc = fs.readFileSync(path.join(ROOT, 'tm-office-flags.js'), 'utf8');
+  assert(flagsSrc.indexOf("'officeDynMigrationEnabled'") >= 0, 'officeDynMigrationEnabled 入 OfficeFlags.LIST');
+  var patches = fs.readFileSync(path.join(ROOT, 'tm-patches.js'), 'utf8');
+  assert(patches.indexOf('officeDynMigrationEnabled') >= 0, '设置面板有旧衙归树开关行');
+
+  console.log('');
+  if (failures.length) {
+    console.log('FAILURES (' + failures.length + '):');
+    failures.forEach(function (f) { console.log('  - ' + f); });
+    process.exit(1);
+  }
+  console.log('smoke-office-dyn-migration: ALL PASS');
+})().catch(function (e) { console.error('SMOKE CRASH:', e); process.exit(1); });

--- a/web/tm-edict-parser.js
+++ b/web/tm-edict-parser.js
@@ -1848,6 +1848,7 @@
     var isFiscalYear = (typeof global.isYearBoundary === 'function') ? global.isYearBoundary(ctx.turn || G.turn || 0) : ((G.month || 1) === 1 && G.turn > 0);
     G.dynamicInstitutions.forEach(function(inst) {
       if (inst.stage === 'abolished') return;
+      if (inst._migratedToTree) return;   // 批四·已归官制树→岁支旧账停走(俸给改循官制 calcSalary·flag 关时无此标记=零回归)
       if (isFiscalYear && G.guoku) {
         if (G.guoku.money >= inst.annualBudget) {
           G.guoku.money -= inst.annualBudget;

--- a/web/tm-office-charter.js
+++ b/web/tm-office-charter.js
@@ -143,7 +143,7 @@
       + '{"name":"正名","desc":"职掌≤40字","positions":[{"name":"职名","rank":"品级","count":1,"powers":["键名"],"authority":"decision|execution|advisory|supervision","salary":38,"duties":"≤30字"}],"heads":[{"position":"职名","name":"人名","reason":"≤30字"}],"setupCost":3000}';
   }
 
-  async function forgeCharter(G, item) {
+  async function forgeCharter(G, item, opts) {
     if (!_aiOn() || !item) return null;
     try {
       var resp = await global.callAI(_buildPrompt(G, item), 1200, null, (typeof global._useSecondaryTier === 'function' && global._useSecondaryTier()) ? 'secondary' : undefined, { id: 'office-charter' });
@@ -153,12 +153,81 @@
       if (v) {
         item._charter = v;
         delete item._charterPending;
-        _eb('«' + v.name + '»开衙章程已拟：' + v.positions.map(function (p) { return p.name + '(' + p.rank + '×' + p.count + ')'; }).join('·') + '·开办约' + v.setupCost + '两·待廷议裁定');
+        if (!(opts && opts.silent)) _eb('«' + v.name + '»开衙章程已拟：' + v.positions.map(function (p) { return p.name + '(' + p.rank + '×' + p.count + ')'; }).join('·') + '·开办约' + v.setupCost + '两·待廷议裁定');
         return v;
       }
     } catch (_eF) {}
     delete item._charterPending;   // 失败→裁定时裸壳落树(双轨)
     return null;
+  }
+
+  // ── 批四·旧账收口：dynamicInstitutions 一次性迁入官制树（owner 拍板分叉③）──────
+  // 权设台账衙门(浅账·永长不成真衙)→经 applyReformToTree 正门落 officeTree 真节点·著为定制。
+  // 岁支旧账停走(tm-edict-parser tick 见 _migratedToTree 即跳)·俸给改循官制 calcSalary。
+  // 有 AI 则补章程充实职官表(俸循品级·失败留裸节点亦成体统)·旧掌其事者荐正授入建议库。
+  // flag officeDynMigrationEnabled 默认关·幂等(逐 inst 标记)·同名并账不重立。
+  function migEnabled() {
+    try { return typeof global.officeFlagOn === 'function' && global.officeFlagOn('officeDynMigrationEnabled'); }
+    catch (_) { return false; }
+  }
+  function _findTreeNode(G, name) {
+    var hit = null;
+    (function walk(ns) {
+      (ns || []).forEach(function (n) { if (!hit && n) { if (n.name === name) { hit = n; return; } walk(n.subs); } });
+    })(G.officeTree);
+    return hit;
+  }
+  async function _furnishMigratedNode(G, inst) {
+    var node = _findTreeNode(G, inst.name);
+    if (!node || (node.positions && node.positions.length)) return;   // 已有职官(并账/他途充实)→不动
+    var synth = { reformDetail: '增设', dept: inst.name, reason: inst.duties || '' };
+    var v = await forgeCharter(G, synth, { silent: true });
+    if (!v || typeof global._offCharterPositions !== 'function') return;
+    node = _findTreeNode(G, inst.name);                               // 异步窗口后重找(防树已变)
+    if (!node || (node.positions && node.positions.length)) return;
+    node.positions = global._offCharterPositions(v, false);
+    if (!node.desc && v.desc) node.desc = v.desc;
+    _eb('«' + inst.name + '»迁制补章：定' + node.positions.map(function (p) { return p.name + '(' + p.rank + '×' + (p.establishedCount || 1) + ')'; }).join('·') + '·俸给循品级入官俸');
+    (v.heads || []).forEach(function (h) {
+      if (!Array.isArray(G._edictSuggestions)) G._edictSuggestions = [];   // arch-ok 迁制荐单入建议库·只荐不任守五渠道
+      G._edictSuggestions.push({ source: '章程', from: '铨曹', content: '授' + h.name + '为' + inst.name + h.position + (h.reason ? '（' + h.reason + '）' : ''), turn: G.turn, used: false });   // arch-ok 同上
+    });
+  }
+  function migrateDynInstitutions(G) {
+    if (!migEnabled()) return;
+    G = G || global.GM;
+    if (!G || !Array.isArray(G.dynamicInstitutions) || !G.dynamicInstitutions.length) return;
+    if (typeof global.applyReformToTree !== 'function' || !Array.isArray(G.officeTree)) return;
+    G.dynamicInstitutions.forEach(function (inst) {
+      if (!inst || inst._migratedToTree || inst.stage === 'abolished' || inst._viaReform) return;
+      var name = String(inst.name || '').trim();
+      if (!name) { inst._migratedToTree = true; return; }
+      var existed = !!_findTreeNode(G, name);
+      if (!existed) {
+        var reform = (inst.subordinateTo && _findTreeNode(G, inst.subordinateTo))
+          ? { reformDetail: '增设', dept: inst.subordinateTo, newDept: name, reason: inst.duties || '权设之衙·迁制归树' }
+          : { reformDetail: '增设', dept: name, reason: inst.duties || '权设之衙·迁制归树' };
+        var ap = global.applyReformToTree(G, reform);
+        if (!ap || !ap.applied) return;   // 落树未成(异形树等)→下回合再试·不标记
+      }
+      inst._migratedToTree = true;
+      inst.stage = 'migrated';
+      _eb('«' + name + '»由权设台账归入官制树·著为定制' + (existed ? '（同名衙门已在树·并账不重立）' : ''));
+      // 旧掌其事者·荐正授(确定性·不赖 AI)
+      if (inst.headOfficial) {
+        var hc = _findChar(String(inst.headOfficial));
+        if (hc && hc.alive !== false && !hc.isPlayer) {
+          if (!Array.isArray(G._edictSuggestions)) G._edictSuggestions = [];   // arch-ok 迁制正授荐单·只荐不任守五渠道
+          G._edictSuggestions.push({ source: '章程', from: '铨曹', content: '授' + hc.name + '为«' + name + '»主官（旧掌其事·迁制正名）', turn: G.turn, used: false });   // arch-ok 同上
+        }
+      }
+      // AI 补章程充实职官表(新落的裸节点才需要·失败留裸=亦成体统)
+      if (!existed && _aiOn()) {
+        var job = function () { return _furnishMigratedNode(G, inst); };
+        if (typeof global._enqueuePostTurnJob === 'function') global._enqueuePostTurnJob('officeDynMig_' + name, job);
+        else job();
+      }
+    });
   }
 
   // ── 批红修改（批二·owner 拍板：章程进廷议前玩家可改品级/编制/职权）────────────
@@ -261,7 +330,7 @@
     });
   }
 
-  var API = { tick: tick, forgeCharter: forgeCharter, _validateCharter: _validateCharter, _applyCharterRevision: _applyCharterRevision, _buildPrompt: _buildPrompt, enabled: enabled, POWER_KEYS: POWER_KEYS, MAX_POSITIONS: MAX_POSITIONS, SETUP_COST_MIN: SETUP_COST_MIN, SETUP_COST_MAX: SETUP_COST_MAX };
+  var API = { tick: tick, forgeCharter: forgeCharter, _validateCharter: _validateCharter, _applyCharterRevision: _applyCharterRevision, migrateDynInstitutions: migrateDynInstitutions, _furnishMigratedNode: _furnishMigratedNode, migEnabled: migEnabled, _buildPrompt: _buildPrompt, enabled: enabled, POWER_KEYS: POWER_KEYS, MAX_POSITIONS: MAX_POSITIONS, SETUP_COST_MIN: SETUP_COST_MIN, SETUP_COST_MAX: SETUP_COST_MAX };
   global._charterReviewOpen = _charterReviewOpen;
   global.TM = global.TM || {};
   global.TM.OfficeCharter = API;
@@ -272,6 +341,9 @@
       global.SettlementPipeline.register('officeCharter', '章程演绎', function () {
         try { tick(global.GM); } catch (_eT) {}
       }, 93, 'perturn');
+      global.SettlementPipeline.register('officeDynMigration', '旧衙归树', function () {
+        try { migrateDynInstitutions(global.GM); } catch (_eM) {}
+      }, 94, 'perturn');
     }
   } catch (_eR) {}
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/web/tm-office-flags.js
+++ b/web/tm-office-flags.js
@@ -9,6 +9,7 @@
 //   officeAuthorityGateEnabled      Slice③ 权限门控（接活 canPerformAction）
 //   officeReformAdjudicationEnabled Slice④ AI 裁定式改制闭环
 //   officeCharterEnabled            设衙门批一·拟制期 AI 拟开衙章程（职掌/官职表/首任荐单/开办费·须④开才有拟制态可拟）
+//   officeDynMigrationEnabled       设衙门批四·dynamicInstitutions 权设台账一次性迁入官制树（岁支停走俸循官制·有 AI 补章程）
 //   officeRecallAgentEnabled        #1 主推演 office-recall 子调用（按需取数·走次要 API）
 //
 // 语义：组闸 || 各独立开关。
@@ -39,7 +40,7 @@
   var TM = global.TM = global.TM || {};
   TM.OfficeFlags = {
     MASTER: 'officeActivationEnabled',
-    LIST: ['officePowerPerceptionEnabled', 'officeDutyStateEnabled', 'officeAuthorityGateEnabled', 'officeReformAdjudicationEnabled', 'officeCharterEnabled', 'officeRecallAgentEnabled'],
+    LIST: ['officePowerPerceptionEnabled', 'officeDutyStateEnabled', 'officeAuthorityGateEnabled', 'officeReformAdjudicationEnabled', 'officeCharterEnabled', 'officeDynMigrationEnabled', 'officeRecallAgentEnabled'],
     on: officeFlagOn,
     setMaster: function (v) { var P = global.P; if (P) { P.conf = P.conf || {}; P.conf.officeActivationEnabled = !!v; } return !!v; },
     masterOn: function () { var P = global.P || {}; return !!((P.ai && P.ai.officeActivationEnabled) || (P.conf && P.conf.officeActivationEnabled)); },

--- a/web/tm-office-reform.js
+++ b/web/tm-office-reform.js
@@ -328,6 +328,7 @@
 
   global.computeReformResistance = computeReformResistance;
   global.applyReformToTree = applyReformToTree;
+  global._offCharterPositions = _charterPositions;   // 批四·旧账迁树充实职官表复用同一转换(章程→position 形状)
   global.enqueuePendingReform = enqueuePendingReform;
   global.adjudicatePendingReforms = adjudicatePendingReforms;
   if (typeof module !== 'undefined' && module.exports) module.exports = { computeReformResistance: computeReformResistance, applyReformToTree: applyReformToTree, enqueuePendingReform: enqueuePendingReform, adjudicatePendingReforms: adjudicatePendingReforms, FORCE: FORCE };

--- a/web/tm-patches.js
+++ b/web/tm-patches.js
@@ -972,6 +972,7 @@ openSettings=function(){
               ['officeAuthorityGateEnabled','权限门控','掌“征税”等权者出缺/失职→实征打折·腐败涨(影响 balance)。',false],
               ['officeReformAdjudicationEnabled','改制裁定','玩家自由改官制→官僚抵抗·拟制两回合·AI 裁定准驳。',false],
               ['officeCharterEnabled','设衙章程','下诏设新衙门时 AI 拟开衙章程：正名·职掌·官职表(品级/编制/职权/月俸)·首任荐单·开办费(国库真扣)，廷议裁定后按章开衙。须同开「改制裁定」方有拟制态可拟(增 AI 子调用)。',false],
+              ['officeDynMigrationEnabled','旧衙归树','把历年「设衙门」攒下的权设台账衙门一次性迁入官制树·著为定制：岁支旧账停走·员额俸给改循官制·旧掌其事者荐正授入建议库·有 AI 则补章程定职官表。开一次迁一次·并账不重立。',false],
               ['officeRecallAgentEnabled','官署按需细查','主推演对焦点衙门发 agent 子调用取职责细节(走次要 API·增调用)。',false],
               ['officeVacancyEnabled','出缺补员（默认开）','官员亡故/致仕留缺→按建制走出缺·可被补员(关则不自动出缺)。',true]
             ];

--- a/web/tm-var-drawers.js
+++ b/web/tm-var-drawers.js
@@ -811,6 +811,13 @@
     if (_diList.length > 0 || _pendInst.length > 0) {
       var dh = '';
       _diList.forEach(function(inst) {
+        // 批四·已迁官制树者：账面改标(岁支停走·员额俸给循官制)·留痕不隐(可查旧账)
+        if (inst._migratedToTree) {
+          dh += '<div style="padding:5px 8px;background:var(--bg-2);border-left:3px solid #6aa88a;margin-bottom:3px;font-size:0.74rem;">';
+          dh += '<b style="color:#6aa88a;">' + _esc(inst.name) + '</b> · <span style="color:var(--txt-d);">已归官制树·著为定制（员额俸给循官制·详见官制册页）</span>';
+          dh += '</div>';
+          return;
+        }
         var stCol = inst.stage === 'abolished' ? 'var(--vermillion-400)' : inst.stage === 'running' ? '#6aa88a' : 'var(--gold)';
         dh += '<div style="padding:5px 8px;background:var(--bg-2);border-left:3px solid ' + stCol + ';margin-bottom:3px;font-size:0.74rem;">';
         dh += '<b style="color:' + stCol + ';">' + _esc(inst.name) + '</b> · 品 ' + (inst.rank!=null?inst.rank:'—') + ' · ' + _esc(inst.stage) + ' · 员额 ' + (inst.staffSize||0) + ' · 岁支 ' + _fmt(inst.annualBudget||0);


### PR DESCRIPTION
## 摘要
批一摊桌 owner 拍板分叉③=「一次性迁入官制树」。历年「设衙门」攒下的 `dynamicInstitutions` 浅台账（有岁支/腐败度但永远长不成真衙门）收口：

- **迁移走正门**：每座权设衙门经 `applyReformToTree` 落 officeTree 真节点；`subordinateTo` 能对上现有衙门则挂靠其下；与树同名者并账不重立；已废之衙与 `_viaReform` 拟制占位不迁。逐 inst 标记幂等，开一次迁一次。
- **旧账停走**：岁支 tick 见 `_migratedToTree` 即跳（俸给改循官制 `calcSalary`）；制度志抽屉标「已归官制树·著为定制」，留痕不隐可查旧账。
- **人事有交代**：`headOfficial` 旧掌其事者确定性荐正授入诏书建议库（只荐不任）。
- **AI 补章程**：有 AI 则为新落的裸节点补章程定职官表（复用批一 forgeCharter + 同一宪法闸 + `_offCharterPositions` 转换），补齐品级/编制/职权/月俸——职权舆图与官俸结算自动接手；无 AI 留裸节点亦成体统。
- flag `officeDynMigrationEnabled` 默认关 + 设置行（官制活化细粒度组）。

## 验证
smoke-office-dyn-migration 22 断言（flag 闸/挂靠/并账/废衙不迁/幂等/荐正授/AI 补章全链/静态契约）·全量 ci-smokes 790 绿·lint-arch-all 8/8·热更基线 --check 绿。

## 合并顺序
本 PR 堆叠在批二分支上（同文件 tm-office-charter.js）：**请先合 #27，本 PR diff 会自动收窄为批四增量再合**。#28（批三）独立可任意顺序。

🤖 Generated with [Claude Code](https://claude.com/claude-code)