### PR TITLE
剧本工坊顶栏收纳：十三钮→六钮+「⋯」菜单（删冗余·重置加二次确认）

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -3286,8 +3286,8 @@
     },
     {
       "path": "preview/scenario-editor-reset-app.js",
-      "sha256": "c0e4ed2ec460d7aaefa5faf314246a3de601ae13ba7aa629b49bd6769ea913aa",
-      "size": 1381554
+      "sha256": "316b07b928d6c580506ab8da313376d46f1179bac941690c6c0e0af908b76e6c",
+      "size": 1384495
     },
     {
       "path": "preview/scenario-editor-reset-data.js",
@@ -3301,8 +3301,8 @@
     },
     {
       "path": "preview/scenario-editor-reset-style.css",
-      "sha256": "66b07f6a2d1b561083220c49cdad4b73c0dcdc8f45fcb038acfc01ee0cd77fab",
-      "size": 381679
+      "sha256": "16fe76c28d50db60419968791594fd109374e492745e21fe81eea0cd7ffec198",
+      "size": 382823
     },
     {
       "path": "preview/scenario-editor-sandbox-bridge.js",

--- a/web/preview/scenario-editor-reset-app.js
+++ b/web/preview/scenario-editor-reset-app.js
@@ -13379,7 +13379,7 @@
       title: 'AI / 校验',
       items: [
         { keys: '顶栏「验」', desc: '校验剧本冲突，写入运行态' },
-        { keys: '顶栏「预」', desc: '运行发布预检（导出守门）' },
+        { keys: '顶栏「⋯」→发布预检', desc: '运行发布预检（导出守门·「出」亦内含预检）' },
         { keys: '顶栏「补齐并运行」', desc: '一键 AI 补齐所有缺失字段' }
       ]
     },
@@ -21456,25 +21456,64 @@
     refreshAiPromptCostBadge();
   }
 
+  function closeTopMoreMenu() {
+    var menu = document.querySelector('.top-more-menu');
+    var btn = document.querySelector('[data-editor-command="toggle-more-menu"]');
+    if (menu) menu.hidden = true;
+    if (btn) btn.setAttribute('aria-expanded', 'false');
+  }
+  function toggleTopMoreMenu() {
+    var menu = document.querySelector('.top-more-menu');
+    var btn = document.querySelector('[data-editor-command="toggle-more-menu"]');
+    if (!menu) return;
+    menu.hidden = !menu.hidden;
+    if (btn) btn.setAttribute('aria-expanded', menu.hidden ? 'false' : 'true');
+  }
+
   function bootstrapChrome() {
     var actions = document.querySelector('.top-actions');
     if (actions) {
+      /* 顶栏收纳(2026-07-21·owner「太乱·冗杂重复」)：十三钮→六钮+「⋯」菜单。
+       * 直出=真高频且职责唯一：退/复(撤销重做)·验(校验)·出(预检并导出)·回(写回正式游戏)·👁(玩家视角·带 data-pv-launch=adapters 免重注)。
+       * 「预」不再直出(出已内含预检=重复)·新/入/链/帮/数值体检/重置(危险区·二次确认)全收「⋯」。
+       * ⚙ API 设置钮已退役(2026-07-03·主API配置移驻国师面板模型徽弹层·生图API在规则AI章面板) */
       actions.innerHTML = [
-        '<button type="button" class="icon-btn" data-editor-command="focus-runtime-panel" data-runtime-panel="new-scenario-starter" title="新建剧本" aria-label="新建剧本">新</button>',
         '<button type="button" class="icon-btn" data-editor-command="undo-edit" title="撤销 (Ctrl+Z)" aria-label="撤销上一步编辑">退</button>',
         '<button type="button" class="icon-btn" data-editor-command="redo-edit" title="重做 (Ctrl+Y)" aria-label="重做上一步撤销">复</button>',
-        '<button type="button" class="icon-btn" data-editor-command="run-preflight" title="发布预检" aria-label="运行发布预检">预</button>',
         '<button type="button" class="icon-btn" data-editor-command="validate" title="校验冲突" aria-label="校验剧本冲突">验</button>',
-        '<button type="button" class="icon-btn" data-editor-command="import" title="导入剧本" aria-label="导入剧本 JSON 文件">入</button>',
         '<button type="button" class="icon-btn" data-editor-command="preflight-export" title="预检并导出" aria-label="先预检再导出剧本">出</button>',
         '<button type="button" class="icon-btn" data-editor-command="return-to-formal-runtime" title="写回正式游戏" aria-label="把当前剧本写回正式游戏运行时">回</button>',
-        '<button type="button" class="icon-btn" data-editor-command="reset" title="重置编辑器" aria-label="重置编辑器到官方基线">归</button>',
-        '<button type="button" class="icon-btn" data-editor-command="copy-share-url" title="复制分享链接" aria-label="复制剧本分享链接到剪贴板">链</button>',
-        /* ⚙ API 设置钮已退役(2026-07-03·主API配置移驻国师面板模型徽弹层·生图API在规则AI章面板) */
-        '<button type="button" class="icon-btn" data-editor-command="open-shortcut-cheatsheet" title="键盘快捷键 (Shift+?)" aria-label="查看键盘快捷键参考" aria-keyshortcuts="Shift+?">帮</button>',
+        '<button type="button" class="icon-btn" data-pv-launch="preview" title="玩家视角预览" aria-label="玩家视角预览">👁</button>',
+        '<span class="top-more-wrap">',
+        '<button type="button" class="icon-btn" data-editor-command="toggle-more-menu" title="更多操作" aria-label="更多操作" aria-haspopup="true" aria-expanded="false">⋯</button>',
+        '<span class="top-more-menu" hidden>',
+        '<button type="button" class="top-more-item" data-editor-command="focus-runtime-panel" data-runtime-panel="new-scenario-starter">新建剧本</button>',
+        '<button type="button" class="top-more-item" data-editor-command="import">导入剧本</button>',
+        '<button type="button" class="top-more-item" data-editor-command="run-preflight">发布预检</button>',
+        '<button type="button" class="top-more-item" data-pv-launch="audit">数值体检</button>',
+        '<button type="button" class="top-more-item" data-editor-command="copy-share-url">复制分享链接</button>',
+        '<button type="button" class="top-more-item" data-editor-command="open-shortcut-cheatsheet" aria-keyshortcuts="Shift+?">键盘快捷键 (Shift+?)</button>',
+        '<span class="top-more-sep" role="separator"></span>',
+        '<button type="button" class="top-more-item top-more-danger" data-editor-command="reset">⚠ 重置到官方基线</button>',
+        '</span>',
+        '</span>',
         '<input id="scenario-import-input" type="file" accept=".json,application/json" hidden>',
         '<input id="project-package-import-input" type="file" accept=".json,application/json" hidden>'
       ].join('');
+      // 「⋯」菜单开合：点外面关·Escape 关·点菜单项(执行命令后)关。document 级委托只装一次。
+      if (!document.body.hasAttribute('data-topmore-wired')) {
+        document.body.setAttribute('data-topmore-wired', '1');
+        document.addEventListener('click', function (ev) {
+          var menu = document.querySelector('.top-more-menu');
+          if (!menu || menu.hidden) return;
+          if (ev.target.closest && ev.target.closest('[data-editor-command="toggle-more-menu"]')) return;   // 开关钮自己在 router 里翻
+          if (ev.target.closest && ev.target.closest('.top-more-item')) { closeTopMoreMenu(); return; }     // 选了菜单项→收
+          if (!(ev.target.closest && ev.target.closest('.top-more-wrap'))) closeTopMoreMenu();              // 点在外面→收
+        });
+        document.addEventListener('keydown', function (ev) {
+          if (ev.key === 'Escape') closeTopMoreMenu();
+        });
+      }
     }
     var bottom = document.querySelector('.bottom-note');
     var runtimeAnchor = document.querySelector('.main-stack .hero-board') || bottom;
@@ -21890,7 +21929,13 @@
     }
     if (command === 'copy-release-notes') copyReleaseNotes();
     if (command === 'export') exportScenario();
-    if (command === 'reset') resetToOfficial();
+    if (command === 'toggle-more-menu') toggleTopMoreMenu();
+    // 重置=丢弃全部改动+清编辑历史·此前一点即毁无确认(地雷)·今必二次确认(仅按钮路径·API/工坊程序化重置不走此)
+    if (command === 'reset') {
+      var _rstOk = true;
+      try { if (typeof window !== 'undefined' && typeof window.confirm === 'function') _rstOk = window.confirm('重置将丢弃当前剧本的全部改动、清空编辑历史，回到官方基线。\n此操作不可撤销——确定重置？'); } catch (_eCf) {}
+      if (_rstOk) resetToOfficial();
+    }
     if (command === 'save-project-snapshot' || command === 'fork-project-snapshot') {
       var nameInput = document.getElementById('project-snapshot-name');
       var label = nameInput && nameInput.value ? nameInput.value : (state.scenario.name || '未命名案卷');

--- a/web/preview/scenario-editor-reset-style.css
+++ b/web/preview/scenario-editor-reset-style.css
@@ -11419,22 +11419,22 @@
        creators can't tell which buttons belong together. Group them by
        function via thin gold-tinted vertical dividers inserted between
        logical bundles. Dividers are pure CSS (separator pseudo via
-       margin-left bumps after each group's last button). The order is:
-       navigation (新 退 复) | validation (预 验) | i/o (入 出 回 归 链) | help (帮). */
+       margin-left bumps after each group's last button). 2026-07-21 顶栏收纳后
+       the order is: edit (退 复) | validation (验) | 成品 (出 回) | 👁 | ⋯ menu. */
     .top-actions {
       gap: 6px;
     }
 
-    .top-actions .icon-btn:not(:last-of-type) + .icon-btn[data-editor-command="run-preflight"],
-    .top-actions .icon-btn:not(:last-of-type) + .icon-btn[data-editor-command="import"],
-    .top-actions .icon-btn:not(:last-of-type) + .icon-btn[data-editor-command="open-shortcut-cheatsheet"] {
+    .top-actions .icon-btn:not(:last-of-type) + .icon-btn[data-editor-command="validate"],
+    .top-actions .icon-btn:not(:last-of-type) + .icon-btn[data-editor-command="preflight-export"],
+    .top-actions .icon-btn:not(:last-of-type) + .icon-btn[data-pv-launch="preview"] {
       margin-left: 10px;
       position: relative;
     }
 
-    .top-actions .icon-btn:not(:last-of-type) + .icon-btn[data-editor-command="run-preflight"]::before,
-    .top-actions .icon-btn:not(:last-of-type) + .icon-btn[data-editor-command="import"]::before,
-    .top-actions .icon-btn:not(:last-of-type) + .icon-btn[data-editor-command="open-shortcut-cheatsheet"]::before {
+    .top-actions .icon-btn:not(:last-of-type) + .icon-btn[data-editor-command="validate"]::before,
+    .top-actions .icon-btn:not(:last-of-type) + .icon-btn[data-editor-command="preflight-export"]::before,
+    .top-actions .icon-btn:not(:last-of-type) + .icon-btn[data-pv-launch="preview"]::before {
       content: "";
       position: absolute;
       left: -5px;
@@ -11445,14 +11445,62 @@
       pointer-events: none;
     }
 
-    .top-actions .icon-btn[data-editor-command="open-shortcut-cheatsheet"] {
-      border-color: rgba(95,157,140,.5);
-      color: rgba(188,230,217,.92);
+    /* 「⋯」收纳菜单（新/入/预/数值体检/链/帮/重置） */
+    .top-more-wrap {
+      position: relative;
+      display: inline-flex;
     }
 
-    .top-actions .icon-btn[data-editor-command="open-shortcut-cheatsheet"]:hover {
-      border-color: rgba(188,230,217,.9);
-      background: rgba(95,157,140,.18);
+    .top-more-menu {
+      position: absolute;
+      top: calc(100% + 6px);
+      right: 0;
+      z-index: 60;
+      min-width: 178px;
+      display: flex;
+      flex-direction: column;
+      padding: 6px;
+      background: var(--je-ink-850, #17140f);
+      border: 1px solid rgba(202,162,76,.45);
+      border-radius: var(--je-radius, 6px);
+      box-shadow: 0 10px 26px rgba(0,0,0,.5);
+    }
+
+    .top-more-item {
+      font-family: inherit;
+      font-size: 13px;
+      text-align: left;
+      padding: 7px 10px;
+      cursor: pointer;
+      border: 0;
+      border-radius: 4px;
+      background: transparent;
+      color: var(--je-ink-200, #d4c9b0);
+      line-height: 1.3;
+      white-space: nowrap;
+    }
+
+    .top-more-item:hover,
+    .top-more-item:focus-visible {
+      background: rgba(184,154,83,.16);
+      color: #f3df9d;
+    }
+
+    .top-more-sep {
+      display: block;
+      height: 1px;
+      margin: 5px 6px;
+      background: linear-gradient(90deg, transparent, rgba(202,162,76,.4), transparent);
+    }
+
+    .top-more-item.top-more-danger {
+      color: rgba(224,122,102,.92);
+    }
+
+    .top-more-item.top-more-danger:hover,
+    .top-more-item.top-more-danger:focus-visible {
+      background: rgba(169,79,63,.18);
+      color: #ef9a86;
     }
 
     .top-actions .icon-btn:active {

--- a/web/scripts/smoke-scenario-editor-reset-preview.js
+++ b/web/scripts/smoke-scenario-editor-reset-preview.js
@@ -2468,8 +2468,8 @@ assert(appJs.includes('aria-label="重做上一步撤销"'),
   'redo icon-btn should expose an explicit aria-label');
 assert(appJs.includes('aria-label="校验剧本冲突"'),
   'validate icon-btn should expose an explicit aria-label');
-assert(appJs.includes('aria-label="复制剧本分享链接到剪贴板"'),
-  'share-url icon-btn should expose an explicit aria-label');
+assert(appJs.includes('data-editor-command="copy-share-url">复制分享链接'),
+  'share-url should live in the ⋯ more-menu with readable text (顶栏收纳 2026-07-21)');
 assert(appJs.includes('title="撤销 (Ctrl+Z)"'),
   'undo icon-btn title should surface the keyboard shortcut');
 assert(appJs.includes('title="重做 (Ctrl+Y)"'),
@@ -2699,12 +2699,25 @@ assert(appJs.includes('persistDraftToIdb') && appJs.includes('function putDraftB
 // Slice 74: top-action group dividers.
 assert(html.includes('Slice 74: Top-action group dividers'),
   'preview shell should mark Slice 74 polish block');
-assert(/\.top-actions \.icon-btn:not\(:last-of-type\) \+ \.icon-btn\[data-editor-command="run-preflight"\]/.test(html),
-  'preflight button should start the validation group with a divider');
-assert(/\.top-actions \.icon-btn:not\(:last-of-type\) \+ \.icon-btn\[data-editor-command="import"\]/.test(html),
-  'import button should start the i/o group with a divider');
-assert(/\.top-actions \.icon-btn\[data-editor-command="open-shortcut-cheatsheet"\]\s*\{[^}]*rgba\(95,157,140/.test(html),
-  '帮 icon-btn should pick up the jade accent');
+assert(/\.top-actions \.icon-btn:not\(:last-of-type\) \+ \.icon-btn\[data-editor-command="validate"\]/.test(html),
+  'validate button should start the check group with a divider (顶栏收纳后分组=退复|验|出回|👁|⋯)');
+assert(/\.top-actions \.icon-btn:not\(:last-of-type\) \+ \.icon-btn\[data-editor-command="preflight-export"\]/.test(html),
+  'preflight-export button should start the 成品 group with a divider');
+// 顶栏收纳(2026-07-21)：十三钮→六钮+「⋯」菜单·预(与出重复)不再直出·重置入危险区二次确认
+assert(html.includes('.top-more-menu') && html.includes('.top-more-danger'),
+  'style should carry the ⋯ more-menu with a danger zone');
+assert(appJs.includes('data-editor-command="toggle-more-menu"'),
+  'toolbar should expose the ⋯ more-menu toggle');
+assert(appJs.includes('class="top-more-item top-more-danger" data-editor-command="reset"'),
+  'reset should live in the more-menu danger zone, not as a bare top button');
+assert(appJs.includes('window.confirm') && appJs.includes('重置将丢弃当前剧本的全部改动'),
+  'reset command must be gated behind an explicit confirm (地雷修复)');
+assert(!/icon-btn" data-editor-command="run-preflight"/.test(appJs),
+  '预 must not be a bare top icon-btn anymore (出 already preflights — redundant)');
+assert(appJs.includes('data-pv-launch="preview"'),
+  'toolbar should carry 玩家视角 launcher inline so adapters skip double-injection');
+assert(appJs.includes('data-pv-launch="audit"'),
+  '数值体检 should live in the more-menu via data-pv-launch=audit');
 assert(/\.top-actions \.icon-btn:active\s*\{[^}]*transform:\s*scale\(0\.96\)/.test(html),
   'icon-btn press should scale down for tactile feedback');
 


### PR DESCRIPTION
## 摘要
owner 批工坊顶栏「太乱、冗杂重复」（截图：十三颗单字钮挤成两行）。收纳如下：

**直出六钮**（真高频且职责唯一）：`退 复 | 验 | 出 回 | 👁`
- 退/复=撤销重做（触屏刚需）；验=校验冲突；出=预检并导出；回=写回正式游戏；👁=玩家视角预览（改为内联渲染并带 `data-pv-launch`，adapters 的注入器识别后自动跳过，不再重复注入）。

**删与收**：
- 「预」（发布预检）**不再直出**——「出」本身就是预检并导出，纯重复；功能保留在「⋯」菜单。
- 「帮」钮退场——Shift+? 快捷键仍在，键盘表入菜单。
- 「⋯」菜单：新建剧本 / 导入 / 发布预检 / 数值体检 / 分享链接 / 快捷键表 / **⚠ 重置到官方基线**（危险区红字）。

**地雷修复**：「归」（重置到官方基线）此前**无任何确认**，一次误触即丢弃全部改动并清空编辑历史。现按钮路径必过 `window.confirm` 二次确认；`TM_SCENARIO_EDITOR_RESET_APP` API 与程序化路径不受影响。

菜单交互：点外面关、Escape 关、选完项自动收。分组分隔线（Slice 74）随新布局重排；快捷键表里「顶栏预」的陈述同步改。

## 验证
smoke-scenario-editor-reset-preview 契约更新+新增 9 断言（⋯菜单/危险区/确认闸/预不直出/adapters 双注防线），2221 断言绿；全量 ci-smokes 791 绿；lint-arch-all 8/8；热更基线 --check 绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)