### PR TITLE
fix: close audit follow-up blockers

### DIFF
--- a/main-impl.js
+++ b/main-impl.js
@@ -422,8 +422,7 @@ function getHotUpdateKeyId(key) {
 }
 
 function verifyAuthenticatedUpdateDocument(document, expectedType) {
-  const allowUnsignedTest = TEST_MODE
-    || (!app.isPackaged && process.env.TIANMING_ALLOW_UNSIGNED_HOT_UPDATE === '1');
+  const allowUnsignedTest = TEST_MODE;
   const auth = document && document.auth;
   if (!auth) {
     if (allowUnsignedTest) return document;
@@ -1190,12 +1189,12 @@ function isAllowedRemoteUrl(rawUrl) {
   const isLocalHttp = parsed.protocol === 'http:' && /^(localhost|127\.0\.0\.1|\[::1\])$/i.test(parsed.hostname);
   if (parsed.username || parsed.password) return false;
   if (parsed.protocol === 'https:' && parsed.port && parsed.port !== '443') return false;
-  return parsed.protocol === 'https:' || (isLocalHttp && !app.isPackaged);
+  return parsed.protocol === 'https:' || (isLocalHttp && TEST_MODE);
 }
 
 function resolveRemoteUrl(rawUrl, baseUrl) {
   const resolved = new URL(rawUrl, baseUrl || undefined).toString();
-  if (!isAllowedRemoteUrl(resolved)) throw new Error('远程地址必须使用 HTTPS；本机调试允许 localhost HTTP。');
+  if (!isAllowedRemoteUrl(resolved)) throw new Error('远程地址必须使用 HTTPS；显式测试模式才允许 localhost HTTP。');
   return resolved;
 }
 
@@ -1230,7 +1229,7 @@ async function assertSafeRemoteUrl(rawUrl) {
   const resolved = resolveRemoteUrl(rawUrl);
   const parsed = new URL(resolved);
   const hostname = remoteHostname(parsed);
-  const localDev = !app.isPackaged && /^(localhost|127\.0\.0\.1|::1)$/i.test(hostname);
+  const localDev = TEST_MODE && /^(localhost|127\.0\.0\.1|::1)$/i.test(hostname);
   if (localDev) return resolved;
   // 生产网络能力不接受 IP literal。域名需经过下方全部 A/AAAA 记录检查，
   // 避免 127.0.0.1、metadata 与保留网段通过十六进制/IPv6 写法绕过。

--- a/main-impl.js
+++ b/main-impl.js
@@ -15,6 +15,8 @@ const dns = require('dns').promises;
 const nodeNet = require('net');
 const { pathToFileURL, fileURLToPath } = require('url');
 const AdmZip = require('adm-zip');
+const yauzl = require('yauzl');
+const { pipeline } = require('stream');
 const { autoUpdater } = require('electron-updater');
 
 // ============================================================
@@ -788,6 +790,15 @@ const ALLOWED_HOT_UPDATE_EXTS = new Set([
   '.glb', '.gltf', '.bin', // 3D 资产（御驾亲征兵模等）
   '.onnx' // 本地语义模型；壳层能力自 1.3.4.12 起，发布器会自动抬高 minAppVersion
 ]);
+const WORKSHOP_ZIP_LIMITS = Object.freeze({
+  maxEntries: 4096,
+  maxTotalBytes: 250 * 1024 * 1024,
+  maxFileBytes: 128 * 1024 * 1024,
+  maxCompressionRatio: 250,
+  compressionRatioMinBytes: 1024 * 1024,
+  maxNameBytes: 240,
+  maxDepth: 16
+});
 
 function walkPackFiles(root) {
   const out = [];
@@ -868,15 +879,231 @@ function createTempDir(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 }
 
-function extractZipToTemp(zipPath) {
-  const temp = createTempDir('tianming-pack-');
-  const zip = new AdmZip(zipPath);
-  zip.getEntries().forEach(entry => {
-    const target = path.resolve(temp, entry.entryName);
-    if (!isInsideDir(temp, target)) throw new Error('压缩包包含越界路径: ' + entry.entryName);
+function openWorkshopZip(zipPath) {
+  return new Promise((resolve, reject) => {
+    yauzl.open(zipPath, {
+      lazyEntries: true,
+      autoClose: false,
+      decodeStrings: true,
+      validateEntrySizes: true,
+      strictFileNames: true
+    }, (error, zip) => error ? reject(error) : resolve(zip));
   });
-  zip.extractAllTo(temp, true);
-  return temp;
+}
+
+function validateWorkshopZipEntry(entry, seenPaths) {
+  const rawName = String(entry && entry.fileName || '');
+  if (!rawName || rawName.indexOf('\0') >= 0) throw new Error('压缩包包含空文件名或 NUL 字节');
+  if (rawName.indexOf('\\') >= 0 || rawName[0] === '/' || /^[a-zA-Z]:/.test(rawName)) {
+    throw new Error('压缩包包含绝对或非规范路径: ' + rawName);
+  }
+  if (Buffer.byteLength(rawName, 'utf8') > WORKSHOP_ZIP_LIMITS.maxNameBytes) {
+    throw new Error('压缩包文件名过长: ' + rawName.slice(0, 80));
+  }
+  const isDirectory = /\/$/.test(rawName);
+  const normalized = isDirectory ? rawName.slice(0, -1) : rawName;
+  const segments = normalized.split('/');
+  if (!normalized || segments.some(part => !part || part === '.' || part === '..')) {
+    throw new Error('压缩包包含越界或非规范路径: ' + rawName);
+  }
+  if (segments.length > WORKSHOP_ZIP_LIMITS.maxDepth) {
+    throw new Error('压缩包目录层级过深: ' + rawName);
+  }
+  const canonical = segments.join('/');
+  const duplicateKey = canonical.toLocaleLowerCase('en-US');
+  if (seenPaths && seenPaths.has(duplicateKey)) throw new Error('压缩包包含重复路径: ' + rawName);
+  if (seenPaths) seenPaths.add(duplicateKey);
+
+  const mode = (Number(entry.externalFileAttributes) >>> 16) & 0xffff;
+  if ((mode & 0xf000) === 0xa000) throw new Error('工坊包不允许包含符号链接: ' + rawName);
+  if ((Number(entry.generalPurposeBitFlag) & 1) !== 0) throw new Error('工坊包不允许加密条目: ' + rawName);
+
+  const compressedSize = Number(entry.compressedSize);
+  const uncompressedSize = Number(entry.uncompressedSize);
+  if (!Number.isSafeInteger(compressedSize) || compressedSize < 0 ||
+      !Number.isSafeInteger(uncompressedSize) || uncompressedSize < 0) {
+    throw new Error('压缩包条目大小非法: ' + rawName);
+  }
+  if (uncompressedSize > WORKSHOP_ZIP_LIMITS.maxFileBytes) {
+    throw new Error('工坊包单文件超过 128MB 上限: ' + rawName);
+  }
+  if (!isDirectory && uncompressedSize >= WORKSHOP_ZIP_LIMITS.compressionRatioMinBytes) {
+    const ratio = compressedSize > 0 ? uncompressedSize / compressedSize : Infinity;
+    if (ratio > WORKSHOP_ZIP_LIMITS.maxCompressionRatio) {
+      throw new Error('工坊包条目压缩比异常，疑似 ZIP 炸弹: ' + rawName);
+    }
+  }
+  if (!isDirectory) {
+    const ext = path.posix.extname(canonical).toLowerCase();
+    if (BLOCKED_PACK_EXTS.has(ext)) throw new Error('工坊包含有禁止类型文件: ' + rawName);
+    if (!ALLOWED_PACK_EXTS.has(ext)) throw new Error('工坊包含有未允许的文件类型: ' + rawName);
+  }
+  return { rawName, canonical, isDirectory, compressedSize, uncompressedSize };
+}
+
+async function preflightWorkshopZip(zipPath) {
+  const archiveStat = fs.statSync(zipPath);
+  if (!archiveStat.isFile()) throw new Error('工坊压缩包不是普通文件');
+  const zip = await openWorkshopZip(zipPath);
+  return new Promise((resolve, reject) => {
+    const seenPaths = new Set();
+    let entries = 0;
+    let files = 0;
+    let totalBytes = 0;
+    let settled = false;
+    function closeQuietly() { try { zip.close(); } catch (_) {} }
+    function fail(error) {
+      if (settled) return;
+      settled = true;
+      closeQuietly();
+      reject(error);
+    }
+    function finish() {
+      if (settled) return;
+      settled = true;
+      closeQuietly();
+      resolve({
+        entries,
+        files,
+        totalBytes,
+        archiveSize: archiveStat.size,
+        archiveMtimeMs: archiveStat.mtimeMs
+      });
+    }
+    zip.on('error', fail);
+    zip.on('entry', entry => {
+      try {
+        entries += 1;
+        if (entries > WORKSHOP_ZIP_LIMITS.maxEntries) throw new Error('工坊包文件数量超过 4096 上限');
+        const info = validateWorkshopZipEntry(entry, seenPaths);
+        if (!info.isDirectory) {
+          files += 1;
+          totalBytes += info.uncompressedSize;
+          if (!Number.isSafeInteger(totalBytes) || totalBytes > WORKSHOP_ZIP_LIMITS.maxTotalBytes) {
+            throw new Error('工坊包声明解压体积超过 250MB 上限');
+          }
+        }
+        zip.readEntry();
+      } catch (error) {
+        fail(error);
+      }
+    });
+    zip.on('end', finish);
+    if (Number(zip.entryCount) > WORKSHOP_ZIP_LIMITS.maxEntries) {
+      fail(new Error('工坊包文件数量超过 4096 上限'));
+      return;
+    }
+    zip.readEntry();
+  });
+}
+
+function streamWorkshopEntry(zip, entry, target, counters) {
+  return new Promise((resolve, reject) => {
+    zip.openReadStream(entry, (openError, readStream) => {
+      if (openError) { reject(openError); return; }
+      let entryBytes = 0;
+      let quotaError = null;
+      const writeStream = fs.createWriteStream(target, { flags: 'wx', mode: 0o600 });
+      readStream.on('data', chunk => {
+        entryBytes += chunk.length;
+        counters.totalBytes += chunk.length;
+        if (entryBytes > WORKSHOP_ZIP_LIMITS.maxFileBytes ||
+            counters.totalBytes > WORKSHOP_ZIP_LIMITS.maxTotalBytes ||
+            entryBytes > Number(entry.uncompressedSize)) {
+          quotaError = new Error('工坊包实际解压体积超过配额: ' + entry.fileName);
+          readStream.destroy(quotaError);
+        }
+      });
+      pipeline(readStream, writeStream, error => {
+        const finalError = quotaError || error;
+        if (finalError) {
+          try { fs.rmSync(target, { force: true }); } catch (_) {}
+          reject(finalError);
+          return;
+        }
+        if (entryBytes !== Number(entry.uncompressedSize)) {
+          try { fs.rmSync(target, { force: true }); } catch (_) {}
+          reject(new Error('工坊包条目解压大小与中央目录不一致: ' + entry.fileName));
+          return;
+        }
+        resolve(entryBytes);
+      });
+    });
+  });
+}
+
+async function extractWorkshopZipStreamed(zipPath, temp, expected) {
+  const zip = await openWorkshopZip(zipPath);
+  return new Promise((resolve, reject) => {
+    const seenPaths = new Set();
+    const counters = { entries: 0, files: 0, totalBytes: 0 };
+    let settled = false;
+    function closeQuietly() { try { zip.close(); } catch (_) {} }
+    function fail(error) {
+      if (settled) return;
+      settled = true;
+      closeQuietly();
+      reject(error);
+    }
+    function finish() {
+      if (settled) return;
+      if (counters.entries !== expected.entries || counters.files !== expected.files ||
+          counters.totalBytes !== expected.totalBytes) {
+        fail(new Error('工坊包在预检后发生变化，拒绝安装'));
+        return;
+      }
+      settled = true;
+      closeQuietly();
+      resolve(counters);
+    }
+    zip.on('error', fail);
+    zip.on('entry', entry => {
+      if (settled) return;
+      let info;
+      try {
+        counters.entries += 1;
+        if (counters.entries > WORKSHOP_ZIP_LIMITS.maxEntries) throw new Error('工坊包文件数量超过 4096 上限');
+        info = validateWorkshopZipEntry(entry, seenPaths);
+        const target = path.resolve(temp, info.canonical);
+        if (!isInsideDir(temp, target)) throw new Error('压缩包包含越界路径: ' + info.rawName);
+        if (info.isDirectory) {
+          fs.mkdirSync(target, { recursive: true });
+          zip.readEntry();
+          return;
+        }
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        counters.files += 1;
+        streamWorkshopEntry(zip, entry, target, counters).then(() => {
+          if (!settled) zip.readEntry();
+        }, fail);
+      } catch (error) {
+        fail(error);
+      }
+    });
+    zip.on('end', finish);
+    zip.readEntry();
+  });
+}
+
+async function extractZipToTemp(zipPath) {
+  // 中央目录配额、路径、类型和压缩比必须在创建输出目录及写出任何条目前全部通过。
+  const preflight = await preflightWorkshopZip(zipPath);
+  const currentStat = fs.statSync(zipPath);
+  if (currentStat.size !== preflight.archiveSize || currentStat.mtimeMs !== preflight.archiveMtimeMs) {
+    throw new Error('工坊包在预检后发生变化，拒绝安装');
+  }
+  const temp = createTempDir('tianming-pack-');
+  try {
+    await extractWorkshopZipStreamed(zipPath, temp, preflight);
+    return temp;
+  } catch (error) {
+    try {
+      if (isInsideDir(os.tmpdir(), temp) && path.basename(temp).indexOf('tianming-pack-') === 0) {
+        fs.rmSync(temp, { recursive: true, force: true });
+      }
+    } catch (_) {}
+    throw error;
+  }
 }
 
 function extractZipToTempChecked(zipPath, prefix) {
@@ -3423,7 +3650,7 @@ ipcMain.handle('workshop-install-from-url', async (event, options = {}) => {
     zipPath = path.join(WORKSHOP_DIR, 'downloads', 'tianming-workshop-' + Date.now() + '.tm-pack');
     const fileInfo = await downloadRemoteFile(packageUrl, zipPath, 250 * 1024 * 1024);
     if (expectedHash !== fileInfo.sha256.toLowerCase()) throw new Error('工坊包 sha256 不一致');
-    tempDir = extractZipToTemp(zipPath);
+    tempDir = await extractZipToTemp(zipPath);
     return installWorkshopPackFromDir(tempDir, { overwrite: !!options.overwrite, source: packageUrl });
   } catch (e) {
     return { success: false, error: e.message };
@@ -3481,7 +3708,7 @@ ipcMain.handle('workshop-import-pack', async (event, options = {}) => {
     if (!stat.isDirectory()) {
       const ext = path.extname(selected).toLowerCase();
       if (ext === '.zip' || ext === '.tm-pack') {
-        tempDir = extractZipToTemp(selected);
+        tempDir = await extractZipToTemp(selected);
         sourceDir = tempDir;
       } else if (ext === '.json') {
         tempDir = createScenarioPackFromJson(selected);
@@ -3628,6 +3855,9 @@ if (TEST_MODE) {
     toPublicAccountSession,
     sanitizeOnlineResponse,
     normalizeOnlineRendererRoute,
+    preflightWorkshopZip,
+    extractZipToTemp,
+    WORKSHOP_ZIP_LIMITS,
     verifyAuthenticatedUpdateDocument,
     getCurrentComparableVersion,
     getPackageBuildVersion,

--- a/main-impl.js
+++ b/main-impl.js
@@ -61,6 +61,9 @@ const HOT_UPDATE_APP_ID = 'com.tianming.history';
 const HOT_UPDATE_CHANNEL = 'stable';
 const HOT_UPDATE_PUBLIC_KEY_FILE = path.join(APP_ROOT_DIR, 'resources', 'hot-update-public-key.pem');
 const WORKSHOP_CATALOG_AUTHORIZATIONS = new Map();
+// 测试闸只允许未打包开发进程显式开启。打包产物即使继承了同名环境变量，
+// 也不得替换发布公钥、放行未签名文档、访问 localhost 或导出内部函数。
+const TEST_MODE = !app.isPackaged && process.env.TIANMING_TEST_EXPORTS === '1';
 
 // ============================================================
 //  调试日志 (debug logger)·2026-05-28
@@ -403,7 +406,7 @@ function compareVersions(a, b) {
 let _hotUpdatePublicKey = null;
 function getHotUpdatePublicKey() {
   if (_hotUpdatePublicKey) return _hotUpdatePublicKey;
-  const override = process.env.TIANMING_TEST_EXPORTS && process.env.TIANMING_HOT_UPDATE_PUBLIC_KEY
+  const override = TEST_MODE && process.env.TIANMING_HOT_UPDATE_PUBLIC_KEY
     ? path.resolve(process.env.TIANMING_HOT_UPDATE_PUBLIC_KEY)
     : HOT_UPDATE_PUBLIC_KEY_FILE;
   if (!fs.existsSync(override)) throw new Error('应用缺少固定热更新公钥');
@@ -417,7 +420,7 @@ function getHotUpdateKeyId(key) {
 }
 
 function verifyAuthenticatedUpdateDocument(document, expectedType) {
-  const allowUnsignedTest = !!process.env.TIANMING_TEST_EXPORTS
+  const allowUnsignedTest = TEST_MODE
     || (!app.isPackaged && process.env.TIANMING_ALLOW_UNSIGNED_HOT_UPDATE === '1');
   const auth = document && document.auth;
   if (!auth) {
@@ -960,7 +963,7 @@ function isAllowedRemoteUrl(rawUrl) {
   const isLocalHttp = parsed.protocol === 'http:' && /^(localhost|127\.0\.0\.1|\[::1\])$/i.test(parsed.hostname);
   if (parsed.username || parsed.password) return false;
   if (parsed.protocol === 'https:' && parsed.port && parsed.port !== '443') return false;
-  return parsed.protocol === 'https:' || (isLocalHttp && (!app.isPackaged || !!process.env.TIANMING_TEST_EXPORTS));
+  return parsed.protocol === 'https:' || (isLocalHttp && !app.isPackaged);
 }
 
 function resolveRemoteUrl(rawUrl, baseUrl) {
@@ -1001,7 +1004,7 @@ async function assertSafeRemoteUrl(rawUrl) {
   const parsed = new URL(resolved);
   const hostname = remoteHostname(parsed);
   const localDev = !app.isPackaged && /^(localhost|127\.0\.0\.1|::1)$/i.test(hostname);
-  if (localDev || (process.env.TIANMING_TEST_EXPORTS && /^(localhost|127\.0\.0\.1|::1)$/i.test(hostname))) return resolved;
+  if (localDev) return resolved;
   // 生产网络能力不接受 IP literal。域名需经过下方全部 A/AAAA 记录检查，
   // 避免 127.0.0.1、metadata 与保留网段通过十六进制/IPv6 写法绕过。
   if (nodeNet.isIP(hostname)) throw new Error('远程地址不允许直接使用 IP，已拒绝');
@@ -1308,6 +1311,28 @@ function readAccountSession() {
   };
 }
 
+function toPublicAccountSession(session = readAccountSession()) {
+  const user = session && session.user && typeof session.user === 'object' ? session.user : null;
+  return {
+    loggedIn: !!(session && session.token),
+    user,
+    loggedInAt: session && session.loggedInAt || ''
+  };
+}
+
+function sanitizeOnlineResponse(value, seen = new WeakSet()) {
+  if (value == null || typeof value !== 'object') return value;
+  if (seen.has(value)) return null;
+  seen.add(value);
+  if (Array.isArray(value)) return value.map(item => sanitizeOnlineResponse(item, seen));
+  const out = {};
+  Object.keys(value).forEach(key => {
+    if (/^(?:token|accessToken|refreshToken|idToken|authorization|sessionSecret)$/i.test(key)) return;
+    out[key] = sanitizeOnlineResponse(value[key], seen);
+  });
+  return out;
+}
+
 function writeAccountSession(session) {
   ensureSaveDir();
   writeJson(ACCOUNT_SESSION_FILE, {
@@ -1329,7 +1354,8 @@ function getAccountApiUrl() {
 }
 
 function getAccountAuthHeaders(options = {}) {
-  const token = String(options.token || readAccountSession().token || '').trim();
+  const supplied = Object.prototype.hasOwnProperty.call(options, 'token');
+  const token = String(supplied ? options.token : (readAccountSession().token || '')).trim();
   return token ? { Authorization: 'Bearer ' + token } : {};
 }
 
@@ -1345,6 +1371,85 @@ async function getOnlineApi(pathname, options = {}) {
   const url = new URL(String(pathname || '').replace(/^\//, ''), apiUrl).toString();
   const headers = Object.assign({}, getAccountAuthHeaders(options), options.headers || {});
   return requestJsonRemote(url, { method: 'GET', headers, maxBytes: options.maxBytes });
+}
+
+const ONLINE_RENDERER_ROUTES = Object.freeze({
+  GET: new Set([
+    'health', 'account/me', 'arena', 'arenas', 'chronicles', 'chronicles/chain',
+    'circle', 'circles', 'collection', 'collections', 'commissions', 'feed',
+    'follow', 'friends', 'friends/requests', 'messages/conversation',
+    'messages/inbox', 'notifications', 'revisions', 'workshop/author',
+    'workshop/catalog', 'workshop/comments', 'workshop/favorites',
+    'workshop/featured', 'workshop/lineage', 'workshop/pack'
+  ]),
+  POST: new Set([
+    'account/email-code', 'account/email-login', 'account/login', 'account/logout',
+    'account/register', 'account/request-reset', 'account/reset', 'account/set-email',
+    'arena/create', 'arena/submit', 'chronicles/publish', 'circle/create',
+    'circle/join', 'collection/create', 'collection/item', 'commission/close',
+    'commission/post', 'feed/like', 'feed/post', 'follow', 'friends/remove',
+    'friends/request', 'friends/respond', 'messages/send', 'notifications/read',
+    'revision/propose', 'revision/respond', 'workshop/comment', 'workshop/endorse',
+    'workshop/favorite', 'workshop/rate', 'workshop/upload'
+  ])
+});
+
+function normalizeOnlineRendererRoute(method, rawPathname) {
+  const verb = String(method || '').toUpperCase();
+  if (!ONLINE_RENDERER_ROUTES[verb]) throw new Error('在线请求方法不受支持');
+  const raw = String(rawPathname || '');
+  if (!raw || raw.includes('\\') || raw.includes('#') || /^[a-z][a-z0-9+.-]*:/i.test(raw) || raw.startsWith('//')) {
+    throw new Error('在线请求路径非法');
+  }
+  let rawDecodedPath;
+  try { rawDecodedPath = decodeURIComponent(raw.split('?')[0]); } catch (_) { throw new Error('在线请求路径编码非法'); }
+  if (rawDecodedPath.split('/').some(part => part === '.' || part === '..')) throw new Error('在线请求路径非法');
+  const parsed = new URL(raw.replace(/^\/+/, ''), 'https://tianming.invalid/');
+  const route = parsed.pathname.replace(/^\/+/, '');
+  let decoded;
+  try { decoded = decodeURIComponent(route); } catch (_) { throw new Error('在线请求路径编码非法'); }
+  if (!route || decoded.split('/').some(part => part === '.' || part === '..') || !ONLINE_RENDERER_ROUTES[verb].has(route)) {
+    throw new Error('在线请求路径未获授权');
+  }
+  return { method: verb, pathname: route + parsed.search, route };
+}
+
+async function handleOnlineRendererRequest(method, pathname, body) {
+  const req = normalizeOnlineRendererRoute(method, pathname);
+  if (body != null) {
+    const encoded = JSON.stringify(body);
+    if (Buffer.byteLength(encoded, 'utf8') > 260 * 1024 * 1024) throw new Error('在线请求内容超过 260MB 上限');
+  }
+  const noAuth = new Set([
+    'health', 'account/email-code', 'account/email-login', 'account/login',
+    'account/register', 'account/request-reset', 'account/reset'
+  ]);
+  const options = noAuth.has(req.route) ? { token: '' } : {};
+  let response;
+  if (req.route === 'account/logout') {
+    try { response = await postOnlineApi(req.pathname, body || {}, options); }
+    finally { clearAccountSession(); }
+  } else if (req.method === 'GET') {
+    response = await getOnlineApi(req.pathname, options);
+  } else {
+    response = await postOnlineApi(req.pathname, body == null ? {} : body, options);
+  }
+
+  if (response && response.success && response.token
+      && (req.route === 'account/register' || req.route === 'account/login' || req.route === 'account/email-login')) {
+    writeAccountSession({ token: response.token, user: response.user || null });
+  } else if (response && response.success && response.user
+      && (req.route === 'account/me' || req.route === 'account/set-email')) {
+    const current = readAccountSession();
+    if (current.token) writeAccountSession({ token: current.token, user: response.user });
+  }
+
+  const publicResponse = Object.assign({ success: false }, sanitizeOnlineResponse(response || {}));
+  if (/^account\//.test(req.route)) {
+    publicResponse.session = toPublicAccountSession();
+    publicResponse.loggedIn = publicResponse.session.loggedIn;
+  }
+  return publicResponse;
 }
 
 function updateInfoSize(info) {
@@ -3138,7 +3243,15 @@ ipcMain.handle('online-service-status', async (event, options = {}) => {
   }
 });
 
-ipcMain.handle('account-session', async () => ({ success: true, session: readAccountSession() }));
+ipcMain.handle('online-request', async (event, request = {}) => {
+  try {
+    return await handleOnlineRendererRequest(request.method, request.pathname, request.body);
+  } catch (e) {
+    return { success: false, error: e.message };
+  }
+});
+
+ipcMain.handle('account-session', async () => ({ success: true, session: toPublicAccountSession() }));
 
 ipcMain.handle('account-register', async (event, options = {}) => {
   try {
@@ -3151,7 +3264,7 @@ ipcMain.handle('account-register', async (event, options = {}) => {
     if (res && res.success && res.token) {
       writeAccountSession({ token: res.token, apiUrl: getAccountApiUrl(options), user: res.user || null });
     }
-    return Object.assign({ success: false }, res || {});
+    return Object.assign({ success: false }, sanitizeOnlineResponse(res || {}), { session: toPublicAccountSession() });
   } catch (e) {
     return { success: false, error: e.message };
   }
@@ -3167,7 +3280,7 @@ ipcMain.handle('account-login', async (event, options = {}) => {
     if (res && res.success && res.token) {
       writeAccountSession({ token: res.token, apiUrl: getAccountApiUrl(options), user: res.user || null });
     }
-    return Object.assign({ success: false }, res || {});
+    return Object.assign({ success: false }, sanitizeOnlineResponse(res || {}), { session: toPublicAccountSession() });
   } catch (e) {
     return { success: false, error: e.message };
   }
@@ -3176,12 +3289,12 @@ ipcMain.handle('account-login', async (event, options = {}) => {
 ipcMain.handle('account-me', async (event, options = {}) => {
   try {
     const session = readAccountSession();
-    if (!session.token) return { success: true, loggedIn: false, session };
+    if (!session.token) return { success: true, loggedIn: false, session: toPublicAccountSession(session) };
     const res = await getOnlineApi('account/me', { apiUrl: options.apiUrl || session.apiUrl, token: session.token });
     if (res && res.success && res.user) writeAccountSession({ token: session.token, apiUrl: options.apiUrl || session.apiUrl, user: res.user });
-    return Object.assign({ loggedIn: !!(res && res.user), session: readAccountSession() }, res || {});
+    return Object.assign({ loggedIn: !!(res && res.user) }, sanitizeOnlineResponse(res || {}), { session: toPublicAccountSession() });
   } catch (e) {
-    return { success: false, error: e.message, session: readAccountSession() };
+    return { success: false, error: e.message, session: toPublicAccountSession() };
   }
 });
 
@@ -3278,8 +3391,7 @@ ipcMain.handle('content-status', async () => {
     defaultWorkshopCatalogUrl: DEFAULT_WORKSHOP_CATALOG_URL,
     defaultOnlineApiUrl: DEFAULT_ONLINE_API_URL,
     hotUpdate: getHotUpdatePublicStatus(),
-    account: readAccountSession(),
-    dirs: { saveDir: SAVE_DIR, scenariosDir: SCENARIOS_DIR, bundledScenariosDir: BUNDLED_SCENARIOS_DIR, turnDataDir: TURN_DATA_DIR, updateDir: UPDATE_DIR, officialContentDir: OFFICIAL_CONTENT_DIR, workshopDir: WORKSHOP_DIR, workshopPacksDir: WORKSHOP_PACKS_DIR, hotUpdateDir: HOT_UPDATE_DIR },
+    account: toPublicAccountSession(),
     workshopPacks: listWorkshopPacksInternal()
   };
 });
@@ -3503,7 +3615,7 @@ app.on('activate', () => {
 //  测试出口·仅 TIANMING_TEST_EXPORTS=1 时暴露·生产零影响
 //  （verify-* 脚本用 Module._load 桩掉 electron 后 require 本文件取内部函数）
 // ============================================================
-if (process.env.TIANMING_TEST_EXPORTS) {
+if (TEST_MODE) {
   module.exports.__test = {
     compareVersions,
     isAllowedRemoteUrl,
@@ -3513,6 +3625,9 @@ if (process.env.TIANMING_TEST_EXPORTS) {
     isPrivateNetworkAddress,
     isTrustedRendererUrl,
     assertTrustedIpcSender,
+    toPublicAccountSession,
+    sanitizeOnlineResponse,
+    normalizeOnlineRendererRoute,
     verifyAuthenticatedUpdateDocument,
     getCurrentComparableVersion,
     getPackageBuildVersion,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.3.411",
       "dependencies": {
         "adm-zip": "^0.5.17",
-        "electron-updater": "^6.8.3"
+        "electron-updater": "^6.8.3",
+        "yauzl": "^2.10.0"
       },
       "devDependencies": {
         "electron": "^33.0.0",
@@ -1290,7 +1291,6 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmmirror.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -2672,7 +2672,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmmirror.com/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -4292,7 +4291,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmmirror.com/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -5313,7 +5311,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmmirror.com/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
   },
   "dependencies": {
     "adm-zip": "^0.5.17",
-    "electron-updater": "^6.8.3"
+    "electron-updater": "^6.8.3",
+    "yauzl": "^2.10.0"
   }
 }

--- a/preload-impl.js
+++ b/preload-impl.js
@@ -135,6 +135,10 @@ contextBridge.exposeInMainWorld('tianming', {
   onlineServiceStatus: () =>
     ipcRenderer.invoke('online-service-status'),
 
+  // 在线账号与社区请求由主进程固定域名、固定路由代发；Bearer Token 永不进入 renderer。
+  onlineRequest: (method, pathname, body) =>
+    ipcRenderer.invoke('online-request', { method, pathname, body }),
+
   accountSession: () =>
     ipcRenderer.invoke('account-session'),
 

--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-18T16:19:56.050Z",
+  "generatedAt": "2026-08-19T03:06:50.652Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -3391,8 +3391,8 @@
     },
     {
       "path": "tm-ai-change-pathutils.js",
-      "sha256": "c41bab37c0308a455c8f7d52b703950383522603b8ff5834542afbc5795ded66",
-      "size": 35299
+      "sha256": "1f77d45c532c46f73b9af9ce9915112ced98954362f9beec1906f0d348f6d959",
+      "size": 35615
     },
     {
       "path": "tm-ai-infra-json.js",
@@ -3481,8 +3481,8 @@
     },
     {
       "path": "tm-battle-adapter.js",
-      "sha256": "ea124f50a814589f0f85b37547a2ef69e7f048bb046aa4299da59f5df6abd81e",
-      "size": 27081
+      "sha256": "b2aa64dfabd72d4ed64a4317709d87e2e6b89aeab0fb3193c6256529100f95d5",
+      "size": 27746
     },
     {
       "path": "tm-battle-embed.js",
@@ -3731,13 +3731,13 @@
     },
     {
       "path": "tm-content-manager-community.js",
-      "sha256": "7f0e8d6fb2cb90714b9f6a7e769d8dc2c0e6e7fd1763b8bedb8f08b652df2a3f",
-      "size": 189783
+      "sha256": "9a9c36367c4bec8473a99e21dc9279fa5121be7a66caabe2ff89a9b3e5748d05",
+      "size": 189785
     },
     {
       "path": "tm-content-manager.js",
-      "sha256": "0ab326f32a1eee38407c123fa6d8a0c4c9ff88cdfcdcc64c6bfc38290229159e",
-      "size": 184921
+      "sha256": "fd7cc4c65fa8e81bd50feb757e04fdd9bf98578efbe877db25f71af550152831",
+      "size": 184923
     },
     {
       "path": "tm-context-zones.js",
@@ -3761,8 +3761,8 @@
     },
     {
       "path": "tm-court-meter.js",
-      "sha256": "65b1337e518f9bb599dbbf0dd505b5b3b607de9e7f08a6f424268455ebf4b69a",
-      "size": 15114
+      "sha256": "06240a9c3a762c9452de47f4d5f3c4e4f9ab339004a2fddbebefafcc0f2df5db",
+      "size": 15243
     },
     {
       "path": "tm-custom-build-agent.js",
@@ -3826,8 +3826,8 @@
     },
     {
       "path": "tm-economy.js",
-      "sha256": "c2a0b0ed7cc177100266407e540a89a87da8b25c007a9cfd2eb46eafa0c88d2a",
-      "size": 31234
+      "sha256": "8702ebf826c8ff77c7d6a210782fddbde6d992f595c4e129663aa966d97a302f",
+      "size": 31854
     },
     {
       "path": "tm-edict-complete.js",
@@ -3906,8 +3906,8 @@
     },
     {
       "path": "tm-endturn-ai.js",
-      "sha256": "9276b05714e380a4424ac6909fcb1396f523a6e4ccab78d2909fb1441b06dfef",
-      "size": 402016
+      "sha256": "5e0fbe1fd2c8d070e59b4ceee592734ec8b76c8ecaf37b2c13d7b56af2852783",
+      "size": 402499
     },
     {
       "path": "tm-endturn-apply-stages.js",
@@ -3921,8 +3921,8 @@
     },
     {
       "path": "tm-endturn-core.js",
-      "sha256": "2d97bdaae068c1724eca0f340d9ce3ec9a863416e5724003ca81492a7fca03ff",
-      "size": 88753
+      "sha256": "97807c75dbae3c9f4d7511c468564715b86fd99d7dc7f644521e7fce9eec16f5",
+      "size": 89806
     },
     {
       "path": "tm-endturn-edict.js",
@@ -3936,8 +3936,8 @@
     },
     {
       "path": "tm-endturn-followup.js",
-      "sha256": "00c970c2acac03bb019fc4fbb80f3931f35b1e9565be9976a0f02a417d72b0a7",
-      "size": 296040
+      "sha256": "552d95351ed5c8547fda8970e2699afb55bcfc355b5afdeb8a97f16f657eef8b",
+      "size": 296225
     },
     {
       "path": "tm-endturn-helpers.js",
@@ -4016,8 +4016,8 @@
     },
     {
       "path": "tm-endturn-systems.js",
-      "sha256": "f068efdc216780aa97eb8656fde647fb715e042580cc8d94af069612b0a6184f",
-      "size": 38798
+      "sha256": "2f79686edcff09014a7b222a51a16230394ba20a11b270d6ce1431a5e62df6f5",
+      "size": 39434
     },
     {
       "path": "tm-endturn-timing-ledger.js",
@@ -4096,8 +4096,8 @@
     },
     {
       "path": "tm-faction-diplomacy.js",
-      "sha256": "a509e0f01de318cb623251f4dab2f1058373a96ea13ad684922f528347de84e0",
-      "size": 19179
+      "sha256": "4b6145640201764f563f6b20f1774500949369455ffc9f26ff20a76cb2257177",
+      "size": 21951
     },
     {
       "path": "tm-faction-goal-stack.js",
@@ -4146,8 +4146,8 @@
     },
     {
       "path": "tm-faction-npc-llm-decision.js",
-      "sha256": "cdf96965aa72753fcb3898c2ad9acf50ab2556bb87d1506c842f8a69db6a00bd",
-      "size": 169814
+      "sha256": "12b28f07671cb303ec70fc137060b8a081190d7caa86ab667cc3dd67f321561a",
+      "size": 169808
     },
     {
       "path": "tm-faction-npc-llm-enrich.js",
@@ -4591,8 +4591,8 @@
     },
     {
       "path": "tm-map-system.js",
-      "sha256": "63a1d535d564fa81a8b7f6768fb976298f6e6570555fda44bfefb0bd41e16f92",
-      "size": 85997
+      "sha256": "139f14c739ab45991cea5b9c246f76c82af0ae46e86a6024ba13a3e2e6a04557",
+      "size": 88692
     },
     {
       "path": "tm-mapeditor-fit.js",
@@ -4776,8 +4776,8 @@
     },
     {
       "path": "tm-negotiation.js",
-      "sha256": "ebf0dba7f7bb78cc1d1401665fb210bfb00023f2fffb1152581f275352b5a3cc",
-      "size": 10956
+      "sha256": "5b9a42b6e0a1a514a38cf885d9b433c72bb9f09a068e1c363d624286bf086506",
+      "size": 11476
     },
     {
       "path": "tm-neitang-engine.js",
@@ -4901,8 +4901,8 @@
     },
     {
       "path": "tm-online-client.js",
-      "sha256": "2b0bc02f1153682b79a14b7cfe476250764523eab349173300c0a0b7a9583667",
-      "size": 39079
+      "sha256": "0ef6b2524a0fee7a905194933d9f3c2bac6ee315a1a16f41f4502d62573ca875",
+      "size": 41964
     },
     {
       "path": "tm-online-mall.css",
@@ -5001,8 +5001,8 @@
     },
     {
       "path": "tm-post-turn-jobs.js",
-      "sha256": "741d0a9df911f83ae37f93d06dc9122d150097c8910068688b47c442319e83ec",
-      "size": 29394
+      "sha256": "75b1618594952cdff9c343092d6ce9d0dc07fd497d5dbabeb5d5102cea90664c",
+      "size": 30838
     },
     {
       "path": "tm-promotion.js",
@@ -5156,8 +5156,8 @@
     },
     {
       "path": "tm-storage.js",
-      "sha256": "95594ee7e815d1a32e08ee9bfb33a7878578f39578b19b9aa32172c80b4f2d86",
-      "size": 23137
+      "sha256": "e24584dff3cdd1f64db1b8baaafea2921876265ea1ddaf0c9ecd20ed28bb1fbe",
+      "size": 24045
     },
     {
       "path": "tm-talent-backlash.js",

--- a/web/scripts/smoke-ai-writeback-integrity.js
+++ b/web/scripts/smoke-ai-writeback-integrity.js
@@ -167,6 +167,22 @@ async function main() {
   const allowedAppendRes = ctx.applyAITurnChanges({ char_updates: [{ name: '真人', updates: { '+careerHistory': { title: '合法履历追加' } } }] });
   check(Array.isArray(ctx.GM.chars[0].careerHistory) && ctx.GM.chars[0].careerHistory.length === 1 && allowedAppendRes.applied.failed.length === 0, 'only explicitly allowed careerHistory array append may apply');
 
+  // B3. 已声明字段也不能被 set 成不兼容类型；任一类型漂移必须触发整批回滚。
+  ctx.GM = baseGM({ custom: { score: 40, rows: [1], settings: { enabled: true } } });
+  const typeMismatch = ctx.applyAITurnChanges({
+    changes: [
+      { path: 'custom.score', op: 'delta', delta: 5, reason: '合法兄弟项也须回滚' },
+      { path: 'custom.score', op: 'set', value: { unexpected: true } },
+      { path: 'custom.rows', op: 'set', value: 'not-an-array' },
+      { path: 'custom.settings', op: 'set', value: [] }
+    ]
+  });
+  check(typeMismatch.ok === false && typeMismatch.rolledBack === true, 'schema-incompatible set must reject the whole AI batch');
+  check(ctx.GM.custom.score === 40 && Array.isArray(ctx.GM.custom.rows) && !Array.isArray(ctx.GM.custom.settings),
+    'type mismatch rollback must restore number/array/object fields exactly');
+  check(typeMismatch.applied.failed.filter((row) => /type does not match existing schema/.test(row.reason || '')).length === 3,
+    'each schema type mismatch must be visible in applied.failed');
+
   // C. faction leader 与 army commander 的最终 sink 只接受真实活人，并同步所有镜像。
   ctx.GM = baseGM({
     chars: [{ name: '韩旷', id: 'char_hankuang', alive: true }, { name: '亡将', alive: false, dead: true }],

--- a/web/scripts/smoke-battle-adapter.js
+++ b/web/scripts/smoke-battle-adapter.js
@@ -37,6 +37,19 @@ ok(t0.parentArmyId === 'pa1', '② parentArmyId 回填母军');
 const yf = cfg.armies.ming.find(u => u.gen && u.gen.n === '岳飞');
 ok(yf && yf.gen.valor === 95 && yf.gen.mil === 92 && yf.gen.int === 88, '③ 主将岳飞 valor95/mil92/int88(翻GM.chars)');
 ok(cfg.armies.ming.some(u => u.gen.n === '裨将'), '③ 麾下分队挂裨将(非全具名英雄)');
+const duplicateGM = { chars: [
+  { id: 'same-a', name: '同名将', valor: 99, military: 98, intelligence: 97 },
+  { id: 'same-b', name: '同名将', valor: 41, military: 42, intelligence: 43 }
+] };
+const duplicateById = ADP.genFor('同名将', duplicateGM, 'same-b');
+const duplicateWithoutId = ADP.genFor('同名将', duplicateGM);
+ok(duplicateById.valor === 41 && duplicateById.mil === 42 && duplicateById.int === 43, '③b 同名主将按稳定人物 ID 绑定正确角色');
+ok(duplicateWithoutId.valor === 60 && duplicateWithoutId.mil === 62 && duplicateWithoutId.int === 55,
+  '③b 同名且缺 ID 时使用中庸默认，不再误取数组首人');
+const sameNameArmy = [{ id: 'same-army', name: '同名军', commander: '同名将', commanderId: 'same-b', morale: 70, training: 60,
+  composition: [{ type: '步兵', count: 1000 }] }];
+const sameNameCfg = ADP.buildBattleConfig(sameNameArmy, [], { GM: duplicateGM });
+ok(sameNameCfg.armies.ming[0].gen.valor === 41, '③b 军队适配链透传 commanderId');
 
 /* ④ 兵种识别(经 units[] 派生) */
 ok(cfg.armies.ming.some(u => u.type === 'cav'), '④ 背嵬铁骑→cav');

--- a/web/scripts/smoke-content-manager-account-session.js
+++ b/web/scripts/smoke-content-manager-account-session.js
@@ -70,7 +70,8 @@ vm.runInContext(resetSrc + '\n' + identitySrc + '\n' + replaceSrc + '\n' + inval
   ok((community.match(/if \(!_sameAccountEpoch\(requestEpoch\)\) return;/g) || []).length >= 8, '好友、通知和私信成功/失败回调都拒绝旧身份 epoch');
   ok(((main + community).match(/replaceAccountSession\(/g) || []).length >= 4, '网页/桌面重开工坊与登录刷新统一走身份替换入口');
   ok(((main + community).match(/state\.accountSession\s*=/g) || []).length === 2, '账号内存身份只允许由替换/失效两个集中写口修改');
-  ok(/replaceAccountSession\(\(onlineSession && onlineSession\.token\)/.test(community), '更新中心读取桌面状态时仍优先当前在线会话，不复活旧 IPC 身份');
+  ok(/replaceAccountSession\(\(onlineSession && \(onlineSession\.loggedIn \|\| onlineSession\.user\)\)/.test(community),
+    '更新中心读取无 token 的桌面公开会话时仍优先当前在线身份，不复活旧 IPC 身份');
   ok((community.match(/_invalidateExpiredAtEpoch\(/g) || []).length >= 10, '好友、通知与私信写操作的 resolved/rejected 认证失败都统一失效会话');
   ok(/accountRefresh[\s\S]*?var requestEpoch = _accountEpoch\(\)[\s\S]*?_sameAccountEpoch\(requestEpoch\)/.test(community), '手动身份刷新拒绝旧账号晚到回包');
   ok(/tm-online-client\.js\?v=20260811-auditfix1/.test(indexHtml), '在线客户端修复已刷新运行时缓存戳');

--- a/web/scripts/smoke-endturn-transaction-failures.js
+++ b/web/scripts/smoke-endturn-transaction-failures.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const WEB = path.resolve(__dirname, '..');
+const coreSource = fs.readFileSync(path.join(WEB, 'tm-endturn-core.js'), 'utf8');
+const systemsSource = fs.readFileSync(path.join(WEB, 'tm-endturn-systems.js'), 'utf8');
+let assertions = 0;
+function ok(value, label) {
+  if (!value) throw new Error('[smoke-endturn-transaction-failures] ' + label);
+  assertions++;
+}
+
+function sourceBetween(source, startText, endText) {
+  const start = source.indexOf(startText);
+  const end = source.indexOf(endText, start);
+  if (start < 0 || end <= start) throw new Error('source slice missing: ' + startText);
+  return source.slice(start, end);
+}
+
+const ctx = {
+  console,
+  Date,
+  Promise,
+  Object,
+  JSON,
+  Math,
+  Error,
+  setTimeout,
+  clearTimeout,
+  deepClone: value => JSON.parse(JSON.stringify(value)),
+  buildIndices() {},
+  renderGameState() {},
+  showLoading() {},
+  processBiannian() {},
+  _dbg() {},
+  TM: { errors: { capture() {} } }
+};
+ctx.window = ctx;
+vm.createContext(ctx);
+vm.runInContext(sourceBetween(coreSource, 'async function _runPreSubmitPartyClassCalibration()', 'async function _endTurnInternal'), ctx);
+vm.runInContext(sourceBetween(coreSource, 'function _tmCaptureEndTurnObject', 'async function _tmFinalizeEndTurnTransaction'), ctx);
+vm.runInContext(systemsSource, ctx);
+
+function resetWorld(extra) {
+  ctx.GM = Object.assign({ turn: 4, sid: 's1', _campaignId: 'c1', busy: false, marker: 10, armies: [{ soldiers: 100 }], treasury: 50 }, extra || {});
+  ctx.P = { marker: 'template', conf: {}, ai: {}, battleConfig: {} };
+  ctx._tmLoadGen = 0;
+  delete ctx.BattleEngine;
+  delete ctx.GuokuEngine;
+  delete ctx.CorruptionEngine;
+  delete ctx.HujiEngine;
+  delete ctx.HujiDeepFill;
+  delete ctx.updateProvinceEconomy;
+  ctx.SubTickRunner = { run() {} };
+}
+
+async function expectFailure(promise, text) {
+  try { await promise; }
+  catch (error) { return !text || String(error && error.message || error).includes(text); }
+  return false;
+}
+
+async function main() {
+  const snapshotIndex = coreSource.indexOf('_turnTxn = _tmCaptureEndTurnTransaction();');
+  const calibrationIndex = coreSource.indexOf('await _runPreSubmitPartyClassCalibration();');
+  ok(snapshotIndex >= 0 && calibrationIndex > snapshotIndex, 'pre-submit calibration is inside the transaction boundary');
+
+  resetWorld();
+  ctx.TM.PartyClassActionScheduler = {
+    scheduleBeforeSubmit(GM) { GM.marker = 20; GM.calibrationWrite = true; }
+  };
+  let txn = ctx._tmCaptureEndTurnTransaction();
+  await ctx._runPreSubmitPartyClassCalibration();
+  ok(ctx.GM.marker === 20, 'calibration probe mutates the live world');
+  ctx._tmRollbackEndTurnTransaction(txn, new Error('forced pre-save failure'));
+  ok(ctx.GM.marker === 10 && !ctx.GM.calibrationWrite && ctx.P.marker === 'template', 'pre-save failure rolls calibration changes back to click-time state');
+  delete ctx.TM.PartyClassActionScheduler;
+
+  resetWorld();
+  txn = ctx._tmCaptureEndTurnTransaction();
+  ctx.BattleEngine = {
+    _getConfig: () => ({ enabled: true }),
+    resolveAllBattles() { ctx.GM.armies[0].soldiers = 25; throw new Error('battle-ledger-failure'); }
+  };
+  ok(await expectFailure(ctx._endTurn_updateSystems(1, ''), 'battle-ledger-failure'), 'battle failure propagates out of systems step');
+  ctx._tmRollbackEndTurnTransaction(txn, new Error('battle-ledger-failure'));
+  ok(ctx.GM.armies[0].soldiers === 100 && ctx.GM.turn === 4, 'partial battle mutation and turn state roll back atomically');
+
+  resetWorld();
+  txn = ctx._tmCaptureEndTurnTransaction();
+  ctx.GuokuEngine = {
+    tick() { ctx.GM.treasury = -999; throw new Error('guoku-ledger-failure'); }
+  };
+  ok(await expectFailure(ctx._endTurn_updateSystems(1, ''), 'guoku-ledger-failure'), 'treasury failure propagates after an intermediate turn increment');
+  ctx._tmRollbackEndTurnTransaction(txn, new Error('guoku-ledger-failure'));
+  ok(ctx.GM.treasury === 50 && ctx.GM.turn === 4, 'partial treasury mutation and turn increment roll back atomically');
+
+  resetWorld({ turn: 8 });
+  let releaseSubticks;
+  ctx.SubTickRunner = { run: () => new Promise(resolve => { releaseSubticks = resolve; }) };
+  const pending = ctx._endTurn_updateSystems(1, '');
+  await Promise.resolve();
+  await Promise.resolve();
+  ok(ctx.GM.turn === 8, 'turn does not advance while asynchronous subticks are pending');
+  releaseSubticks();
+  await expectFailure(pending);
+  ok(ctx.GM.turn === 9, 'systems continue only after asynchronous subticks resolve');
+
+  console.log('[smoke-endturn-transaction-failures] PASS assertions=' + assertions);
+}
+
+main().catch(error => {
+  console.error(error && error.stack || error);
+  process.exit(1);
+});

--- a/web/scripts/smoke-faction-living-world.js
+++ b/web/scripts/smoke-faction-living-world.js
@@ -52,10 +52,10 @@ function installCasusBelli(ctx) {
 
 function baseGM(ctx, opts) {
   opts = opts || {};
-  ctx.P = { playerInfo: { factionName: '玩家朝廷' }, conf: { npcAiPrecision: true }, ai: { key: 'fake' } };
+  ctx.P = { playerInfo: { factionId: 'fac-player', factionName: '玩家朝廷' }, conf: { npcAiPrecision: true }, ai: { key: 'fake' } };
   ctx.GM = {
     turn: 5,
-    facs: [ { name: '甲势力', treasury: { money: 100000 } }, { name: '乙势力', treasury: { money: 100000 } }, { name: '玩家朝廷', isPlayer: true } ],
+    facs: [ { id: 'fac-a', name: '甲势力', treasury: { money: 100000 } }, { id: 'fac-b', name: '乙势力', treasury: { money: 100000 } }, { id: 'fac-player', name: '玩家朝廷', isPlayer: true } ],
     chars: [],
     _facIndex: { '甲势力': { chars: [], parties: {}, metrics: {} }, '乙势力': { chars: [], parties: {}, metrics: {} } },
     activeWars: [], factionRelations: []
@@ -359,6 +359,30 @@ function b3AllianceTreatyTest() {
   });
   assert(tr, 'B3: accepted alliance lodges a real GM.treaties entry (not just aiStrategy.alliances)');
   assert(tr.mutual_defense === true && tr.active === true, 'B3: alliance treaty carries mutual_defense + active (feudal-warfare _ty_callAlliesToWar consumes these)');
+  assert(tr.parties[0].id === 'fac-a' && tr.parties[1].id === 'fac-b', 'B3: treaty parties carry stable faction ids alongside display names');
+}
+
+// B3b·同名势力必须按 ID 路由；缺 ID 的歧义名称 fail-closed。
+function b3bStableFactionIdentityTest() {
+  const ctx = buildContext(); installCasusBelli(ctx);
+  ctx.P = { playerInfo: { factionId: 'fac-player', factionName: '玩家朝廷' }, conf: { npcAiPrecision: true }, ai: { key: 'fake' } };
+  const from = { id: 'fac-from', name: '发议方' };
+  const sameA = { id: 'fac-same-a', name: '同名势力' };
+  const sameB = { id: 'fac-same-b', name: '同名势力' };
+  ctx.GM = { turn: 5, _factionLivingWorld: true, facs: [from, sameA, sameB], activeWars: [], factionRelations: [] };
+  const dip = ctx.TM.FactionDiplomacy;
+  const routed = dip.recordProposals(from, [{ toFaction: '同名势力', toFactionId: 'fac-same-b', type: 'alliance', terms: '凭 ID 缔盟' }], 5);
+  assert(routed.recorded === 1 && !sameA._incomingProposals && sameB._incomingProposals.length === 1,
+    'B3b: explicit toFactionId routes a proposal to the correct same-name faction only');
+  const proposal = sameB._incomingProposals[0];
+  assert(proposal.fromId === 'fac-from' && proposal.toId === 'fac-same-b', 'B3b: proposal persists stable from/to ids');
+  dip.applyResponses(sameB, [{ proposalId: proposal.id, decision: 'accept' }], 5);
+  assert(from.aiStrategy.allianceIds[0] === 'fac-same-b' && sameB.aiStrategy.allianceIds[0] === 'fac-from',
+    'B3b: accepted alliance canonical relation arrays use stable ids');
+  assert(ctx.GM.treaties[0].parties.some(function(p){ return p.id === 'fac-same-b'; }), 'B3b: same-name treaty preserves the selected faction id');
+  const ambiguous = dip.recordProposals(from, [{ toFaction: '同名势力', type: 'deal', terms: '无 ID 歧义' }], 6);
+  assert(ambiguous.recorded === 0 && (sameA._incomingProposals || []).length === 0,
+    'B3b: ambiguous same-name target without id is rejected instead of selecting array-first');
 }
 
 // B4·目标契约不撞车：goal-stack 激活时 s.goals 纯结构对象·字符串标签落 recentActionLabels
@@ -556,6 +580,7 @@ function main() {
   b8OffContractFilterTest();
   b2ResponseIdMatchTest();
   b3AllianceTreatyTest();
+  b3bStableFactionIdentityTest();
   b4GoalStructureTest();
   b5JoinWarParentTest();
   b6PlayerCbFailClosedTest();

--- a/web/scripts/smoke-map-pathfinding-heap.js
+++ b/web/scripts/smoke-map-pathfinding-heap.js
@@ -35,10 +35,11 @@ function extractFunction(text, name) {
   throw new Error('unterminated function ' + name);
 }
 
-const context = { GM: { mapData: { adjacencyGraph: {}, regions: [] } } };
+const context = { GM: { mapData: { adjacencyGraph: {}, regions: [] } }, P: { battleConfig: { supplyConfig: {} }, map: { regions: [] } } };
 context.getLiveMapData = () => context.GM.mapData;
 vm.createContext(context);
 vm.runInContext(extractFunction(source, 'findPath'), context, { filename: 'findPath.js' });
+vm.runInContext(extractFunction(source, 'calculateSupplyLine'), context, { filename: 'calculateSupplyLine.js' });
 
 context.GM.mapData.adjacencyGraph = {
   A: [
@@ -80,6 +81,22 @@ context.GM.mapData.adjacencyGraph = {
 };
 result = context.findPath('A', 'B', { avoidEnemy: true, faction: '我军' });
 check(JSON.stringify(result.path) === JSON.stringify(['A', 'D', 'B']), 'avoidEnemy must consult live runtime ownership');
+
+context.P.map.regions = [{ id: 'C', owner: '我军' }];
+context.GM.mapData.regions = [{ id: 'C', owner: '敌军' }, { id: 'B', owner: '我军' }];
+context.GM.mapData.adjacencyGraph = {
+  A: [{ target: 'C', distance: 1, movementCost: 1, type: 'land' }],
+  C: [{ target: 'B', distance: 1, movementCost: 1, type: 'land' }],
+  B: []
+};
+let supply = context.calculateSupplyLine('A', 'B', '我军');
+check(supply.isCut === true && supply.efficiency === 0.1,
+  'supply occupation must use hostile GM runtime state even when P template still says friendly');
+context.GM.mapData.regions[0].owner = '我军';
+context.P.battleConfig.supplyConfig.distanceDecay = 0;
+supply = context.calculateSupplyLine('A', 'B', '我军');
+check(supply.isCut === false && supply.efficiency === 1,
+  'explicit distanceDecay=0 must remain zero instead of reverting to the default');
 
 const graph = Object.create(null);
 const count = 4000;

--- a/web/scripts/smoke-map-pathfinding-heap.js
+++ b/web/scripts/smoke-map-pathfinding-heap.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.resolve(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'tm-map-system.js'), 'utf8');
+let assertions = 0;
+function check(condition, message) {
+  if (!condition) throw new Error('[smoke-map-pathfinding-heap] ' + message);
+  assertions += 1;
+}
+
+function extractFunction(text, name) {
+  const start = text.indexOf('function ' + name + '(');
+  if (start < 0) throw new Error('missing function ' + name);
+  const brace = text.indexOf('{', start);
+  let depth = 0;
+  let quote = null;
+  let escaped = false;
+  for (let i = brace; i < text.length; i++) {
+    const ch = text[i];
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') { quote = ch; continue; }
+    if (ch === '{') depth += 1;
+    else if (ch === '}' && --depth === 0) return text.slice(start, i + 1);
+  }
+  throw new Error('unterminated function ' + name);
+}
+
+const context = { GM: { mapData: { adjacencyGraph: {}, regions: [] } } };
+context.getLiveMapData = () => context.GM.mapData;
+vm.createContext(context);
+vm.runInContext(extractFunction(source, 'findPath'), context, { filename: 'findPath.js' });
+
+context.GM.mapData.adjacencyGraph = {
+  A: [
+    { target: 'B', distance: 10, movementCost: 1, type: 'land', terrain: 'plain' },
+    { target: 'C', distance: 1, movementCost: 1, type: 'land', terrain: 'forest', hasPostRoad: true }
+  ],
+  C: [{ target: 'B', distance: 1, movementCost: 1, type: 'land', terrain: 'hill' }],
+  B: []
+};
+let result = context.findPath('A', 'B');
+check(JSON.stringify(result.path) === JSON.stringify(['A', 'C', 'B']) && result.cost === 1.7,
+  'Dijkstra heap must relax a previously discovered node to the cheaper route');
+check(result.hasPostRoad === true && JSON.stringify(result.terrainTypes) === JSON.stringify(['forest', 'hill']),
+  'predecessor reconstruction must preserve terrain order and post-road metadata');
+
+context.GM.mapData.adjacencyGraph = {
+  A: [
+    { target: 'W', distance: 2, movementCost: 1, type: 'water', terrain: 'water' },
+    { target: 'L', distance: 1, movementCost: 1, type: 'land', terrain: 'plain' }
+  ],
+  W: [{ target: 'B', distance: 2, movementCost: 1, type: 'water', terrain: 'water' }],
+  L: [{ target: 'B', distance: 1, movementCost: 1, type: 'land', terrain: 'plain' }],
+  B: []
+};
+result = context.findPath('A', 'B', { waterOnly: true });
+check(JSON.stringify(result.path) === JSON.stringify(['A', 'W', 'B']), 'waterOnly must filter every land edge');
+
+context.GM.mapData.regions = [
+  { id: 'C', owner: '敌军' }, { id: 'D', owner: '我军' }, { id: 'B', owner: '我军' }
+];
+context.GM.mapData.adjacencyGraph = {
+  A: [
+    { target: 'C', distance: 1, movementCost: 1, type: 'land' },
+    { target: 'D', distance: 3, movementCost: 1, type: 'land' }
+  ],
+  C: [{ target: 'B', distance: 1, movementCost: 1, type: 'land' }],
+  D: [{ target: 'B', distance: 3, movementCost: 1, type: 'land' }],
+  B: []
+};
+result = context.findPath('A', 'B', { avoidEnemy: true, faction: '我军' });
+check(JSON.stringify(result.path) === JSON.stringify(['A', 'D', 'B']), 'avoidEnemy must consult live runtime ownership');
+
+const graph = Object.create(null);
+const count = 4000;
+for (let i = 0; i < count; i++) {
+  const edges = [];
+  if (i + 1 < count) edges.push({ target: String(i + 1), distance: 1, movementCost: 1, type: 'land' });
+  if (i + 2 < count) edges.push({ target: String(i + 2), distance: 2, movementCost: 1, type: 'land' });
+  graph[String(i)] = edges;
+}
+context.GM.mapData.regions = [];
+context.GM.mapData.adjacencyGraph = graph;
+const startedAt = Date.now();
+result = context.findPath('0', String(count - 1));
+check(result && result.cost === count - 1 && result.path[0] === '0' && result.path[result.path.length - 1] === String(count - 1),
+  'large graph must return the optimal route');
+check(Date.now() - startedAt < 2000, '4000-node path should complete without repeated full-queue sorts or path cloning');
+check(!/openSet\.sort|current\.path\.concat/.test(extractFunction(source, 'findPath')) && /bestG/.test(extractFunction(source, 'findPath')),
+  'source guard requires heap relaxation and predecessor reconstruction');
+
+console.log('[smoke-map-pathfinding-heap] PASS assertions=' + assertions);

--- a/web/scripts/smoke-negotiation-sessions.js
+++ b/web/scripts/smoke-negotiation-sessions.js
@@ -53,12 +53,19 @@ assert((GA._negotiations || []).length === 1, '会话账本仍只一条(复用�
 
 var s2 = N.open({ topic: 'peace', initiator: '后金', sourceRef: { kind: 'invasion', refId: '后金' }, offer: { by: 'them', terms: '岁币二十万' }, turn: 5 });
 assert(s2 !== s1 && (GA._negotiations || []).length === 2, '异 sourceRef → 新开会话');
+var beforeMissingRef = (GA._negotiations || []).length;
+assert(N.open({ topic: 'diplomacy', initiator: '无引用甲', offer: { by: 'them', terms: '空引用一' } }) === null
+  && N.open({ topic: 'diplomacy', initiator: '无引用乙', sourceRef: { kind: '', refId: '' }, offer: { by: 'them', terms: '空引用二' } }) === null,
+  '缺失/空 sourceRef 必须拒绝创建，不能把两个无关谈判误并');
+assert((GA._negotiations || []).length === beforeMissingRef, '拒绝空 sourceRef 不得污染会话账本');
+assert(N.findOpenByRef('', '') === null, '空来源查找 fail-closed');
 
 console.log('§A2 fail-closed get / playerCounter round 封3');
 assert(N.get(s1.id) === s1, 'get 命中返会话');
 assert(N.get('ng-999-999') === null, 'fail-closed·带 id 未命中返 null(绝不模糊猜)');
 assert(N.get(null) === null, 'get(null) 返 null');
 assert(N.playerCounter('ng-nope', '还价', 0) === null, 'playerCounter 未命中 id → null');
+assert(N.resolve(s2.id, 'unknown-status') === null && s2.status === 'open', 'resolve 非法状态返回 null 且不改变会话');
 
 var pc1 = N.playerCounter(s1.id, '许银八万', 80000);
 assert(pc1 === s1 && s1.round === 2 && s1.offers.length === 3, '玩家回价1 → round2·追 player offer');

--- a/web/scripts/smoke-nokey-endturn-guard.js
+++ b/web/scripts/smoke-nokey-endturn-guard.js
@@ -3,7 +3,7 @@
 // smoke-nokey-endturn-guard — 验证「无 AI 密钥前置守卫」(2026-06-14)
 // 抽取真 endTurn() 函数源在 vm 沙箱实跑（非重新实现）：
 //   · 无 key / 空白 key → 弹 notifyUrgent + 中止过回合（不进 court prompt）+ 确认跳设置
-//   · 有效 key → 不弹 + 正常进入 pre-submit 校准 + court prompt
+//   · 有效 key → 不弹 + 只进入纯 UI court prompt；pre-submit 校准留在事务快照之后
 //   · 源契约：守卫必须在 court prompt 之前（否则拦不住）
 
 const fs = require('fs');
@@ -77,8 +77,12 @@ async function run(key) {
   // C. 有效 key → 放行
   c = await run('sk-test-123');
   assert(c.notifyUrgent === 0, 'C 有效key：不弹通知');
-  assert(c.calibration === 1, 'C 有效key：进入 pre-submit 校准');
+  assert(c.calibration === 0, 'C 有效key：court 选择前不得运行会修改 GM 的 pre-submit 校准');
   assert(c.court === 1, 'C 有效key：进入 court prompt');
+
+  const captureIdx = coreSrc.indexOf('_turnTxn = _tmCaptureEndTurnTransaction()', ei);
+  const calibrationIdx = coreSrc.indexOf('await _runPreSubmitPartyClassCalibration()', captureIdx);
+  assert(captureIdx >= 0 && calibrationIdx > captureIdx, 'pre-submit 校准只在事务快照创建后执行');
 
   console.log('PASS smoke-nokey-endturn-guard · ' + passed + ' 断言');
 })().catch(e => { console.error('FAIL smoke-nokey-endturn-guard'); console.error(e); process.exit(1); });

--- a/web/scripts/smoke-online-desktop-token-boundary.js
+++ b/web/scripts/smoke-online-desktop-token-boundary.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const { createOnlineClient } = require(path.resolve(__dirname, '..', 'tm-online-client.js'));
+
+let assertions = 0;
+function ok(value, label) {
+  if (!value) throw new Error('[smoke-online-desktop-token-boundary] ' + label);
+  assertions++;
+}
+
+async function main() {
+  const memory = {
+    tm_online_session: JSON.stringify({ token: 'legacy-renderer-secret', user: { id: 1 } }),
+    tm_online_api_url: 'https://attacker.invalid/'
+  };
+  const calls = [];
+  const bridge = {
+    accountSession: async () => ({ success: true, session: { loggedIn: true, user: { id: 7, username: '史官' }, loggedInAt: 'now' } }),
+    accountLogout: async () => ({ success: true }),
+    onlineRequest: async (method, pathname, body) => {
+      calls.push({ method, pathname, body });
+      if (pathname === 'account/login') {
+        return { success: true, user: { id: 7, username: '史官' }, session: { loggedIn: true, user: { id: 7, username: '史官' }, loggedInAt: 'later' } };
+      }
+      return { success: true, friends: [] };
+    }
+  };
+  const storage = {
+    getItem: key => Object.prototype.hasOwnProperty.call(memory, key) ? memory[key] : null,
+    setItem: (key, value) => { memory[key] = String(value); },
+    removeItem: key => { delete memory[key]; }
+  };
+  const client = createOnlineClient({ desktopBridge: bridge, storage, fetch: () => { throw new Error('desktop must not fetch directly'); } });
+  await Promise.resolve();
+  await Promise.resolve();
+
+  ok(!Object.prototype.hasOwnProperty.call(memory, 'tm_online_session'), 'desktop startup removes legacy renderer token storage');
+  ok(client.isLoggedIn() && client.getSession().user.id === 7, 'desktop exposes public login state and identity');
+  ok(client.getToken() === '' && !Object.prototype.hasOwnProperty.call(client.getSession(), 'token'), 'desktop API never exposes bearer token');
+
+  const login = await client.login({ username: '史官', password: 'secret' });
+  ok(login.success && client.getSession().loggedIn, 'desktop login consumes sanitized main-process response');
+  await client.friends();
+  ok(calls.some(call => call.method === 'POST' && call.pathname === 'account/login')
+    && calls.some(call => call.method === 'GET' && call.pathname === 'friends'), 'desktop online calls use the fixed IPC proxy');
+  ok(calls.every(call => !call.body || !Object.prototype.hasOwnProperty.call(call.body, 'token')), 'renderer never sends bearer token through IPC payloads');
+
+  console.log('[smoke-online-desktop-token-boundary] PASS assertions=' + assertions);
+}
+
+main().catch(error => {
+  console.error(error && error.stack || error);
+  process.exit(1);
+});

--- a/web/scripts/smoke-postturn-court-turn-gating.js
+++ b/web/scripts/smoke-postturn-court-turn-gating.js
@@ -12,6 +12,7 @@ const ROOT = path.resolve(__dirname, '..');
 const promptSrc = fs.readFileSync(path.join(ROOT, 'tm-endturn-prompt.js'), 'utf8');
 const changchaoSrc = (fs.readFileSync(path.join(ROOT, 'tm-chaoyi-changchao-adapter.js'), 'utf8') + '\n' + fs.readFileSync(path.join(ROOT, 'tm-chaoyi-changchao.js'), 'utf8') + '\n' + fs.readFileSync(path.join(ROOT, 'tm-chaoyi-changchao-flows.js'), 'utf8'));
 const courtSrc = fs.readFileSync(path.join(ROOT, 'tm-court-meter.js'), 'utf8');
+const coreSrc = fs.readFileSync(path.join(ROOT, 'tm-endturn-core.js'), 'utf8');
 const chaoyiSrc = fs.readFileSync(path.join(ROOT, 'tm-chaoyi.js'), 'utf8');
 
 let passed = 0;
@@ -49,12 +50,16 @@ assert(closeMatch[1].indexOf('GM._isPostTurnCourt') < 0, 'manual Changchao close
 
 const openBranch = courtSrc.match(/function _postTurnCourtChoose\(openCourt\)\s*\{([\s\S]*?)\}\s*else\s*\{/);
 assert(!!openBranch, 'post-turn court open branch found');
-const startIdx = openBranch[1].indexOf('_endTurnInternal();');
+const startIdx = openBranch[1].indexOf('_endTurnInternal({ postTurnCourt: true });');
 const courtUiIdx = openBranch[1].indexOf('setTimeout(function(){');
 assert(startIdx >= 0, 'opening Shuochao starts end-turn pipeline');
 assert(courtUiIdx >= 0, 'opening Shuochao schedules court UI');
 assert(startIdx < courtUiIdx, 'end-turn pipeline starts before Shuochao UI schedule');
-assert(openBranch[1].indexOf('courtDone: false') >= 0 && openBranch[1].indexOf('GM._isPostTurnCourt = true') >= 0, 'Shuochao marks deferred Shiji modal state before pipeline');
+const txnIdx = coreSrc.indexOf('_turnTxn = _tmCaptureEndTurnTransaction();');
+const courtStateIdx = coreSrc.indexOf("Object.prototype.hasOwnProperty.call(options, 'postTurnCourt')");
+const calibrationIdx = coreSrc.indexOf('await _runPreSubmitPartyClassCalibration();');
+assert(txnIdx >= 0 && courtStateIdx > txnIdx && calibrationIdx > courtStateIdx,
+  'court flags and mutating pre-submit calibration begin only after the transaction snapshot');
 
 const postTurnGM = {
   turn: 1,

--- a/web/scripts/smoke-postturn-critical-failures.js
+++ b/web/scripts/smoke-postturn-critical-failures.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const source = fs.readFileSync(path.resolve(__dirname, '..', 'tm-post-turn-jobs.js'), 'utf8');
+const start = source.indexOf('var _POST_TURN_NEXT_REQUIRED_IDS');
+const end = source.indexOf('function _compressOldArchives', start);
+if (start < 0 || end <= start) throw new Error('post-turn queue source slice missing');
+
+let assertions = 0;
+function ok(value, label) {
+  if (!value) throw new Error('[smoke-postturn-critical-failures] ' + label);
+  assertions++;
+}
+
+const ctx = { console, Promise, Date, Object, JSON, Error, _dbg() {}, TM: {}, recordMemoryDiagnostic() {} };
+ctx.window = ctx;
+ctx._tmLoadGen = 0;
+vm.createContext(ctx);
+vm.runInContext(source.slice(start, end), ctx);
+
+function resetWorld() {
+  ctx.GM = { turn: 6, sid: 's1', _campaignId: 'c1', _turnAiResults: { sourcePayload: { keep: true } } };
+  ctx.P = { marker: 'p1' };
+  ctx._tmLoadGen = 0;
+}
+
+async function rejects(fn) {
+  try { await fn(); return null; }
+  catch (error) { return error; }
+}
+
+async function main() {
+  resetWorld();
+  ctx._enqueuePostTurnJob('sc25c', async function() { throw new Error('sc25c forced failure'); });
+  const failedQueue = ctx.GM._postTurnJobs;
+  const error = await rejects(() => ctx._awaitPostTurnJobs());
+  ok(error && /sc25c/.test(error.message), 'critical sc25c rejection blocks next-turn freshness');
+  ok(ctx.GM._postTurnJobs === failedQueue && ctx.GM._postTurnJobs.pending.length === 1, 'failed critical queue remains available for retry and diagnosis');
+  ok(ctx.GM._turnAiResults.sourcePayload.keep === true, 'failed critical job preserves source AI data');
+  const saveError = await rejects(() => ctx._awaitPostTurnJobsForSave());
+  ok(saveError && /sc25c/.test(saveError.message), 'failed critical job blocks save commit');
+
+  let childRan = false;
+  ctx._enqueuePostTurnJob('dependent-probe', async function() { childRan = true; }, { dependsOn: ['sc25c'] });
+  const child = ctx.GM._postTurnJobs.pending.find(job => job.id === 'dependent-probe');
+  const childResult = await child.promise;
+  ok(childResult && childResult.ok === false && childRan === false, 'dependency failure prevents child task execution');
+
+  resetWorld();
+  ctx._enqueuePostTurnJob('sc25c', async function() { return { tactical: true, strategic: true }; });
+  await ctx._awaitPostTurnJobs();
+  ok(ctx.GM._postTurnJobs === null && !Object.prototype.hasOwnProperty.call(ctx.GM, '_turnAiResults'), 'successful critical jobs clear queue and source data');
+
+  console.log('[smoke-postturn-critical-failures] PASS assertions=' + assertions);
+}
+
+main().catch(error => {
+  console.error(error && error.stack || error);
+  process.exit(1);
+});

--- a/web/scripts/smoke-runtime-map-economy.js
+++ b/web/scripts/smoke-runtime-map-economy.js
@@ -7,11 +7,32 @@ const vm = require('vm');
 
 const ROOT = path.resolve(__dirname, '..');
 const source = fs.readFileSync(path.join(ROOT, 'tm-economy.js'), 'utf8');
+const mapSource = fs.readFileSync(path.join(ROOT, 'tm-map-system.js'), 'utf8');
 let assertions = 0;
 
 function check(condition, message) {
   if (!condition) throw new Error('[smoke-runtime-map-economy] ' + message);
   assertions += 1;
+}
+
+function extractFunction(text, name) {
+  const start = text.indexOf('function ' + name + '(');
+  if (start < 0) throw new Error('missing function ' + name);
+  const brace = text.indexOf('{', start);
+  let depth = 0, quote = null, escaped = false;
+  for (let i = brace; i < text.length; i++) {
+    const ch = text[i];
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') { quote = ch; continue; }
+    if (ch === '{') depth += 1;
+    else if (ch === '}' && --depth === 0) return text.slice(start, i + 1);
+  }
+  throw new Error('unterminated function ' + name);
 }
 
 const changes = [];
@@ -60,5 +81,23 @@ check(tributeRows[0][4] === 35 && tributeRows[1][4] === 35,
 check(allocationRows.length === 2, 'stable region ids must prevent same-name redistribution ledger collisions');
 check(context.P.map.regions[0].population === 1000000 && context.GM.mapData.regions[0].population === 1000,
   'template and runtime fixtures must remain isolated');
+
+const mapContext = {
+  P: { adminHierarchy: null, map: { regions: [{ id: 'r1', name: '模板地区', owner: '旧主', color: '#111111' }], items: [] } },
+  GM: {
+    adminHierarchy: null,
+    facs: [{ id: 'new-owner', name: '新主', color: '#abcdef' }],
+    mapData: { regions: [{ id: 'r1', name: '运行地区', owner: 'new-owner', color: '#222222' }], items: [], factionColors: {} }
+  },
+  _dbg() {}
+};
+mapContext.getLiveMapData = () => mapContext.GM.mapData;
+mapContext.window = mapContext;
+mapContext.globalThis = mapContext;
+vm.createContext(mapContext);
+vm.runInContext(extractFunction(mapSource, 'updateMapColors'), mapContext, { filename: 'updateMapColors.js' });
+mapContext.updateMapColors();
+check(mapContext.GM.mapData.regions[0].color === '#abcdef', 'map color refresh must update the runtime GM region');
+check(mapContext.P.map.regions[0].color === '#111111', 'map color refresh must not mutate or display the scenario template region');
 
 console.log('[smoke-runtime-map-economy] PASS assertions=' + assertions);

--- a/web/scripts/smoke-runtime-map-economy.js
+++ b/web/scripts/smoke-runtime-map-economy.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.resolve(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'tm-economy.js'), 'utf8');
+let assertions = 0;
+
+function check(condition, message) {
+  if (!condition) throw new Error('[smoke-runtime-map-economy] ' + message);
+  assertions += 1;
+}
+
+const changes = [];
+const context = {
+  console: { log() {}, warn() {}, error() {} },
+  Math, Date, JSON, Object, Array, Number, String, Boolean,
+  parseInt, parseFloat, isFinite,
+  finiteNumberOr(value, fallback) { return typeof value === 'number' && Number.isFinite(value) ? value : fallback; },
+  clamp(value, min, max) { return Math.max(min, Math.min(max, value)); },
+  recordChange() { changes.push(Array.from(arguments)); },
+  addEB() {},
+  P: {
+    economyConfig: { baseIncome: 100, redistributionRate: 0.5 },
+    map: {
+      regions: [
+        { id: 'template-a', name: '同名州', population: 1000000, controller: '朝廷' }
+      ]
+    }
+  },
+  GM: {
+    turn: 8,
+    classes: [],
+    eraState: { centralControl: 0.5, economicProsperity: 1, socialStability: 1 },
+    mapData: {
+      regions: [
+        { id: 'runtime-a', name: '同名州', population: 1000, controller: '某节度使' },
+        { id: 'runtime-b', name: '同名州', population: 2000, controller: '某节度使' }
+      ]
+    }
+  }
+};
+context.getLiveMapData = () => context.GM.mapData;
+context.window = context;
+context.global = context;
+context.globalThis = context;
+vm.createContext(context);
+vm.runInContext(source, context, { filename: 'tm-economy.js' });
+
+context.updateEconomy(1);
+
+const tributeRows = changes.filter((row) => row[0] === 'economy' && row[2] === 'tribute');
+const allocationRows = changes.filter((row) => row[0] === 'economy' && row[2] === 'allocation');
+check(tributeRows.length === 2, 'both runtime regions must be taxed even when their display names match');
+check(tributeRows[0][4] === 35 && tributeRows[1][4] === 35,
+  'tax must use GM population/controller, not the high-population civil template region');
+check(allocationRows.length === 2, 'stable region ids must prevent same-name redistribution ledger collisions');
+check(context.P.map.regions[0].population === 1000000 && context.GM.mapData.regions[0].population === 1000,
+  'template and runtime fixtures must remain isolated');
+
+console.log('[smoke-runtime-map-economy] PASS assertions=' + assertions);

--- a/web/scripts/smoke-security-content-boundary.js
+++ b/web/scripts/smoke-security-content-boundary.js
@@ -8,6 +8,7 @@ const vm = require('vm');
 const WEB = path.resolve(__dirname, '..');
 const indexSource = fs.readFileSync(path.join(WEB, 'index.html'), 'utf8');
 const mapSource = fs.readFileSync(path.join(WEB, 'map-display.js'), 'utf8');
+const interactiveMapSource = fs.readFileSync(path.join(WEB, 'tm-map-system.js'), 'utf8');
 const saveSource = fs.readFileSync(path.join(WEB, 'tm-save-manager.js'), 'utf8');
 const launchSource = fs.readFileSync(path.join(WEB, 'tm-launch.js'), 'utf8');
 let assertions = 0;
@@ -102,6 +103,43 @@ function runMapDetailsProbe() {
   ok(html.includes('&lt;script&gt;owned()&lt;/script&gt;<br>次行'), '历史换行只在转义后转换为 br');
 }
 
+function runInteractiveMapProbe() {
+  let htmlWrites = 0;
+  const createdTags = [];
+  function makeNode(tag, text) {
+    const node = {
+      tagName: String(tag || '').toUpperCase(),
+      textContent: text == null ? '' : String(text),
+      children: [],
+      style: {},
+      appendChild(child) { this.children.push(child); return child; },
+      replaceChildren() { this.children = Array.prototype.slice.call(arguments); }
+    };
+    Object.defineProperty(node, 'innerHTML', { set() { htmlWrites++; }, get() { return ''; } });
+    if (tag) createdTags.push(node.tagName);
+    return node;
+  }
+  const info = makeNode('section');
+  const document = {
+    getElementById(id) { return id === 'map-region-info' ? info : null; },
+    createElement(tag) { return makeNode(tag); },
+    createTextNode(text) { return makeNode('', text); }
+  };
+  const start = interactiveMapSource.indexOf('var InteractiveMap = {');
+  const end = interactiveMapSource.indexOf('\n};\n\n// 打开交互式地图', start);
+  ok(start >= 0 && end > start, '交互地图对象可定位');
+  const ctx = { document, getLiveMapData: () => ({ regions: [] }), Math, String };
+  vm.runInNewContext(interactiveMapSource.slice(start, end + 3), ctx);
+  const marker = '<img src=x onerror="globalThis.__owned=1">';
+  ctx.InteractiveMap.showRegionInfo({ name: marker, controller: '<script>owned()</script>', population: 0, income: 0, desc: marker });
+  function flatten(node) { return node.textContent + node.children.map(flatten).join(''); }
+  const rendered = flatten(info);
+  ok(htmlWrites === 0, '交互地图地区详情不写动态 innerHTML');
+  ok(rendered.includes(marker) && rendered.includes('<script>owned()</script>'), '恶意地区字段只作为文本显示');
+  ok(rendered.includes('人口: 0') && rendered.includes('收入: 0'), '交互地图保留人口和收入零值');
+  ok(createdTags.every(tag => ['SECTION', 'H4', 'DIV', 'STRONG'].includes(tag)), '地区字段不会创建活动 DOM 标签');
+}
+
 ok(/http-equiv=["']Content-Security-Policy["']/i.test(indexSource)
   && /object-src 'none'/.test(indexSource) && /base-uri 'none'/.test(indexSource), '首页声明 CSP 基础纵深防护');
 ok(!/span\.innerHTML\s*=/.test(indexSource.slice(indexSource.indexOf('(function fillHomeRecent(){'), indexSource.indexOf('})();', indexSource.indexOf('(function fillHomeRecent(){')))),
@@ -113,5 +151,6 @@ ok(/data-scenario-id/.test(launchSource) && /addEventListener\(['"]click['"]/.te
 
 runRecentSaveCardProbe();
 runMapDetailsProbe();
+runInteractiveMapProbe();
 
 console.log('[smoke-security-content-boundary] PASS assertions=' + assertions);

--- a/web/scripts/smoke-security-ipc-hardening.js
+++ b/web/scripts/smoke-security-ipc-hardening.js
@@ -167,8 +167,10 @@ assert(/if\s*\(!\/\^\[0-9a-f\]\{64\}\$\/\.test\(expectedHash\)\)\s*throw/.test(S
   'src· 工坊安装仍强制 /^[0-9a-f]{64}$/ hash 格式门（修B 未回退）');
 assert(/expectedHash !== fileInfo\.sha256/.test(SRC),
   'src· 工坊安装仍比对 expectedHash 与本地 fileInfo.sha256（修B 未回退）');
-assert(/function extractZipToTemp\(zipPath\)\s*\{[\s\S]*?isInsideDir\(temp, target\)[\s\S]*?throw/.test(SRC),
-  'src· extractZipToTemp 仍做 zip-slip 越界检查（工坊解压纵深防护）');
+assert(/async function extractZipToTemp\(zipPath\)\s*\{[\s\S]*?await preflightWorkshopZip\(zipPath\)[\s\S]*?createTempDir\('tianming-pack-'\)/.test(SRC)
+  && SRC.includes('WORKSHOP_ZIP_LIMITS.maxCompressionRatio') && SRC.includes('压缩包包含重复路径')
+  && /extractWorkshopZipStreamed[\s\S]*?isInsideDir\(temp, target\)/.test(SRC),
+  'src· 工坊 ZIP 在创建输出目录前预检总量/压缩比/重复路径，并在流式解压时复验 zip-slip');
 assert(/BLOCKED_PACK_EXTS\.has\(ext\)[\s\S]*?ALLOWED_PACK_EXTS\.has\(ext\)/.test(SRC),
   'src· validateWorkshopPack 仍走 BLOCKED+ALLOWED 双白名单（hash 只保完整性·安全靠此层）');
 assert(/sha256:\s*inlineHash\.digest\('hex'\)/.test(SRC) && /sha256FileStream\(dest\)/.test(SRC) && /sha256:\s*sha256File\(dest\)/.test(SRC),

--- a/web/scripts/smoke-security-trust-boundary.js
+++ b/web/scripts/smoke-security-trust-boundary.js
@@ -118,6 +118,8 @@ async function main() {
   check(bodyAbortObserved && /aborted/.test(String(stalledError && stalledError.message)), 'caller abort remains connected after response headers and stops a stalled body');
   check(T.verifyAuthenticatedUpdateDocument(payload, 'tianming-hot-update-feed') === payload,
     'unsigned fixtures are allowed only inside explicit unpackaged test mode');
+  check(T.isAllowedRemoteUrl('http://127.0.0.1/test') === true,
+    'localhost HTTP is available inside explicit unpackaged test mode');
 
   const trustedUrl = pathToFileURL(path.join(ROOT, 'web', 'index.html')).toString();
   const mainFrame = { url: trustedUrl, parent: null };
@@ -198,6 +200,10 @@ async function main() {
   delete require.cache[require.resolve(path.join(ROOT, 'main-impl.js'))];
   const packagedModule = require(path.join(ROOT, 'main-impl.js'));
   check(!packagedModule.__test, 'packaged build ignores TIANMING_TEST_EXPORTS and exposes no test internals');
+  check(/const allowUnsignedTest = TEST_MODE;/.test(mainSource)
+    && /isLocalHttp && TEST_MODE/.test(mainSource)
+    && /const localDev = TEST_MODE/.test(mainSource),
+    'unsigned updates, localhost HTTP and test exports share the same unpackaged TEST_MODE gate');
 
   console.log('[smoke-security-trust-boundary] PASS assertions=' + assertions);
 }

--- a/web/scripts/smoke-security-trust-boundary.js
+++ b/web/scripts/smoke-security-trust-boundary.js
@@ -7,6 +7,7 @@ const Module = require('module');
 const os = require('os');
 const path = require('path');
 const { pathToFileURL } = require('url');
+const AdmZip = require('adm-zip');
 const { verifyAuthenticatedDocument: verifyArtifactDocument } = require(path.resolve(__dirname, '..', '..', 'scripts', 'lib', 'verify-artifacts.js'));
 
 const ROOT = path.resolve(__dirname, '..', '..');
@@ -157,6 +158,28 @@ async function main() {
   try { await T.readRemoteTextLimited({ headers: actualHeaders, arrayBuffer: async () => Buffer.from('01234567890') }, 10, 50); }
   catch (error) { bodyError = error; }
   check(bodyError && /大小上限/.test(bodyError.message), 'undeclared oversized response is rejected after bounded read');
+
+  const bombPath = path.join(TMP, 'workshop-bomb.tm-pack');
+  const bombZip = new AdmZip();
+  bombZip.addFile('manifest.json', Buffer.from('{"id":"bomb","type":"scenario","entry":"payload.json"}'));
+  bombZip.addFile('payload.json', Buffer.alloc(2 * 1024 * 1024, 0x41));
+  bombZip.writeZip(bombPath);
+  const tempNamesBefore = new Set(fs.readdirSync(os.tmpdir()).filter(name => name.startsWith('tianming-pack-')));
+  let bombError = null;
+  try { await T.extractZipToTemp(bombPath); } catch (error) { bombError = error; }
+  const tempNamesAfter = fs.readdirSync(os.tmpdir()).filter(name => name.startsWith('tianming-pack-'));
+  check(bombError && /压缩比异常|ZIP 炸弹/.test(bombError.message), 'high-ratio workshop ZIP is rejected during central-directory preflight');
+  check(tempNamesAfter.every(name => tempNamesBefore.has(name)), 'rejected ZIP creates no extraction directory and writes no expanded payload');
+
+  const safeZipPath = path.join(TMP, 'workshop-safe.tm-pack');
+  const safeZip = new AdmZip();
+  safeZip.addFile('manifest.json', Buffer.from('{"id":"safe","type":"scenario","entry":"scenario.json"}'));
+  safeZip.addFile('scenario.json', Buffer.from('{"id":"safe-scenario","name":"安全测试"}'));
+  safeZip.writeZip(safeZipPath);
+  const extractedSafe = await T.extractZipToTemp(safeZipPath);
+  check(JSON.parse(fs.readFileSync(path.join(extractedSafe, 'scenario.json'), 'utf8')).id === 'safe-scenario',
+    'valid workshop ZIP is extracted entry-by-entry after preflight');
+  fs.rmSync(extractedSafe, { recursive: true, force: true });
 
   const mainSource = fs.readFileSync(path.join(ROOT, 'main-impl.js'), 'utf8');
   const preloadSource = fs.readFileSync(path.join(ROOT, 'preload-impl.js'), 'utf8');

--- a/web/scripts/smoke-security-trust-boundary.js
+++ b/web/scripts/smoke-security-trust-boundary.js
@@ -32,7 +32,7 @@ const electronStub = {
     getPath: () => path.join(TMP, 'userData'),
     getVersion: () => '1.3.4.11',
     getAppPath: () => ROOT,
-    isPackaged: true,
+    isPackaged: false,
     whenReady: () => new Promise(() => {}),
     on() {}, once() {}, relaunch() {}, exit() {}, quit() {}
   },
@@ -115,9 +115,8 @@ async function main() {
   const stalledError = await stalledRead;
   electronStub.net.fetch = originalNetFetch;
   check(bodyAbortObserved && /aborted/.test(String(stalledError && stalledError.message)), 'caller abort remains connected after response headers and stops a stalled body');
-  // Public key is cached above. Removing the test-export flag exercises the production unsigned branch.
-  delete process.env.TIANMING_TEST_EXPORTS;
-  check(throws(() => T.verifyAuthenticatedUpdateDocument(payload, 'tianming-hot-update-feed'), /缺少 Ed25519/), 'production path rejects unsigned update documents');
+  check(T.verifyAuthenticatedUpdateDocument(payload, 'tianming-hot-update-feed') === payload,
+    'unsigned fixtures are allowed only inside explicit unpackaged test mode');
 
   const trustedUrl = pathToFileURL(path.join(ROOT, 'web', 'index.html')).toString();
   const mainFrame = { url: trustedUrl, parent: null };
@@ -134,8 +133,19 @@ async function main() {
   check(T.isAllowedRemoteUrl('https://example.com/path') && !T.isAllowedRemoteUrl('https://example.com:444/path')
     && !T.isAllowedRemoteUrl('https://user:pass@example.com/path'), 'URL parser enforces HTTPS default port and no userinfo');
   let ipError = null;
-  try { await T.assertSafeRemoteUrl('https://127.0.0.1/path'); } catch (error) { ipError = error; }
+  try { await T.assertSafeRemoteUrl('https://10.0.0.1/path'); } catch (error) { ipError = error; }
   check(ipError && /IP/.test(ipError.message), 'production remote requests reject IP literals before fetch');
+
+  const publicSession = T.toPublicAccountSession({ token: 'secret', user: { id: 7 }, loggedInAt: 'now' });
+  check(publicSession.loggedIn === true && publicSession.user.id === 7 && !Object.prototype.hasOwnProperty.call(publicSession, 'token'),
+    'renderer account session exposes identity without bearer token');
+  const sanitized = T.sanitizeOnlineResponse({ success: true, token: 'secret', nested: { refreshToken: 'refresh', value: 1 } });
+  check(sanitized.success && sanitized.nested.value === 1 && !('token' in sanitized) && !('refreshToken' in sanitized.nested),
+    'account responses recursively remove session secrets');
+  check(T.normalizeOnlineRendererRoute('GET', 'workshop/pack?id=x').route === 'workshop/pack'
+    && throws(() => T.normalizeOnlineRendererRoute('GET', 'https://attacker.invalid/steal'), /非法|授权/)
+    && throws(() => T.normalizeOnlineRendererRoute('POST', '../account/login'), /非法|授权/),
+    'renderer online proxy accepts only fixed methods and routes');
 
   const oversizedHeaders = { get: name => name === 'content-length' ? '20' : null };
   let bodyError = null;
@@ -159,6 +169,12 @@ async function main() {
     && !/checkForUpdate:\s*\([^)]*feedUrl/.test(preloadSource), 'renderer bridge cannot provide ordinary/hot update feed URLs');
   check(!builderSource.includes("addLocalFile(path.join(APP_ROOT, 'main")
     && !builderSource.includes("addLocalFile(path.join(APP_ROOT, 'preload"), 'content OTA builder cannot package main/preload executable code');
+
+  // 打包进程即使继承测试环境变量，也不得暴露任何测试出口。
+  electronStub.app.isPackaged = true;
+  delete require.cache[require.resolve(path.join(ROOT, 'main-impl.js'))];
+  const packagedModule = require(path.join(ROOT, 'main-impl.js'));
+  check(!packagedModule.__test, 'packaged build ignores TIANMING_TEST_EXPORTS and exposes no test internals');
 
   console.log('[smoke-security-trust-boundary] PASS assertions=' + assertions);
 }

--- a/web/scripts/smoke-storage-local-fallback.js
+++ b/web/scripts/smoke-storage-local-fallback.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.resolve(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'tm-storage.js'), 'utf8');
+let assertions = 0;
+
+function check(condition, message) {
+  if (!condition) throw new Error('[smoke-storage-local-fallback] ' + message);
+  assertions += 1;
+}
+
+function makeLocalStorage() {
+  const data = new Map();
+  return {
+    get length() { return data.size; },
+    key(index) { return Array.from(data.keys())[index] || null; },
+    getItem(key) { return data.has(String(key)) ? data.get(String(key)) : null; },
+    setItem(key, value) { data.set(String(key), String(value)); },
+    removeItem(key) { data.delete(String(key)); },
+    clear() { data.clear(); }
+  };
+}
+
+function makeFailingIndexedDB() {
+  return {
+    open() {
+      const request = {};
+      queueMicrotask(() => {
+        if (typeof request.onerror === 'function') {
+          request.onerror({ target: { error: new Error('synthetic IndexedDB open failure') } });
+        }
+      });
+      return request;
+    }
+  };
+}
+
+function makeContext(indexedDB) {
+  const localStorage = makeLocalStorage();
+  const quietConsole = { log() {}, warn() {}, error() {}, info() {} };
+  const context = {
+    console: quietConsole,
+    Promise, Math, Date, JSON, Object, Array, Number, String, Boolean, Error,
+    Blob, Response, CompressionStream, DecompressionStream, TextDecoder,
+    localStorage,
+    navigator: { storage: null },
+    indexedDB
+  };
+  context.window = context;
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(source, context, { filename: 'tm-storage.js' });
+  return context;
+}
+
+async function exerciseFallback(indexedDB, label) {
+  const context = makeContext(indexedDB);
+  const expected = {
+    GM: { turn: 12, sid: 'fallback-smoke', nested: { zero: 0, empty: [], enabled: false } },
+    P: { name: '降级存档', flags: { safe: true } }
+  };
+  const saved = await context.TM_SaveDB.save('fallback', expected, { type: 'manual', turn: 12 });
+  check(saved === true, label + ': save should report success');
+
+  const raw = JSON.parse(context.localStorage.getItem('tm_idb_saves_fallback'));
+  check(raw._compressed === false, label + ': localStorage record must not claim gzip compression');
+  check(typeof raw.gameState === 'string' && raw.gameState.indexOf('fallback-smoke') >= 0,
+    label + ': localStorage record must retain the JSON payload instead of serializing Blob to {}');
+
+  const loaded = await context.TM_SaveDB.load('fallback');
+  check(JSON.stringify(loaded.gameState) === JSON.stringify(expected), label + ': save/load must round-trip deeply');
+}
+
+(async function main() {
+  check(typeof CompressionStream !== 'undefined', 'fixture requires CompressionStream to exercise the Blob branch');
+  await exerciseFallback(undefined, 'missing IndexedDB');
+  await exerciseFallback(makeFailingIndexedDB(), 'failed IndexedDB open');
+  console.log('[smoke-storage-local-fallback] PASS assertions=' + assertions);
+})().catch((error) => {
+  console.error(error && error.stack || error);
+  process.exit(1);
+});

--- a/web/tm-ai-change-pathutils.js
+++ b/web/tm-ai-change-pathutils.js
@@ -453,6 +453,14 @@
     var declaredDynamic = /^corruption\.byDept\.(central|provincial|county|military|palace|technical)$/.test(path);
     if (!r.parent || (!r.exists && !declaredDynamic)) return { ok: false, path: path, reason: 'path not declared in state schema' };
     var old = r.value;
+    function valueType(input) {
+      if (Array.isArray(input)) return 'array';
+      if (input === null) return 'null';
+      return typeof input;
+    }
+    if (r.exists && valueType(old) !== valueType(value)) {
+      return { ok: false, path: path, reason: 'set value type does not match existing schema' };
+    }
     if (/^chars\.[^.]+\.loyalty$/.test(String(path)) && typeof global.setCharacterLoyalty === 'function') {
       var loySet = global.setCharacterLoyalty(r.parent, value, reason, {
         source: 'ai-anypath-loyalty-set',

--- a/web/tm-battle-adapter.js
+++ b/web/tm-battle-adapter.js
@@ -13,19 +13,26 @@
   }
 
   /* 主将名 → 战斗 gen{n,valor,mil,int}(翻 GM.chars·缺则中庸默认·永不崩) */
-  function genFor(commander, GMref) {
+  function genFor(commander, GMref, commanderId) {
     var name = commander || '';
     var g = GMref || (typeof window !== 'undefined' && window.GM) || (typeof GM !== 'undefined' ? GM : null);
     var c = null;
-    if (g && Array.isArray(g.chars) && name) {
-      for (var i = 0; i < g.chars.length; i++) {
-        var ch = g.chars[i];
-        if (ch && (ch.name === name || ch['姓名'] === name)) { c = ch; break; }
+    if (g && Array.isArray(g.chars) && (name || commanderId)) {
+      var stableRef = commanderId || name;
+      var idMatches = g.chars.filter(function(ch) {
+        if (!ch) return false;
+        return [ch.id, ch.characterId, ch.charId].some(function(id) { return id != null && String(id) === String(stableRef); });
+      });
+      if (idMatches.length === 1) c = idMatches[0];
+      if (!c && !commanderId && name) {
+        var nameMatches = g.chars.filter(function(ch) { return ch && (ch.name === name || ch['姓名'] === name); });
+        // 同名人物没有稳定 ID 时宁可使用中庸默认，也不能绑定到数组中的第一个人。
+        if (nameMatches.length === 1) c = nameMatches[0];
       }
     }
     function pick(o, keys, d) { for (var k = 0; k < keys.length; k++) { if (o && o[keys[k]] != null) return o[keys[k]]; } return d; }
     return {
-      n: name || '裨将',
+      n: (c && (c.name || c['姓名'])) || name || '裨将',
       valor: c ? Math.round(pick(c, ['valor', '武力', '勇武'], 60)) : 60,
       mil: c ? Math.round(pick(c, ['military', '军事', '统率', '将略'], 62)) : 62,
       int: c ? Math.round(pick(c, ['intelligence', '智力', '智'], 55)) : 55
@@ -77,7 +84,8 @@
     var out = [];
     (armies || []).forEach(function (a) {
       if (!a) return;
-      var us = armyUnits(a), gen = genFor(a.commander, GMref), dep = deputyGen(gen);
+      var commanderId = a.commanderId || a.commanderCharacterId || a.generalId || a.leaderId || '';
+      var us = armyUnits(a), gen = genFor(a.commander, GMref, commanderId), dep = deputyGen(gen);
       var isEmp = emperorArmyId != null && (a.id === emperorArmyId);
       us.filter(function (u) { return u && Number(u.men) > 0; }).forEach(function (u, i) {
         var tok = unitToToken(u, a, i === 0 ? gen : dep);

--- a/web/tm-content-manager-community.js
+++ b/web/tm-content-manager-community.js
@@ -704,7 +704,6 @@
   }
   function accountSessionIdentity(session) {
     if (!session) return '';
-    if (session.token) return 'token:' + String(session.token);
     var user = session.user || session;
     var userKey = user && user.id != null ? user.id : (user && user.username);
     return 'user:' + String(userKey == null ? '' : userKey);
@@ -724,7 +723,7 @@
   }
   async function refreshAccountSession() {
     var session = (window.TM && TM.OnlineClient) ? TM.OnlineClient.getSession() : state.accountSession;
-    session = session && session.token ? session : null;
+    session = session && (session.loggedIn || session.user) ? session : null;
     return replaceAccountSession(session, true);
   }
   async function accountRefresh() {
@@ -783,7 +782,7 @@
     }
     if (!_sameAccountEpoch(logoutEpoch)) return;
     var currentSession = TM.OnlineClient.getSession ? TM.OnlineClient.getSession() : null;
-    if (currentSession && currentSession.token && accountSessionIdentity(currentSession) !== logoutIdentity) {
+    if (currentSession && (currentSession.loggedIn || currentSession.user) && accountSessionIdentity(currentSession) !== logoutIdentity) {
       replaceAccountSession(currentSession, false);
       state.accountMessage = '账号已在退出期间切换，已保留新的登录。';
       render();
@@ -1229,7 +1228,7 @@
       state.defaultOnlineApiUrl = status.defaultOnlineApiUrl || state.defaultOnlineApiUrl || '';
       state.hotStatus = status.hotUpdate || state.hotStatus || null;
       var onlineSession = (window.TM && TM.OnlineClient) ? TM.OnlineClient.getSession() : null;
-      replaceAccountSession((onlineSession && onlineSession.token) ? onlineSession : (status.account || state.accountSession || null), false);
+      replaceAccountSession((onlineSession && (onlineSession.loggedIn || onlineSession.user)) ? onlineSession : (status.account || state.accountSession || null), false);
       if (!state.feedUrl) state.feedUrl = loadFeedUrl();
       if (!state.hotFeedUrl) state.hotFeedUrl = loadHotFeedUrl();
       if (!state.catalogUrl) state.catalogUrl = loadCatalogUrl();

--- a/web/tm-content-manager.js
+++ b/web/tm-content-manager.js
@@ -1271,9 +1271,9 @@
         if (!state.hotFeedUrl) state.hotFeedUrl = loadHotFeedUrl();
         if (!state.catalogUrl) state.catalogUrl = loadCatalogUrl();
         if (!state.onlineApiUrl) state.onlineApiUrl = loadOnlineApiUrl();
-        // 账号统一走 TM.OnlineClient（渲染层 localStorage）。优先它；旧 IPC session 仅作兜底。
+        // 账号统一走 TM.OnlineClient；Electron 会话与 Bearer Token 只保存在主进程。
         var ocSess = (window.TM && TM.OnlineClient) ? TM.OnlineClient.getSession() : null;
-        replaceAccountSession((ocSess && ocSess.token) ? ocSess : (status.account || state.accountSession || null), false);
+        replaceAccountSession((ocSess && (ocSess.loggedIn || ocSess.user)) ? ocSess : (status.account || state.accountSession || null), false);
         state.status = { currentVersion: status.currentVersion };
       }
     } catch(e) {

--- a/web/tm-court-meter.js
+++ b/web/tm-court-meter.js
@@ -153,6 +153,19 @@ function _postTurnCourtChoose(openCourt) {
   }
 }
 
+// 后朝状态只由朝会子系统写入；end-turn core 在事务快照后调用本写口。
+function _beginPostTurnCourtState(openCourt) {
+  var shouldOpen = !!openCourt;
+  GM._pendingShijiModal = {
+    aiReady: false,
+    courtDone: !shouldOpen,
+    payload: null,
+    source: shouldOpen ? 'post-turn-court' : 'post-turn-skip',
+    startedTurn: GM.turn || 0
+  };
+  GM._isPostTurnCourt = shouldOpen;
+}
+
 // 底栏进度 banner（朝会期间常驻）
 function _showPostTurnCourtBanner() {
   var _existing = _$('post-turn-court-banner');

--- a/web/tm-court-meter.js
+++ b/web/tm-court-meter.js
@@ -124,12 +124,10 @@ function _showPostTurnCourtPromptAndStartEndTurn() {
 function _postTurnCourtChoose(openCourt) {
   var _bg = _$('post-turn-court-prompt');
   if (_bg) _bg.remove();
+  if (typeof endTurn === 'function') endTurn._preSubmitInFlight = false;
   if (openCourt) {
-    // 先标记 courtDone=false 并启动 AI 推演（后台）
-    GM._pendingShijiModal = { aiReady: false, courtDone: false, payload: null, source: 'post-turn-court', startedTurn: GM.turn || 0 };
-    GM._isPostTurnCourt = true;
     // 并发：启动 endTurn 主流程（不 await·让 AI 在后台跑）
-    _endTurnInternal();
+    _endTurnInternal({ postTurnCourt: true });
     // 同时开朝——先打开 chaoyi-modal 再直跳常朝准备
     setTimeout(function(){
       try {
@@ -151,9 +149,7 @@ function _postTurnCourtChoose(openCourt) {
     }, 200);
   } else {
     // 不开朝——直接跑 endTurn，显示加载条
-    GM._pendingShijiModal = { aiReady: false, courtDone: true, payload: null, source: 'post-turn-skip', startedTurn: GM.turn || 0 };
-    GM._isPostTurnCourt = false;
-    _endTurnInternal();
+    _endTurnInternal({ postTurnCourt: false });
   }
 }
 

--- a/web/tm-economy.js
+++ b/web/tm-economy.js
@@ -98,10 +98,19 @@ function updateEconomy(timeRatio) {
   var totalTribute = 0;
   var tributeByRegion = {}; // 记录各地区贡奉
 
+  // 运行局以 GM 地图为唯一事实来源；P 仅是新局前/旧档缺少运行地图时的模板回退。
+  var runtimeMap = null;
+  if (typeof getLiveMapData === 'function') runtimeMap = getLiveMapData();
+  if (!runtimeMap && GM) runtimeMap = GM.mapData || GM.map || null;
+  if (!runtimeMap && P) runtimeMap = P.mapData || P.map || null;
+  var runtimeRegions = runtimeMap && Array.isArray(runtimeMap.regions) ? runtimeMap.regions : [];
+
   // 如果有地图系统
-  if (P.map && P.map.regions && P.map.regions.length > 0) {
-    P.map.regions.forEach(function(region) {
-      if (!region || !region.name) return;
+  if (runtimeRegions.length > 0) {
+    runtimeRegions.forEach(function(region) {
+      if (!region || (!region.id && !region.name)) return;
+      var regionKey = String(region.id || region.name);
+      var regionName = String(region.name || region.id);
 
       // 计算月度收入
       var income = calculateMonthlyIncome(region, es);
@@ -122,7 +131,9 @@ function updateEconomy(timeRatio) {
       var tribute = Math.floor(income * tributeRatio);
 
       totalTribute += tribute;
-      tributeByRegion[region.name] = {
+      tributeByRegion[regionKey] = {
+        id: region.id || '',
+        name: regionName,
         income: income,
         tribute: tribute,
         ratio: tributeRatio,
@@ -131,7 +142,7 @@ function updateEconomy(timeRatio) {
 
       // 记录变化
       if (tribute > 0) {
-        recordChange('economy', region.name, 'tribute', 0, tribute, '向中央贡奉');
+        recordChange('economy', regionName, 'tribute', 0, tribute, '向中央贡奉');
       }
     });
   }
@@ -157,13 +168,13 @@ function updateEconomy(timeRatio) {
 
   // 3. 按贡献占比分配回拨
   if (totalTribute > 0 && redistributed > 0) {
-    Object.keys(tributeByRegion).forEach(function(regionName) {
-      var regionData = tributeByRegion[regionName];
+    Object.keys(tributeByRegion).forEach(function(regionKey) {
+      var regionData = tributeByRegion[regionKey];
       var share = regionData.tribute / totalTribute;
       var allocation = Math.floor(redistributed * share);
 
       if (allocation > 0) {
-        recordChange('economy', regionName, 'allocation', 0, allocation, '中央回拨');
+        recordChange('economy', regionData.name || regionKey, 'allocation', 0, allocation, '中央回拨');
       }
     });
   }

--- a/web/tm-endturn-ai.js
+++ b/web/tm-endturn-ai.js
@@ -978,6 +978,7 @@
               try {
                 if (typeof setAIBranchDiagnostic === 'function') setAIBranchDiagnostic(id, 'failed', _errInfo.message);
               } catch(_branchFailErr) { try { console.warn('[AIDiagnostic] branch failed failed:', _branchFailErr); } catch(_) {} }
+              if (typeof _isCriticalPostTurnJob === 'function' && _isCriticalPostTurnJob({ id: id })) throw _scErr;
             }
           }
         }
@@ -1218,7 +1219,12 @@
       }
       function _enqueueLocalPostTurnJob(id, fn) {
         if (!GM._postTurnJobs || !Array.isArray(GM._postTurnJobs.pending)) GM._postTurnJobs = { pending: [], launchedAt: Date.now(), results: {} };
-        var p = Promise.resolve().then(fn).catch(function(e){ _dbg('[PostTurn]' + id + ' failed:', e); });
+        var p = Promise.resolve().then(fn).then(function(value) {
+          return { ok: true, value: value };
+        }, function(e) {
+          _dbg('[PostTurn]' + id + ' failed:', e);
+          return { ok: false, error: e };
+        });
         GM._postTurnJobs.pending.push({ id: id, promise: p });
         return p;
       }
@@ -1232,7 +1238,11 @@
         var waiting = GM._postTurnJobs.pending.filter(function(job) {
           return job && ids.indexOf(job.id) >= 0 && job.promise;
         });
-        if (waiting.length) await Promise.all(waiting.map(function(job) { return job.promise; }));
+        if (waiting.length) {
+          var results = await Promise.all(waiting.map(function(job) { return job.promise; }));
+          var failed = results.filter(function(result) { return result && result.ok === false; });
+          if (failed.length) throw failed[0].error || new Error('关键后台任务失败');
+        }
       }
 
       // --- 预处理：等待上回合 post-turn 任务 + 同步本地记忆保鲜 ---
@@ -1240,7 +1250,7 @@
         if (typeof _awaitPostTurnJobs === 'function') await _awaitPostTurnJobs();
         if (typeof _ensureMemoryFreshness === 'function') _ensureMemoryFreshness(GM);
         if (typeof recordMemoryDiagnostic === 'function') recordMemoryDiagnostic('turn_start', { stage: 'after_post_turn_jobs', snapshot: (typeof buildMemoryDiagnosticSnapshot === 'function' ? buildMemoryDiagnosticSnapshot(GM) : null) });
-      } catch(_emfE) { _dbg('[MemoryFresh] 预处理失败:', _emfE); }
+      } catch(_emfE) { _dbg('[MemoryFresh] 预处理失败:', _emfE); throw _emfE; }
 
       // ═══════════════════════════════════════════════════════════
       // §3 Sub-calls sc0/sc05/sc1/sc1b/sc1c（深度思考·记忆·主推演·文事·势力）

--- a/web/tm-endturn-core.js
+++ b/web/tm-endturn-core.js
@@ -419,15 +419,8 @@ async function _endTurnCore(options){
   if(GM.busy)return;
   _turnTxn = _tmCaptureEndTurnTransaction();
   if (options && Object.prototype.hasOwnProperty.call(options, 'postTurnCourt')) {
-    var _openPostTurnCourt = !!options.postTurnCourt;
-    GM._pendingShijiModal = {
-      aiReady: false,
-      courtDone: !_openPostTurnCourt,
-      payload: null,
-      source: _openPostTurnCourt ? 'post-turn-court' : 'post-turn-skip',
-      startedTurn: GM.turn || 0
-    };
-    GM._isPostTurnCourt = _openPostTurnCourt;
+    if (typeof _beginPostTurnCourtState !== 'function') throw new Error('后朝状态写口未加载');
+    _beginPostTurnCourtState(!!options.postTurnCourt);
   }
   GM._endTurnCommitPending = true; // arch-ok end-turn transaction owns its commit barrier
   GM.busy=true;

--- a/web/tm-endturn-core.js
+++ b/web/tm-endturn-core.js
@@ -25,6 +25,7 @@ async function _runPreSubmitPartyClassCalibration() {
       }
     } catch(_partyClassSchedulerE) {
       try { console.warn('[endTurn] pre-submit party/class action scheduler failed', _partyClassSchedulerE); } catch(_){}
+      throw _partyClassSchedulerE;
     }
     if (!_pcSchedulerRan && typeof window !== 'undefined' && window.TM && TM.SocialPoliticalSignals) {
       try {
@@ -53,6 +54,7 @@ async function _runPreSubmitPartyClassCalibration() {
         }
       } catch(_socialPoliticalE) {
         try { console.warn('[endTurn] pre-submit social/political signal bridge failed', _socialPoliticalE); } catch(_){}
+        throw _socialPoliticalE;
       }
     }
     try {
@@ -64,6 +66,7 @@ async function _runPreSubmitPartyClassCalibration() {
       }
     } catch(_classCharacterRelationsE) {
       try { console.warn('[endTurn] pre-submit class/character relations failed', _classCharacterRelationsE); } catch(_){}
+      throw _classCharacterRelationsE;
     }
     if (!_pcSchedulerRan) try {
       if (typeof window !== 'undefined' && window.TM && TM.PartyClassActors && typeof TM.PartyClassActors.run === 'function') {
@@ -80,6 +83,7 @@ async function _runPreSubmitPartyClassCalibration() {
       }
     } catch(_partyClassActorsE) {
       try { console.warn('[endTurn] pre-submit party/class actors failed', _partyClassActorsE); } catch(_){}
+      throw _partyClassActorsE;
     }
     try {
       if (typeof window !== 'undefined' && window.TM && TM.ClassMinxinBridge && typeof TM.ClassMinxinBridge.maintain === 'function') {
@@ -90,6 +94,7 @@ async function _runPreSubmitPartyClassCalibration() {
       }
     } catch(_classMinxinMaintainE) {
       try { console.warn('[endTurn] pre-submit class/minxin bridge failed', _classMinxinMaintainE); } catch(_){}
+      throw _classMinxinMaintainE;
     }
     try {
       if (typeof window !== 'undefined' && window.TM && TM.MinxinLedger && typeof TM.MinxinLedger.maintain === 'function') {
@@ -100,6 +105,7 @@ async function _runPreSubmitPartyClassCalibration() {
       }
     } catch(_minxinLedgerMaintainE) {
       try { console.warn('[endTurn] pre-submit minxin ledger failed', _minxinLedgerMaintainE); } catch(_){}
+      throw _minxinLedgerMaintainE;
     }
     try {
       if (typeof window !== 'undefined' && window.TM && TM.MinxinPressureActions && typeof TM.MinxinPressureActions.maintain === 'function') {
@@ -110,6 +116,7 @@ async function _runPreSubmitPartyClassCalibration() {
       }
     } catch(_minxinPressureActionsE) {
       try { console.warn('[endTurn] pre-submit minxin pressure actions failed', _minxinPressureActionsE); } catch(_){}
+      throw _minxinPressureActionsE;
     }
     try {
       if (typeof window !== 'undefined' && window.TM && TM.MinxinCommitmentTracker && typeof TM.MinxinCommitmentTracker.tick === 'function') {
@@ -120,6 +127,7 @@ async function _runPreSubmitPartyClassCalibration() {
       }
     } catch(_minxinCommitmentsE) {
       try { console.warn('[endTurn] pre-submit minxin commitments failed', _minxinCommitmentsE); } catch(_){}
+      throw _minxinCommitmentsE;
     }
     try {
       if (typeof window !== 'undefined' && window.TM && TM.MinxinResponsibilityChain && typeof TM.MinxinResponsibilityChain.tick === 'function') {
@@ -130,6 +138,7 @@ async function _runPreSubmitPartyClassCalibration() {
       }
     } catch(_minxinResponsibilityE) {
       try { console.warn('[endTurn] pre-submit minxin responsibility failed', _minxinResponsibilityE); } catch(_){}
+      throw _minxinResponsibilityE;
     }
     try {
       if (typeof window !== 'undefined' && window.TM && TM.HujiGovernanceLoop && typeof TM.HujiGovernanceLoop.ingestPlayerSignals === 'function') {
@@ -146,6 +155,7 @@ async function _runPreSubmitPartyClassCalibration() {
       }
     } catch(_hujiGovernanceE) {
       try { console.warn('[endTurn] pre-submit huji governance loop failed', _hujiGovernanceE); } catch(_){}
+      throw _hujiGovernanceE;
     }
     try {
       if (typeof window !== 'undefined' && window.TM && TM.HujiRuntimeBridge && typeof TM.HujiRuntimeBridge.maintain === 'function') {
@@ -157,6 +167,7 @@ async function _runPreSubmitPartyClassCalibration() {
       }
     } catch(_hujiRuntimeBridgeE) {
       try { console.warn('[endTurn] pre-submit huji runtime bridge failed', _hujiRuntimeBridgeE); } catch(_){}
+      throw _hujiRuntimeBridgeE;
     }
     try {
       if (typeof window !== 'undefined' && window.TM && TM.MinxinHardLinks && typeof TM.MinxinHardLinks.tick === 'function') {
@@ -167,6 +178,7 @@ async function _runPreSubmitPartyClassCalibration() {
       }
     } catch(_minxinHardLinksE) {
       try { console.warn('[endTurn] pre-submit minxin hard links failed', _minxinHardLinksE); } catch(_){}
+      throw _minxinHardLinksE;
     }
     try {
       if (typeof window !== 'undefined' && window.TM && TM.MinxinHardLinkConsumers && typeof TM.MinxinHardLinkConsumers.consume === 'function') {
@@ -177,6 +189,7 @@ async function _runPreSubmitPartyClassCalibration() {
       }
     } catch(_minxinHardLinkConsumersE) {
       try { console.warn('[endTurn] pre-submit minxin hard-link consumers failed', _minxinHardLinkConsumersE); } catch(_){}
+      throw _minxinHardLinkConsumersE;
     }
     try {
       if (typeof window !== 'undefined' && window.TM && TM.HujiRuntimeBridge && typeof TM.HujiRuntimeBridge.maintain === 'function') {
@@ -187,6 +200,7 @@ async function _runPreSubmitPartyClassCalibration() {
       }
     } catch(_hujiRuntimeBridgeAfterE) {
       try { console.warn('[endTurn] post-consumer huji runtime bridge failed', _hujiRuntimeBridgeAfterE); } catch(_){}
+      throw _hujiRuntimeBridgeAfterE;
     }
     if (typeof window === 'undefined' || !window.TM || !TM.PartyClassLlmCalibrator || typeof TM.PartyClassLlmCalibrator.flushBeforeSubmit !== 'function') return;
     if (GM && GM._partyClassPreSubmitBusy) return;
@@ -224,22 +238,24 @@ async function _runPreSubmitPartyClassCalibration() {
       }
     } catch(_partyClassActorsAfterE) {
       try { console.warn('[endTurn] post-calibration party/class actors failed', _partyClassActorsAfterE); } catch(_){}
+      throw _partyClassActorsAfterE;
     }
   } catch(_partyClassLlmE) {
     try { console.warn('[endTurn] pre-submit party/class LLM calibration failed', _partyClassLlmE); } catch(_){}
+    throw _partyClassLlmE;
   } finally {
     try { if (GM) GM._partyClassPreSubmitBusy = false; } catch(_){}
   }
 }
 
-async function _endTurnInternal() {
+async function _endTurnInternal(options) {
   try {
     if (typeof _cancelNpcIdleAutonomyLoop === 'function') _cancelNpcIdleAutonomyLoop('endturn_start');
   } catch(_idleCancelE) {
     try { console.warn('[endTurn] NPC idle autonomy cancel failed', _idleCancelE); } catch(_){}
   }
   // 原 endTurn 的完整内容移入此处，方便并发调用
-  return await _endTurnCore();
+  return await _endTurnCore(options);
 }
 
 async function endTurn(){
@@ -273,9 +289,11 @@ async function endTurn(){
   if (endTurn._preSubmitInFlight) return;
   endTurn._preSubmitInFlight = true;
   try {
-    await _runPreSubmitPartyClassCalibration();
     _showPostTurnCourtPromptAndStartEndTurn();
-  } finally { endTurn._preSubmitInFlight = false; }
+  } catch (error) {
+    endTurn._preSubmitInFlight = false;
+    throw error;
+  }
 }
 
 function _tmCaptureEndTurnObject(obj, runtimeKeys) {
@@ -387,7 +405,7 @@ if (typeof window !== 'undefined') {
   window._tmRollbackEndTurnTransaction = _tmRollbackEndTurnTransaction;
 }
 
-async function _endTurnCore(){
+async function _endTurnCore(options){
   // [slice 7c·2026-05-08] pipeline 是 endturn 唯一执行路径
   // P.flags.useNewPipeline 已废止·观察者 try/catch fallback 已删·step.onError 接管错误
   // pipeline.run 必须在 'await EndTurnHooks.execute(before)' 之后(slice 5 落地)
@@ -400,6 +418,17 @@ async function _endTurnCore(){
   var btn=_$("btn-end")||_$("btn-end-turn");
   if(GM.busy)return;
   _turnTxn = _tmCaptureEndTurnTransaction();
+  if (options && Object.prototype.hasOwnProperty.call(options, 'postTurnCourt')) {
+    var _openPostTurnCourt = !!options.postTurnCourt;
+    GM._pendingShijiModal = {
+      aiReady: false,
+      courtDone: !_openPostTurnCourt,
+      payload: null,
+      source: _openPostTurnCourt ? 'post-turn-court' : 'post-turn-skip',
+      startedTurn: GM.turn || 0
+    };
+    GM._isPostTurnCourt = _openPostTurnCourt;
+  }
   GM._endTurnCommitPending = true; // arch-ok end-turn transaction owns its commit barrier
   GM.busy=true;
   GM._endTurnBusy=true;
@@ -408,6 +437,10 @@ async function _endTurnCore(){
   if (!(GM._pendingShijiModal && GM._pendingShijiModal.courtDone === false)) {
     showLoading("\u65F6\u79FB\u4E8B\u53BB",10);
   }
+
+  // 预提交校准会修改党派、阶层、民心和户籍，必须位于事务快照之后。
+  // 任一关键校准失败都抛到本函数外层，恢复到玩家点击过回合前的完整状态。
+  await _runPreSubmitPartyClassCalibration();
 
   // 上回合 post-turn 任务改到 AI prompt 构造前兜底等待。
   // 入口不硬等，让 prep / 存档快照 / plan-prefetch 与上回合后台债务重叠。

--- a/web/tm-endturn-followup.js
+++ b/web/tm-endturn-followup.js
@@ -2233,6 +2233,9 @@
           var _pS = await _parseOrRepairJsonResult(_sCall.raw || '', _sCall.data, 'sc25c.strategic', { url: url, key: P.ai.key, body: _bodyS, expectedKeys: ['consolidated', 'key_threads', 'npc_trajectories'], priority: 'normal' });
           pS = _pS && _pS.parsed;
         }
+        if (!pT || !pS) {
+          throw new Error('sc25c 双调用未完整产出：tactical=' + (pT ? 'ok' : 'failed') + ' strategic=' + (pS ? 'ok' : 'failed'));
+        }
 
         // 写回 GM·tactical → 旧 sc25 流向 (_stateBoard / _foreshadows / imperial_candidates) ; strategic → 旧 sc_consolidate 流向 (_consolidatedMemory)
         if (pT) {
@@ -2332,7 +2335,7 @@
           _ptQ25c.results.sc_consolidate = pS;
         }
         _dbg('[sc25c] dual-call done·tactical:' + (pT ? 'ok' : 'fail') + ' strategic:' + (pS ? 'ok' : 'fail'));
-      } catch(_25cErr) { _dbg('[sc25c] fail:', _25cErr); if (typeof recordSubcallError === 'function') recordSubcallError('sc25c', 'execute', _25cErr); }
+      } catch(_25cErr) { _dbg('[sc25c] fail:', _25cErr); if (typeof recordSubcallError === 'function') recordSubcallError('sc25c', 'execute', _25cErr); throw _25cErr; }
       }); });
 
       // --- Sub-call 2.5: 深度伏笔种植 + 回合记忆压缩 + NPC情绪快照 ---

--- a/web/tm-endturn-systems.js
+++ b/web/tm-endturn-systems.js
@@ -39,7 +39,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
 
   // 3.0 机械层先行结算（战斗/围城/行军等确定性系统，在AI叙事之后、系统更新之前）
   if (typeof BattleEngine !== 'undefined' && BattleEngine._getConfig().enabled) {
-    try { BattleEngine.resolveAllBattles(); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'BattleEngine] 结算失败:') : console.error('[BattleEngine] 结算失败:', e); }
+    try { await Promise.resolve(BattleEngine.resolveAllBattles()); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'BattleEngine] 结算失败:') : console.error('[BattleEngine] 结算失败:', e); throw e; }
   }
 
   // 3. 通过子回合调度器执行分层结算（daily→monthly→perturn）
@@ -49,7 +49,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
     : ((typeof timeRatio === 'number' && isFinite(timeRatio) && timeRatio > 0) ? timeRatio * 12 : 1);
   var pipelineCtx = { timeRatio: timeRatio, turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio };
   var _currencyFullTicked = false;
-  SubTickRunner.run(pipelineCtx);
+  await Promise.resolve(SubTickRunner.run(pipelineCtx));
 
   // 3.5 NPC 行为推演:旧 NPC 决策驱动 IIFE 已切除(2026-06-16 死簇切除)·此处孤儿调用一并删除。
   //   ⚠ 之前残留该孤儿调用·而 P.npcEngine.enabled 默认 true → 每回合抛 ReferenceError(引擎未定义)被 try/catch 吞作"NPC行为推演失败"。
@@ -62,30 +62,30 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
   GM.turn++;
   // 同步旧子系统读取的年月日镜像；不得另算第二套时钟。
   try { if (typeof _tmSyncGMCalendar === 'function') _tmSyncGMCalendar(GM, GM.turn); }
-  catch (_calendarSyncE) { try { console.warn('[endTurn] calendar sync failed:', _calendarSyncE); } catch (_) {} }
+  catch (_calendarSyncE) { try { console.warn('[endTurn] calendar sync failed:', _calendarSyncE); } catch (_) {} throw _calendarSyncE; }
 
   // 6.01 腐败引擎回合演化（九源累积/衰减/真实感知更新/后果传导/揭发概率）
   try {
     if (typeof CorruptionEngine !== 'undefined') {
       CorruptionEngine.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] CorruptionEngine.tick 失败:') : console.error('[endTurn] CorruptionEngine.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] CorruptionEngine.tick 失败:') : console.error('[endTurn] CorruptionEngine.tick 失败:', e); throw e; }
 
   // 6.012 人力试点种子（A5 时序修）：须先于下方 6.015 huji 早跑——否则首个激活回合 huji 对「尚未种子」的试点地域照产逃亡/役负满意度=与 Renli 双产双扣。
   //   ensurePilotSeeds 幂等（已种子跳过·保运行时累积）·无 GM/剧本 renliPilot 配置则零行为（未激活态 inert）。种子持久故只首回合关键·此处保证 huji 看到已种子→让出。
-  try { if (typeof TM !== 'undefined' && TM.Renli && typeof TM.Renli.ensurePilotSeeds === 'function') TM.Renli.ensurePilotSeeds(GM); } catch(_psSeedE) {}
+  try { if (typeof TM !== 'undefined' && TM.Renli && typeof TM.Renli.ensurePilotSeeds === 'function') TM.Renli.ensurePilotSeeds(GM); } catch(_psSeedE) { throw _psSeedE; }
 
   // 6.015 户口前移（方案联动总表推荐：腐败→户口→帑廪→内帑→民心→皇权→皇威）
   try {
     if (typeof HujiEngine !== 'undefined') {
       HujiEngine.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HujiEngine(early) 失败:') : console.error('[endTurn] HujiEngine(early) 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HujiEngine(early) 失败:') : console.error('[endTurn] HujiEngine(early) 失败:', e); throw e; }
   try {
     if (typeof HujiDeepFill !== 'undefined') {
       HujiDeepFill.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HujiDeepFill(early) 失败:') : console.error('[endTurn] HujiDeepFill(early) 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HujiDeepFill(early) 失败:') : console.error('[endTurn] HujiDeepFill(early) 失败:', e); throw e; }
   // 标记已早跑，后文跳过
   try {
     if (typeof TM !== 'undefined' && TM.HujiGovernanceLoop && typeof TM.HujiGovernanceLoop.tick === 'function') {
@@ -95,7 +95,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
         monthRatio: monthRatio
       });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HujiGovernanceLoop failed:') : console.error('[endTurn] HujiGovernanceLoop failed:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HujiGovernanceLoop failed:') : console.error('[endTurn] HujiGovernanceLoop failed:', e); throw e; }
   try {
     if (typeof TM !== 'undefined' && TM.HujiRuntimeBridge && typeof TM.HujiRuntimeBridge.maintain === 'function') {
       TM.HujiRuntimeBridge.maintain(GM, {
@@ -104,7 +104,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
         monthRatio: monthRatio
       });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HujiRuntimeBridge failed:') : console.error('[endTurn] HujiRuntimeBridge failed:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HujiRuntimeBridge failed:') : console.error('[endTurn] HujiRuntimeBridge failed:', e); throw e; }
   GM._hujiEarlyTicked = true;
 
   // 6.02 帑廪引擎回合结算（八源+八支+月度流水+年末决算）
@@ -112,14 +112,14 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
     if (typeof GuokuEngine !== 'undefined') {
       GuokuEngine.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] GuokuEngine.tick 失败:') : console.error('[endTurn] GuokuEngine.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] GuokuEngine.tick 失败:') : console.error('[endTurn] GuokuEngine.tick 失败:', e); throw e; }
 
   // 6.02b 天灾生命周期·到期灾害出队(治"activeDisasters 永不消除→国库永久失血"·已赈者更快平息)
   try {
     if (typeof GuokuEngine !== 'undefined' && typeof GuokuEngine.tickDisasters === 'function') {
       GuokuEngine.tickDisasters();
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] tickDisasters 失败:') : console.error('[endTurn] tickDisasters 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] tickDisasters 失败:') : console.error('[endTurn] tickDisasters 失败:', e); throw e; }
 
   // 6.03 内帑引擎回合结算（6 源+5 支+月度+年末+危机检查）
   try {
@@ -130,12 +130,12 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
         monthRatio: monthRatio
       });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HujiRuntimeBridge post-fiscal failed:') : console.error('[endTurn] HujiRuntimeBridge post-fiscal failed:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HujiRuntimeBridge post-fiscal failed:') : console.error('[endTurn] HujiRuntimeBridge post-fiscal failed:', e); throw e; }
   try {
     if (typeof NeitangEngine !== 'undefined') {
       NeitangEngine.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] NeitangEngine.tick 失败:') : console.error('[endTurn] NeitangEngine.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] NeitangEngine.tick 失败:') : console.error('[endTurn] NeitangEngine.tick 失败:', e); throw e; }
 
   // 6.04 角色经济回合结算（6 资源 × 全角色）
   try {
@@ -144,7 +144,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
     if (typeof CharEconEngine !== 'undefined') {
       CharEconEngine.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] CharEconEngine.tick 失败:') : console.error('[endTurn] CharEconEngine.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] CharEconEngine.tick 失败:') : console.error('[endTurn] CharEconEngine.tick 失败:', e); throw e; }
 
   // 6.045 功名自动升迁(自动区·正四品及下·功名结算后)。政治区(从三品及上)不自动·归玩家诏令/廷推/AI。
   try {
@@ -155,14 +155,14 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
         (_proRes.demoted || []).forEach(function(_d){ try { addEB('铨选', _d.name + ' 功微降叙 ' + TMPromotion.rankNameOf(_d.to)); } catch(_e2){} });
       }
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] 功名自动升迁失败:') : console.error('[endTurn] 功名自动升迁:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] 功名自动升迁失败:') : console.error('[endTurn] 功名自动升迁:', e); throw e; }
 
   // 6.05 经济联动（层层剥夺/区域财政/俸禄流/贪腐流/下拨/民心反馈）
   try {
     if (typeof EconomyLinkage !== 'undefined') {
       EconomyLinkage.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] EconomyLinkage.tick 失败:') : console.error('[endTurn] EconomyLinkage.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] EconomyLinkage.tick 失败:') : console.error('[endTurn] EconomyLinkage.tick 失败:', e); throw e; }
 
   // 6.055 货币系统（铸币/纸币生命周期/市场/海外银流/钱荒钱贱）
   try {
@@ -171,49 +171,49 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
       _currencyFullTicked = true;
       try { GM._lastCurrencyFullTickTurn = GM.turn; } catch(_) {}
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] CurrencyEngine.tick 失败:') : console.error('[endTurn] CurrencyEngine.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] CurrencyEngine.tick 失败:') : console.error('[endTurn] CurrencyEngine.tick 失败:', e); throw e; }
 
   // 6.056 央地财政（合规率/地方 AI 决策/14 支出效果/监察/自立藩镇）
   try {
     if (typeof CentralLocalEngine !== 'undefined') {
       CentralLocalEngine.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] CentralLocalEngine.tick 失败:') : console.error('[endTurn] CentralLocalEngine.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] CentralLocalEngine.tick 失败:') : console.error('[endTurn] CentralLocalEngine.tick 失败:', e); throw e; }
 
   // 6.057 经济补完（封建财政/土地兼并/借贷/虚报差额/地域接受度/套利）
   try {
     if (typeof EconomyGapFill !== 'undefined') {
       EconomyGapFill.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] EconomyGapFill.tick 失败:') : console.error('[endTurn] EconomyGapFill.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] EconomyGapFill.tick 失败:') : console.error('[endTurn] EconomyGapFill.tick 失败:', e); throw e; }
 
   // 6.07 户口系统（已在 6.015 早跑，跳过）
   if (!GM._hujiEarlyTicked) try {
     if (typeof HujiEngine !== 'undefined') {
       HujiEngine.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HujiEngine.tick 失败:') : console.error('[endTurn] HujiEngine.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HujiEngine.tick 失败:') : console.error('[endTurn] HujiEngine.tick 失败:', e); throw e; }
 
   // 6.08 环境承载力（五维/疤痕/过载/危机/技术/政策）
   try {
     if (typeof EnvCapacityEngine !== 'undefined') {
       EnvCapacityEngine.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] EnvCapacityEngine.tick 失败:') : console.error('[endTurn] EnvCapacityEngine.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] EnvCapacityEngine.tick 失败:') : console.error('[endTurn] EnvCapacityEngine.tick 失败:', e); throw e; }
 
   // 6.09 诏令/奏疏/抗疏（二阶段流程、待朱批清理）
   try {
     if (typeof EdictParser !== 'undefined') {
       EdictParser.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] EdictParser.tick 失败:') : console.error('[endTurn] EdictParser.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] EdictParser.tick 失败:') : console.error('[endTurn] EdictParser.tick 失败:', e); throw e; }
 
   // 6.10 户口深化（已在 6.015 早跑，跳过）
   if (!GM._hujiEarlyTicked) try {
     if (typeof HujiDeepFill !== 'undefined') {
       HujiDeepFill.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HujiDeepFill.tick 失败:') : console.error('[endTurn] HujiDeepFill.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HujiDeepFill.tick 失败:') : console.error('[endTurn] HujiDeepFill.tick 失败:', e); throw e; }
   // 清 early 标记，下回合重新走
   GM._hujiEarlyTicked = false;
 
@@ -222,88 +222,88 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
     if (typeof EdictComplete !== 'undefined') {
       EdictComplete.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] EdictComplete.tick 失败:') : console.error('[endTurn] EdictComplete.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] EdictComplete.tick 失败:') : console.error('[endTurn] EdictComplete.tick 失败:', e); throw e; }
 
   // 6.12 环境恢复政策 + §9 联动
   try {
     if (typeof EnvRecoveryFill !== 'undefined') {
       EnvRecoveryFill.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] EnvRecoveryFill.tick 失败:') : console.error('[endTurn] EnvRecoveryFill.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] EnvRecoveryFill.tick 失败:') : console.error('[endTurn] EnvRecoveryFill.tick 失败:', e); throw e; }
 
   // 6.13 皇威/皇权/民心 tick + 42 项变量联动
   try {
     if (typeof AuthorityEngines !== 'undefined') {
       AuthorityEngines.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] AuthorityEngines.tick 失败:') : console.error('[endTurn] AuthorityEngines.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] AuthorityEngines.tick 失败:') : console.error('[endTurn] AuthorityEngines.tick 失败:', e); throw e; }
 
   // 6.14 权力系统补完（权臣/民变5级/暴君症状/失威危机/天象/联动全）
   try {
     if (typeof AuthorityComplete !== 'undefined') {
       AuthorityComplete.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] AuthorityComplete.tick 失败:') : console.error('[endTurn] AuthorityComplete.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] AuthorityComplete.tick 失败:') : console.error('[endTurn] AuthorityComplete.tick 失败:', e); throw e; }
 
   // 6.15 历史补完（年龄金字塔精细化+疫病战亡字段维护）
   try {
     if (typeof HistoricalPresets !== 'undefined') {
       HistoricalPresets.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HistoricalPresets.tick 失败:') : console.error('[endTurn] HistoricalPresets.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HistoricalPresets.tick 失败:') : console.error('[endTurn] HistoricalPresets.tick 失败:', e); throw e; }
 
   // 6.155 全局持续规则演进（国是·风气：扎根度随在位/同类增长，遭阻力承压，suppressed 即名存实亡）
   try {
     if (typeof GlobalRulesEngine !== 'undefined' && GlobalRulesEngine.tick) GlobalRulesEngine.tick();
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] GlobalRulesEngine.tick 失败:') : console.error('[endTurn] GlobalRulesEngine.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] GlobalRulesEngine.tick 失败:') : console.error('[endTurn] GlobalRulesEngine.tick 失败:', e); throw e; }
 
   // 6.156 典章·祖制建构轴（国策先演进→典章再看哪条熬过考验著为成宪·Wave5 slice-1）
   try {
     if (window.TM && TM.Dianzhang && TM.Dianzhang.tick) TM.Dianzhang.tick(GM);
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] Dianzhang.tick 失败:') : console.error('[endTurn] Dianzhang.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] Dianzhang.tick 失败:') : console.error('[endTurn] Dianzhang.tick 失败:', e); throw e; }
 
   // 6.16 C/D/B/A/E 阶段补丁 tick
   try {
     if (typeof PhaseC !== 'undefined') PhaseC.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseC.tick 失败:') : console.error('[endTurn] PhaseC.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseC.tick 失败:') : console.error('[endTurn] PhaseC.tick 失败:', e); throw e; }
   try {
     if (typeof PhaseD !== 'undefined') PhaseD.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseD.tick 失败:') : console.error('[endTurn] PhaseD.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseD.tick 失败:') : console.error('[endTurn] PhaseD.tick 失败:', e); throw e; }
   try {
     if (typeof PhaseB !== 'undefined') PhaseB.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseB.tick 失败:') : console.error('[endTurn] PhaseB.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseB.tick 失败:') : console.error('[endTurn] PhaseB.tick 失败:', e); throw e; }
   try {
     if (typeof PhaseA !== 'undefined') PhaseA.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseA.tick 失败:') : console.error('[endTurn] PhaseA.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseA.tick 失败:') : console.error('[endTurn] PhaseA.tick 失败:', e); throw e; }
   try {
     if (typeof PhaseE !== 'undefined') PhaseE.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseE.tick 失败:') : console.error('[endTurn] PhaseE.tick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseE.tick 失败:') : console.error('[endTurn] PhaseE.tick 失败:', e); throw e; }
   // 6.17 F 阶段全部补丁 tick
-  try { if (typeof PhaseF1 !== 'undefined') PhaseF1.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseF1.tick 失败:') : console.error('[endTurn] PhaseF1.tick 失败:', e); }
-  try { if (typeof PhaseF2 !== 'undefined') PhaseF2.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseF2.tick 失败:') : console.error('[endTurn] PhaseF2.tick 失败:', e); }
-  try { if (typeof PhaseF3 !== 'undefined') PhaseF3.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseF3.tick 失败:') : console.error('[endTurn] PhaseF3.tick 失败:', e); }
-  try { if (typeof PhaseF4 !== 'undefined') PhaseF4.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseF4.tick 失败:') : console.error('[endTurn] PhaseF4.tick 失败:', e); }
-  try { if (typeof PhaseF5 !== 'undefined') PhaseF5.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseF5.tick 失败:') : console.error('[endTurn] PhaseF5.tick 失败:', e); }
-  try { if (typeof PhaseF6 !== 'undefined') PhaseF6.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseF6.tick 失败:') : console.error('[endTurn] PhaseF6.tick 失败:', e); }
+  try { if (typeof PhaseF1 !== 'undefined') PhaseF1.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseF1.tick 失败:') : console.error('[endTurn] PhaseF1.tick 失败:', e); throw e; }
+  try { if (typeof PhaseF2 !== 'undefined') PhaseF2.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseF2.tick 失败:') : console.error('[endTurn] PhaseF2.tick 失败:', e); throw e; }
+  try { if (typeof PhaseF3 !== 'undefined') PhaseF3.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseF3.tick 失败:') : console.error('[endTurn] PhaseF3.tick 失败:', e); throw e; }
+  try { if (typeof PhaseF4 !== 'undefined') PhaseF4.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseF4.tick 失败:') : console.error('[endTurn] PhaseF4.tick 失败:', e); throw e; }
+  try { if (typeof PhaseF5 !== 'undefined') PhaseF5.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseF5.tick 失败:') : console.error('[endTurn] PhaseF5.tick 失败:', e); throw e; }
+  try { if (typeof PhaseF6 !== 'undefined') PhaseF6.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseF6.tick 失败:') : console.error('[endTurn] PhaseF6.tick 失败:', e); throw e; }
   // 6.18 G 阶段终结补丁 tick
-  try { if (typeof PhaseG1 !== 'undefined') PhaseG1.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseG1.tick 失败:') : console.error('[endTurn] PhaseG1.tick 失败:', e); }
-  try { if (typeof PhaseG2 !== 'undefined') PhaseG2.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseG2.tick 失败:') : console.error('[endTurn] PhaseG2.tick 失败:', e); }
-  try { if (typeof PhaseG3 !== 'undefined') PhaseG3.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseG3.tick 失败:') : console.error('[endTurn] PhaseG3.tick 失败:', e); }
-  try { if (typeof PhaseG4 !== 'undefined') PhaseG4.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseG4.tick 失败:') : console.error('[endTurn] PhaseG4.tick 失败:', e); }
+  try { if (typeof PhaseG1 !== 'undefined') PhaseG1.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseG1.tick 失败:') : console.error('[endTurn] PhaseG1.tick 失败:', e); throw e; }
+  try { if (typeof PhaseG2 !== 'undefined') PhaseG2.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseG2.tick 失败:') : console.error('[endTurn] PhaseG2.tick 失败:', e); throw e; }
+  try { if (typeof PhaseG3 !== 'undefined') PhaseG3.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseG3.tick 失败:') : console.error('[endTurn] PhaseG3.tick 失败:', e); throw e; }
+  try { if (typeof PhaseG4 !== 'undefined') PhaseG4.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] PhaseG4.tick 失败:') : console.error('[endTurn] PhaseG4.tick 失败:', e); throw e; }
   if (!_currencyFullTicked) {
   // 6.19 H 阶段·原 PhaseH.tick 拆为 7 项原生调用 (R10 collapse·delete tm-tax-atomic.js·redistribute → CurrencyEngine·FiscalEngine·FeudalCore·EdictComplete)
-  try { if (typeof CurrencyEngine !== 'undefined' && typeof CurrencyEngine._updatePaperStateAtomic === 'function') CurrencyEngine._updatePaperStateAtomic(GM, monthRatio); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] CurrencyEngine._updatePaperStateAtomic 失败:') : console.error('[endTurn] CurrencyEngine._updatePaperStateAtomic 失败:', e); }
-  try { if (typeof CurrencyEngine !== 'undefined' && typeof CurrencyEngine._updateGrainPriceAtomic === 'function') CurrencyEngine._updateGrainPriceAtomic(GM, monthRatio); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] CurrencyEngine._updateGrainPriceAtomic 失败:') : console.error('[endTurn] CurrencyEngine._updateGrainPriceAtomic 失败:', e); }
+  try { if (typeof CurrencyEngine !== 'undefined' && typeof CurrencyEngine._updatePaperStateAtomic === 'function') CurrencyEngine._updatePaperStateAtomic(GM, monthRatio); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] CurrencyEngine._updatePaperStateAtomic 失败:') : console.error('[endTurn] CurrencyEngine._updatePaperStateAtomic 失败:', e); throw e; }
+  try { if (typeof CurrencyEngine !== 'undefined' && typeof CurrencyEngine._updateGrainPriceAtomic === 'function') CurrencyEngine._updateGrainPriceAtomic(GM, monthRatio); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] CurrencyEngine._updateGrainPriceAtomic 失败:') : console.error('[endTurn] CurrencyEngine._updateGrainPriceAtomic 失败:', e); throw e; }
   }
-  try { if (typeof FiscalEngine !== 'undefined' && typeof FiscalEngine._tickTransferOrders === 'function') FiscalEngine._tickTransferOrders({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }, monthRatio); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] FiscalEngine._tickTransferOrders 失败:') : console.error('[endTurn] FiscalEngine._tickTransferOrders 失败:', e); }
-  try { if (typeof FeudalCore !== 'undefined' && typeof FeudalCore._tickFeudalHoldings === 'function') FeudalCore._tickFeudalHoldings({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }, monthRatio); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] FeudalCore._tickFeudalHoldings 失败:') : console.error('[endTurn] FeudalCore._tickFeudalHoldings 失败:', e); }
-  try { if (typeof EdictComplete !== 'undefined' && typeof EdictComplete._checkProjectCompletion === 'function') EdictComplete._checkProjectCompletion({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] EdictComplete._checkProjectCompletion 失败:') : console.error('[endTurn] EdictComplete._checkProjectCompletion 失败:', e); }
-  try { if (typeof EdictComplete !== 'undefined' && typeof EdictComplete._checkHuangceCycle === 'function') EdictComplete._checkHuangceCycle({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] EdictComplete._checkHuangceCycle 失败:') : console.error('[endTurn] EdictComplete._checkHuangceCycle 失败:', e); }
-  try { if (typeof EdictComplete !== 'undefined' && typeof EdictComplete._checkGaituEscalation === 'function') EdictComplete._checkGaituEscalation({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] EdictComplete._checkGaituEscalation 失败:') : console.error('[endTurn] EdictComplete._checkGaituEscalation 失败:', e); }
+  try { if (typeof FiscalEngine !== 'undefined' && typeof FiscalEngine._tickTransferOrders === 'function') FiscalEngine._tickTransferOrders({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }, monthRatio); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] FiscalEngine._tickTransferOrders 失败:') : console.error('[endTurn] FiscalEngine._tickTransferOrders 失败:', e); throw e; }
+  try { if (typeof FeudalCore !== 'undefined' && typeof FeudalCore._tickFeudalHoldings === 'function') FeudalCore._tickFeudalHoldings({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }, monthRatio); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] FeudalCore._tickFeudalHoldings 失败:') : console.error('[endTurn] FeudalCore._tickFeudalHoldings 失败:', e); throw e; }
+  try { if (typeof EdictComplete !== 'undefined' && typeof EdictComplete._checkProjectCompletion === 'function') EdictComplete._checkProjectCompletion({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] EdictComplete._checkProjectCompletion 失败:') : console.error('[endTurn] EdictComplete._checkProjectCompletion 失败:', e); throw e; }
+  try { if (typeof EdictComplete !== 'undefined' && typeof EdictComplete._checkHuangceCycle === 'function') EdictComplete._checkHuangceCycle({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] EdictComplete._checkHuangceCycle 失败:') : console.error('[endTurn] EdictComplete._checkHuangceCycle 失败:', e); throw e; }
+  try { if (typeof EdictComplete !== 'undefined' && typeof EdictComplete._checkGaituEscalation === 'function') EdictComplete._checkGaituEscalation({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] EdictComplete._checkGaituEscalation 失败:') : console.error('[endTurn] EdictComplete._checkGaituEscalation 失败:', e); throw e; }
   // 6.20 NPC 按立场自主献策产生奏疏（天象/权臣/民变/灾变/瘟疫/军败 触发）
-  try { if (typeof NpcMemorials !== 'undefined') NpcMemorials.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] NpcMemorials.tick 失败:') : console.error('[endTurn] NpcMemorials.tick 失败:', e); }
+  try { if (typeof NpcMemorials !== 'undefined') NpcMemorials.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] NpcMemorials.tick 失败:') : console.error('[endTurn] NpcMemorials.tick 失败:', e); throw e; }
   // 6.21 融合桥接：行政区划 → 七变量 聚合
-  try { if (typeof IntegrationBridge !== 'undefined') IntegrationBridge.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] IntegrationBridge.tick 失败:') : console.error('[endTurn] IntegrationBridge.tick 失败:', e); }
+  try { if (typeof IntegrationBridge !== 'undefined') IntegrationBridge.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio }); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] IntegrationBridge.tick 失败:') : console.error('[endTurn] IntegrationBridge.tick 失败:', e); throw e; }
 
   // 6.06 角色完整字段推演（stressSources/innerThought/career/familyMembers/clanPrestige）
   try {
@@ -330,7 +330,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
         ch._lastRecordedTitle = curTitle;
       });
     }
-  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] CharFullSchema.evolveTick 失败:') : console.error('[endTurn] CharFullSchema.evolveTick 失败:', e); }
+  } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] CharFullSchema.evolveTick 失败:') : console.error('[endTurn] CharFullSchema.evolveTick 失败:', e); throw e; }
   // N4: 精力回复（每回合自动回满）
   if (GM._energy !== undefined) {
     GM._energy = GM._energyMax || 100;
@@ -352,10 +352,10 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
 
   // 6.82-6.85 国策/议程/省经济（已注册到 pipeline，此处仅补充未注册的部分）
   // 这些步骤在 pipeline 中按优先级自动执行，此处保留为兜底
-  try { if (typeof evaluateThresholdTriggers === 'function') evaluateThresholdTriggers(); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] 阈值触发检查失败:') : console.error('[endTurn] 阈值触发检查失败:', e); }
-  try { updateProvinceEconomy(); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] 省经济更新失败:') : console.error('[endTurn] 省经济更新失败:', e); }
-  try { StateCouplingSystem.processCouplings(); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] 状态耦合失败:') : console.error('[endTurn] 状态耦合失败:', e); }
-  try { AutoReboundSystem.applyRebounds(); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] 自动反弹失败:') : console.error('[endTurn] 自动反弹失败:', e); }
+  try { if (typeof evaluateThresholdTriggers === 'function') evaluateThresholdTriggers(); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] 阈值触发检查失败:') : console.error('[endTurn] 阈值触发检查失败:', e); throw e; }
+  try { updateProvinceEconomy(); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] 省经济更新失败:') : console.error('[endTurn] 省经济更新失败:', e); throw e; }
+  try { StateCouplingSystem.processCouplings(); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] 状态耦合失败:') : console.error('[endTurn] 状态耦合失败:', e); throw e; }
+  try { AutoReboundSystem.applyRebounds(); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] 自动反弹失败:') : console.error('[endTurn] 自动反弹失败:', e); throw e; }
 
   // 6.855 应用变动队列（ChangeQueue System）
   var _changeQueueTimingStart = Date.now();
@@ -412,7 +412,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
             at: Date.now()
           };
         } catch(_) {}
-        if (typeof toast === 'function') toast('部分决策变动未能应用，已保留待下回合重试；请查看控制台诊断。');
+        throw new Error('决策变动队列未能原子应用：失败 ' + (queueResult.failedCount || 0) + ' 项');
       } else {
         // 清空队列
         ChangeQueue.clear();
@@ -430,6 +430,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
     StateCouplingSystem.updateSnapshot();
   } catch (error) {
     console.error('[endTurn] 应用变动队列失败:', error);
+    throw error;
   }
   _markSystemStage('changeQueueApply', '应用决策变动', _changeQueueTimingStart, {
     queueLength: _changeQueueLen,
@@ -447,6 +448,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
     if (typeof checkHistoryEvents === 'function') checkHistoryEvents();
   } catch(e) {
     (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] 历史事件触发检查失败:') : console.error('[endTurn] 历史事件触发检查失败:', e);
+    throw e;
   }
 
   // 6.88 检查刚性触发器
@@ -460,6 +462,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
     if (typeof TMXinjun !== 'undefined' && TMXinjun.on(GM)) { try { TMXinjun.refresh(GM); } catch(_xjE){} }
   } catch(e) {
     (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] 刚性触发器检查失败:') : console.error('[endTurn] 刚性触发器检查失败:', e);
+    throw e;
   }
 
   // 6.884 党争张力年度衰减(治"只升不降"·decay 自身年度幂等·换年才实降·防 tension 永久累积)
@@ -467,6 +470,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
     if (typeof _kjDecayFactionTension === 'function') _kjDecayFactionTension();
   } catch(e) {
     (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] 党争张力衰减失败:') : console.error('[endTurn] 党争张力衰减失败:', e);
+    throw e;
   }
 
   // 6.885 检查科举筹办完成
@@ -502,6 +506,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
       }
     } catch(e) {
       (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] 职位系统更新失败:') : console.error('[endTurn] 职位系统更新失败:', e);
+      throw e;
     }
   }
 
@@ -526,6 +531,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
       }
     } catch(e) {
       (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] 自然死亡检查失败:') : console.error('[endTurn] 自然死亡检查失败:', e);
+      throw e;
     }
   }
 
@@ -537,6 +543,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
     }
   } catch(e) {
     (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] 阴谋推演失败:') : console.error('[endTurn] 阴谋推演失败:', e);
+    throw e;
   }
   _markSystemStage('positionAndMortality', '职位与寿数检查', _positionChecksTimingStart);
 
@@ -547,15 +554,16 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
     if (typeof processChangeQueue === 'function') processChangeQueue();
   } catch(e) {
     (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] 监听队列处理失败:') : console.error('[endTurn] 监听队列处理失败:', e);
+    throw e;
   }
 
   // 6.91b 关系网冲突自然衰减（每回合）
   if (typeof decayConflictLevels === 'function') {
-    try { decayConflictLevels(); } catch(_) {}
+    decayConflictLevels();
   }
   // 6.91c 跨代父仇继承（conflictLevel≥4 + 双方有子嗣）
   if (typeof inheritBloodFeuds === 'function') {
-    try { inheritBloodFeuds(); } catch(_) {}
+    inheritBloodFeuds();
   }
   _markSystemStage('reactiveQueueAndRelations', '监听队列与关系衰减', _reactiveQueueTimingStart);
 

--- a/web/tm-faction-diplomacy.js
+++ b/web/tm-faction-diplomacy.js
@@ -27,14 +27,35 @@
 
   function _dbg() { try { if (global.DebugLog && typeof global.DebugLog.log === 'function') global.DebugLog.log.apply(global.DebugLog, ['ai'].concat(Array.prototype.slice.call(arguments))); } catch (e) {} }
   function _norm(s) { return String(s == null ? '' : s).trim().toLowerCase(); }
-  function _facByName(name) { var G = global.GM || {}; if (!Array.isArray(G.facs)) return null; var k = _norm(name); for (var i = 0; i < G.facs.length; i++) { if (G.facs[i] && _norm(G.facs[i].name) === k) return G.facs[i]; } return null; }
-  function _isPlayerName(name) {
-    var P = global.P || {}, k = _norm(name);
-    if (!k) return false;
+  function _facId(fac) { return fac && (fac.id || fac.factionId || fac.facId || fac.key) != null ? String(fac.id || fac.factionId || fac.facId || fac.key) : ''; }
+  function _facName(fac) { return String(fac && (fac.name || fac.title) || ''); }
+  function _facByRef(ref) {
+    var G = global.GM || {};
+    if (!Array.isArray(G.facs) || ref == null) return null;
+    var refId = typeof ref === 'object' ? String(ref.id || ref.factionId || ref.facId || ref.key || '') : String(ref);
+    var refName = typeof ref === 'object' ? String(ref.name || ref.title || '') : String(ref);
+    if (refId) {
+      var idMatches = G.facs.filter(function (fac) { return fac && _facId(fac) === refId; });
+      if (idMatches.length === 1) return idMatches[0];
+      // 显式 ID 未命中时不可降级按同名猜测。
+      if (typeof ref === 'object' && (ref.id || ref.factionId || ref.facId || ref.key)) return null;
+    }
+    var k = _norm(refName);
+    if (!k) return null;
+    var nameMatches = G.facs.filter(function (fac) { return fac && _norm(_facName(fac)) === k; });
+    return nameMatches.length === 1 ? nameMatches[0] : null;
+  }
+  function _isPlayerRef(ref) {
+    var P = global.P || {};
     var pi = P.playerInfo || {};
+    var refId = typeof ref === 'object' ? String(ref.id || ref.factionId || '') : '';
+    if (refId && [pi.factionId, P.playerFactionId, global.GM && global.GM.playerFactionId].some(function (id) { return id != null && String(id) === refId; })) return true;
+    var refName = typeof ref === 'object' ? ref.name : ref;
+    var k = _norm(refName);
+    if (!k) return false;
     return [pi.factionName, P.playerFactionName, P.playerFaction, (global.GM && global.GM.playerFaction)].some(function (n) { return n && _norm(n) === k; });
   }
-  function _strat(fac) { if (!fac.aiStrategy || typeof fac.aiStrategy !== 'object') fac.aiStrategy = {}; var s = fac.aiStrategy; if (!Array.isArray(s.alliances)) s.alliances = []; if (!Array.isArray(s.grudges)) s.grudges = []; return s; }
+  function _strat(fac) { if (!fac.aiStrategy || typeof fac.aiStrategy !== 'object') fac.aiStrategy = {}; var s = fac.aiStrategy; if (!Array.isArray(s.alliances)) s.alliances = []; if (!Array.isArray(s.grudges)) s.grudges = []; if (!Array.isArray(s.allianceIds)) s.allianceIds = []; if (!Array.isArray(s.grudgeIds)) s.grudgeIds = []; return s; }
   function _pushUniq(arr, v) { if (v && arr.indexOf(v) < 0) arr.push(v); }
   function _log(entry) { try { var G = global.GM; if (!G) return; if (!Array.isArray(G._factionDiplomacyLog)) G._factionDiplomacyLog = []; G._factionDiplomacyLog.push(entry); if (G._factionDiplomacyLog.length > 40) G._factionDiplomacyLog = G._factionDiplomacyLog.slice(-40); } catch (e) {} }
 
@@ -60,7 +81,7 @@
     G._pendingAudiences.push({
       name: fromName + '使节', reason: '【' + (TYPE_CN[item.type] || item.type) + '】' + (item.terms || '') + (item.rationale ? '（' + item.rationale + '）' : ''),
       turn: item.turn, isEnvoy: true, fromFaction: fromName, interactionType: (_DIP2ENVOY[item.type] || 'faction_proposal'),
-      _factionProposalId: item.id, _diplomacyType: item.type, _negotiationId: _ngId
+      _fromFactionId: item.fromId || '', _factionProposalId: item.id, _diplomacyType: item.type, _negotiationId: _ngId
     });
     if (typeof _wdCapPendingAudiences === 'function' && typeof GM !== 'undefined' && G === GM) _wdCapPendingAudiences(20);   // 唯一去顶写口
     else if (G._pendingAudiences.length > 20) G._pendingAudiences = G._pendingAudiences.slice(-20);
@@ -70,14 +91,22 @@
   // ── ① 存提议：A 的 proposals → 目标派 _incomingProposals(玩家目标入 player 队·留 S2) ──
   // B2②·全局递增序号(GM 级)·防同回合多次 recordProposals 的本地 n 重置 → id 碰撞(dp-5-a-0 撞 dp-5-a-0)
   function _dipSeq() { var G = global.GM; if (!G) return Date.now(); var v = Number(G._factionDiplomacySeq); G._factionDiplomacySeq = (isFinite(v) ? v : 0) + 1; return G._factionDiplomacySeq; }   // arch-ok: F2 外交提案全局递增序号(GM 级·防 id 碰撞)
-  function recordProposals(fromName, proposals, turn) {
+  function recordProposals(fromRef, proposals, turn) {
     if (!Array.isArray(proposals) || !proposals.length) return { recorded: 0, toPlayer: 0 };
+    var fromFac = _facByRef(fromRef);
+    var fromName = fromFac ? _facName(fromFac) : String(fromRef && (fromRef.name || fromRef.title) || fromRef || '');
+    var fromId = _facId(fromFac);
+    if (!fromName && !fromId) return { recorded: 0, toPlayer: 0 };
     var recorded = 0, toPlayer = 0;
     proposals.slice(0, 4).forEach(function (p) {
       if (!p || !p.toFaction || !p.type || !TYPES[p.type]) return;
-      if (_norm(p.toFaction) === _norm(fromName)) return; // 不向自己提
-      var item = { id: 'dp-' + turn + '-' + _norm(fromName).slice(0, 6) + '-' + _dipSeq(), from: String(fromName).slice(0, 30), type: p.type, terms: String(p.terms || '').slice(0, 60), rationale: String(p.rationale || '').slice(0, 50), turn: turn, status: 'pending' };
-      if (_isPlayerName(p.toFaction)) {
+      var targetRef = { id: p.toFactionId || p.toId || '', name: p.toFaction };
+      var target = _facByRef(targetRef);
+      var targetId = _facId(target) || String(targetRef.id || '');
+      var targetName = target ? _facName(target) : String(p.toFaction || '');
+      if ((fromFac && target && fromFac === target) || (fromId && targetId && fromId === targetId) || (!fromId && !targetId && _norm(targetName) === _norm(fromName))) return;
+      var item = { id: 'dp-' + turn + '-' + _norm(fromId || fromName).slice(0, 12) + '-' + _dipSeq(), from: String(fromName).slice(0, 30), fromId: fromId, to: String(targetName).slice(0, 30), toId: targetId, type: p.type, terms: String(p.terms || '').slice(0, 60), rationale: String(p.rationale || '').slice(0, 50), turn: turn, status: 'pending' };
+      if (_isPlayerRef(targetRef)) {
         // 目标=玩家：①入队(供观测/反馈) ②【S2】路由成「势力使节」求见(复用现有 envoy audience·surface 到问对)
         var G = global.GM; if (!G) return;
         if (!Array.isArray(G._pendingFactionProposalsToPlayer)) G._pendingFactionProposalsToPlayer = [];
@@ -87,14 +116,16 @@
         toPlayer++;
         return;
       }
-      var target = _facByName(p.toFaction);
       if (!target) return; // 目标势力不存在
       if (!Array.isArray(target._incomingProposals)) target._incomingProposals = [];
       // B2①·去重键加 terms 摘要：仅【同 from+type+条款】的重复才合并·真正不同条款的两提案都保留(不再丢第一条)
-      target._incomingProposals = target._incomingProposals.filter(function (x) { return !(x.status === 'pending' && _norm(x.from) === _norm(item.from) && x.type === item.type && _norm(x.terms) === _norm(item.terms)); });
+      target._incomingProposals = target._incomingProposals.filter(function (x) {
+        var sameFrom = x.fromId && item.fromId ? String(x.fromId) === String(item.fromId) : _norm(x.from) === _norm(item.from);
+        return !(x.status === 'pending' && sameFrom && x.type === item.type && _norm(x.terms) === _norm(item.terms));
+      });
       target._incomingProposals.push(item);
       if (target._incomingProposals.length > MAX_PENDING) target._incomingProposals = target._incomingProposals.slice(-MAX_PENDING);
-      _log({ turn: turn, kind: 'propose', from: item.from, to: p.toFaction, type: p.type, terms: item.terms });
+      _log({ turn: turn, kind: 'propose', from: item.from, fromId: item.fromId, to: targetName, toId: targetId, type: p.type, terms: item.terms });
       recorded++;
     });
     return { recorded: recorded, toPlayer: toPlayer };
@@ -129,12 +160,13 @@
         if (!prop) return;   // 带 id 未命中 → fail-closed·保持未决
       } else {
         var cand = pendAll;
-        if (r.from) cand = cand.filter(function (p) { return _norm(p.from) === _norm(r.from); });
+        if (r.fromId) cand = cand.filter(function (p) { return p.fromId && String(p.fromId) === String(r.fromId); });
+        else if (r.from) cand = cand.filter(function (p) { return _norm(p.from) === _norm(r.from); });
         if (r.type) { var rt = _norm(r.type); cand = cand.filter(function (p) { return _norm(p.type) === rt || _norm(TYPE_CN[p.type]) === rt; }); }
         if (cand.length !== 1) return;   // 无候选/歧义 → 保持未决(不错配)
         prop = cand[0];
       }
-      var proposer = _facByName(prop.from);
+      var proposer = _facByRef({ id: prop.fromId || '', name: prop.from });
       var dec = _norm(r.decision);
       if (dec === 'accept') {
         prop.status = 'accepted';
@@ -144,7 +176,7 @@
         prop.status = 'countered';
         // 反向新提议：fac → proposer(还价)
         if (proposer) {
-          recordProposals(fac.name, [{ toFaction: prop.from, type: prop.type, terms: String(r.counterTerms || r.reason || '').slice(0, 60), rationale: '对「' + prop.from + '」原议的还价' }], turn);
+          recordProposals(fac, [{ toFaction: prop.from, toFactionId: prop.fromId || '', type: prop.type, terms: String(r.counterTerms || r.reason || '').slice(0, 60), rationale: '对「' + prop.from + '」原议的还价' }], turn);
         }
         _log({ turn: turn, kind: 'counter', from: prop.from, to: fac.name, type: prop.type, counter: String(r.counterTerms || '').slice(0, 50) });
       } else { // reject
@@ -152,6 +184,7 @@
         // 提议被拒·提议方可能结怨被拒方(尤其最后通牒/结盟被拒)
         if (proposer && (prop.type === 'ultimatum' || prop.type === 'alliance' || prop.type === 'joint_action')) {
           _pushUniq(_strat(proposer).grudges, fac.name);
+          _pushUniq(_strat(proposer).grudgeIds, _facId(fac));
         }
         _log({ turn: turn, kind: 'reject', from: prop.from, to: fac.name, type: prop.type, reason: String(r.reason || '').slice(0, 50) });
       }
@@ -167,16 +200,19 @@
   function _lodgeTreaty(a, b, type, turn) {
     try {
       var G = global.GM; if (!G) return;
+      var aName = _facName(a), bName = _facName(b), aId = _facId(a), bId = _facId(b);
+      var aKey = aId ? 'id:' + aId : 'name:' + _norm(aName);
+      var bKey = bId ? 'id:' + bId : 'name:' + _norm(bName);
       if (!Array.isArray(G.treaties)) G.treaties = [];   // arch-ok: F2 势力社会结盟落账(GM.treaties 既有子树·战争引擎消费面)
       var mutual = (type === 'alliance');
       var typeName = ({ alliance: '同盟', nonaggression: '互不侵犯', joint_action: '共同行动' })[type] || type;
       var dup = G.treaties.some(function (t) {
         if (!t || t.active === false || t.type !== type) return false;
-        var parties = Array.isArray(t.parties) ? t.parties.map(function (p) { return (p && p.name) || p; }) : [];
-        return parties.indexOf(a) >= 0 && parties.indexOf(b) >= 0;
+        var parties = Array.isArray(t.parties) ? t.parties.map(function (p) { return p && p.id ? 'id:' + p.id : 'name:' + _norm((p && p.name) || p); }) : [];
+        return parties.indexOf(aKey) >= 0 && parties.indexOf(bKey) >= 0;
       });
       if (dup) return;
-      G.treaties.push({ id: 'ftr-' + (turn || _turn()) + '-' + _norm(type).slice(0, 10) + '-' + _dipSeq(), type: type, typeName: typeName, mutual_defense: mutual, parties: [{ name: a }, { name: b }], startTurn: (turn || _turn()), active: true, _source: 'faction-diplomacy' });   // arch-ok: F2 结盟落 GM.treaties(战争引擎消费面)·全局序号防同回合跨类型碰撞
+      G.treaties.push({ id: 'ftr-' + (turn || _turn()) + '-' + _norm(type).slice(0, 10) + '-' + _dipSeq(), type: type, typeName: typeName, mutual_defense: mutual, parties: [{ id: aId, name: aName }, { id: bId, name: bName }], startTurn: (turn || _turn()), active: true, _source: 'faction-diplomacy' });   // arch-ok: F2 结盟落 GM.treaties(战争引擎消费面)·全局序号防同回合跨类型碰撞
       if (G.treaties.length > 80) G.treaties = G.treaties.slice(-80);   // arch-ok: F2 结盟落账截断(GM.treaties 既有子树·战争引擎消费面)
     } catch (e) {}
   }
@@ -186,10 +222,11 @@
     var ps = _strat(proposer), ts = _strat(target);
     if (prop.type === 'alliance' || prop.type === 'nonaggression' || prop.type === 'joint_action') {
       _pushUniq(ps.alliances, target.name); _pushUniq(ts.alliances, proposer.name);
+      _pushUniq(ps.allianceIds, _facId(target)); _pushUniq(ts.allianceIds, _facId(proposer));
       // 结盟→消解彼此宿怨
       ps.grudges = ps.grudges.filter(function (g) { return _norm(g) !== _norm(target.name); });
       ts.grudges = ts.grudges.filter(function (g) { return _norm(g) !== _norm(proposer.name); });
-      _lodgeTreaty(proposer.name, target.name, prop.type, prop.turn);   // B3·落 GM.treaties·让战争盟友参战真读到
+      _lodgeTreaty(proposer, target, prop.type, prop.turn);   // B3·落 GM.treaties·让战争盟友参战真读到
     } else if (prop.type === 'peace') {
       // 媾和必须走唯一战争终结入口；只消宿怨不等于结束战争。
       ps.grudges = ps.grudges.filter(function (g) { return _norm(g) !== _norm(target.name); });
@@ -224,7 +261,7 @@
   // ── ⑥【S3】玩家对「我的提议」的答复 → 回写发起势力持久记忆(aiStrategy)·供其下回合决策显式感知(非仅邦交 delta 间接推) ──
   function recordPlayerResponse(fromName, info) {
     info = info || {};
-    var fac = _facByName(fromName); if (!fac) return false;
+    var fac = _facByRef(fromName); if (!fac) return false;
     if (!fac.aiStrategy) fac.aiStrategy = {};
     var arr = Array.isArray(fac.aiStrategy.playerProposalOutcomes) ? fac.aiStrategy.playerProposalOutcomes : [];
     arr = arr.filter(function (o) { return o && o.id !== info.id; }); // 同提议只留一条结果

--- a/web/tm-faction-npc-llm-decision.js
+++ b/web/tm-faction-npc-llm-decision.js
@@ -2608,7 +2608,7 @@
       try {
         if (Array.isArray(decision.proposalResponses) && decision.proposalResponses.length) global.TM.FactionDiplomacy.applyResponses(fac, decision.proposalResponses, _currentTurn());
         if (Array.isArray(decision.proposals) && decision.proposals.length) {
-          var _dp = global.TM.FactionDiplomacy.recordProposals(fac.name, decision.proposals, _currentTurn());
+          var _dp = global.TM.FactionDiplomacy.recordProposals(fac, decision.proposals, _currentTurn());
           if (summary && typeof summary === 'object') summary.diplomacy = _dp;
         }
       } catch (_dpE) {}

--- a/web/tm-map-system.js
+++ b/web/tm-map-system.js
@@ -103,6 +103,7 @@ function ensureMapDataScaffold(mapData) {
 
 function getLiveMapData() {
   if (typeof GM !== 'undefined' && GM && GM.mapData && GM.mapData.regions) return GM.mapData;
+  if (typeof GM !== 'undefined' && GM && GM.map && GM.map.regions) return GM.map;
   if (typeof P !== 'undefined' && P && P.map && P.map.regions) return P.map;
   if (typeof P !== 'undefined' && P && P.mapData && P.mapData.regions) return P.mapData;
   return null;
@@ -2033,12 +2034,13 @@ function closeMapViewer() {
  * 在doActualStart中调用（地图启用时）
  */
 function buildAdjacencyGraph() {
-  if (!P.map || !P.map.regions || !P.map.regions.length) return;
+  var runtimeMap = getLiveMapData();
+  if (!runtimeMap || !runtimeMap.regions || !runtimeMap.regions.length) return;
   if (!GM.mapData) GM.mapData = {};
 
   var graph = {};
-  var regions = P.map.regions;
-  var roads = P.map.roads || [];
+  var regions = runtimeMap.regions;
+  var roads = runtimeMap.roads || [];
 
   // 构建road索引（双向查找）
   var roadMap = {};
@@ -2178,14 +2180,16 @@ function calculateSupplyLine(baseCityId, armyCityId, factionName) {
   }
 
   // 效率随距离递减
-  var distanceDecay = (P.battleConfig && P.battleConfig.supplyConfig && P.battleConfig.supplyConfig.distanceDecay) || 0.08;
+  var configuredDecay = P.battleConfig && P.battleConfig.supplyConfig && P.battleConfig.supplyConfig.distanceDecay;
+  var distanceDecay = configuredDecay == null ? 0.08 : Math.max(0, Number(configuredDecay) || 0);
   var efficiency = Math.max(0.1, 1.0 - pathResult.distance * distanceDecay);
 
   // 检查路径上是否有敌方占领的节点（补给线被截断）
   var isCut = false;
+  var runtimeMap = getLiveMapData() || {};
   for (var i = 1; i < pathResult.path.length - 1; i++) {
     var node = pathResult.path[i];
-    var region = (P.map.regions || []).find(function(r) { return (r.id || r.name) === node; });
+    var region = (runtimeMap.regions || []).find(function(r) { return (r.id || r.name) === node; });
     if (region) {
       var nodeOwner = region.occupiedBy || region.owner || '';
       if (nodeOwner && factionName && nodeOwner !== factionName) {
@@ -2206,11 +2210,12 @@ function calculateSupplyLine(baseCityId, armyCityId, factionName) {
 // ============================================================
 function drawMinimap(){
   var c=_$("g-minimap");if(!c)return;
-  if(!P.mapData || !P.mapData.regions || P.mapData.regions.length === 0) return;
+  var liveMap=getLiveMapData();
+  if(!liveMap || !liveMap.regions || liveMap.regions.length === 0) return;
   var ctx=c.getContext("2d");
   ctx.fillStyle="#1a1a2e";ctx.fillRect(0,0,c.width,c.height);
-  var scale=c.width/(P.mapData.width||800);
-  P.mapData.regions.forEach(function(r){
+  var scale=c.width/(liveMap.width||800);
+  liveMap.regions.forEach(function(r){
     ctx.save();ctx.globalAlpha=0.35;ctx.fillStyle=r.color||"#c9a84c";
     if(r.type==="rect"&&r.rect){
       ctx.fillRect(r.rect.x*scale,r.rect.y*scale,r.rect.w*scale,r.rect.h*scale);
@@ -2244,6 +2249,7 @@ var InteractiveMap = {
   dragStartY: 0,
   selectedRegion: null,
   hoveredRegion: null,
+  mapData: null,
 
   // 初始化
   init: function(canvas) {
@@ -2252,6 +2258,7 @@ var InteractiveMap = {
     this.scale = 1;
     this.offsetX = 0;
     this.offsetY = 0;
+    this.mapData = getLiveMapData();
 
     // 绑定事件
     this.bindEvents();
@@ -2337,10 +2344,11 @@ var InteractiveMap = {
 
   // 获取指定坐标的区域
   getRegionAt: function(x, y) {
-    if (!P.mapData || !P.mapData.regions) return null;
+    var mapData = this.mapData || getLiveMapData();
+    if (!mapData || !mapData.regions) return null;
 
-    for (var i = P.mapData.regions.length - 1; i >= 0; i--) {
-      var r = P.mapData.regions[i];
+    for (var i = mapData.regions.length - 1; i >= 0; i--) {
+      var r = mapData.regions[i];
 
       if (r.type === 'rect' && r.rect) {
         if (x >= r.rect.x && x <= r.rect.x + r.rect.w &&
@@ -2374,7 +2382,8 @@ var InteractiveMap = {
 
   // 绘制地图
   draw: function() {
-    if (!this.ctx || !P.mapData || !P.mapData.regions) return;
+    var mapData = this.mapData || getLiveMapData();
+    if (!this.ctx || !mapData || !mapData.regions) return;
 
     var ctx = this.ctx;
     var w = this.canvas.width;
@@ -2390,7 +2399,7 @@ var InteractiveMap = {
     ctx.scale(this.scale, this.scale);
 
     // 绘制所有区域
-    P.mapData.regions.forEach(function(r) {
+    mapData.regions.forEach(function(r) {
       var isSelected = this.selectedRegion && this.selectedRegion.name === r.name;
       var isHovered = this.hoveredRegion && this.hoveredRegion.name === r.name;
 
@@ -2475,36 +2484,40 @@ var InteractiveMap = {
   showRegionInfo: function(region) {
     var infoDiv = document.getElementById('map-region-info');
     if (!infoDiv) return;
+    infoDiv.replaceChildren();
 
-    var html = '<h4 style="color:var(--gold);margin-bottom:0.5rem;">' + region.name + '</h4>';
+    var title = document.createElement('h4');
+    title.style.cssText = 'color:var(--gold);margin-bottom:0.5rem;';
+    title.textContent = String(region && region.name != null ? region.name : '');
+    infoDiv.appendChild(title);
 
-    // 显示控制者
-    if (region.controller) {
-      html += '<div style="margin-bottom:0.3rem;"><strong>控制者:</strong> ' + region.controller + '</div>';
+    function appendInfoRow(label, value) {
+      var row = document.createElement('div');
+      row.style.cssText = 'margin-bottom:0.3rem;';
+      var strong = document.createElement('strong');
+      strong.textContent = label + ': ';
+      row.appendChild(strong);
+      row.appendChild(document.createTextNode(String(value)));
+      infoDiv.appendChild(row);
     }
 
-    // 显示人口
-    if (region.population) {
-      html += '<div style="margin-bottom:0.3rem;"><strong>人口:</strong> ' + region.population + '</div>';
-    }
+    if (region && region.controller != null) appendInfoRow('控制者', region.controller);
+    if (region && region.population != null) appendInfoRow('人口', region.population);
+    if (region && region.income != null) appendInfoRow('收入', region.income);
 
-    // 显示收入
-    if (region.income) {
-      html += '<div style="margin-bottom:0.3rem;"><strong>收入:</strong> ' + region.income + '</div>';
+    if (region && region.desc != null && region.desc !== '') {
+      var description = document.createElement('div');
+      description.style.cssText = 'margin-top:0.5rem;color:var(--txt-d);font-size:0.85rem;';
+      description.textContent = String(region.desc);
+      infoDiv.appendChild(description);
     }
-
-    // 显示描述
-    if (region.desc) {
-      html += '<div style="margin-top:0.5rem;color:var(--txt-d);font-size:0.85rem;">' + region.desc + '</div>';
-    }
-
-    infoDiv.innerHTML = html;
   }
 };
 
 // 打开交互式地图
 function openInteractiveMap() {
-  if (!P.mapData || !P.mapData.regions || P.mapData.regions.length === 0) {
+  var runtimeMap = getLiveMapData();
+  if (!runtimeMap || !runtimeMap.regions || runtimeMap.regions.length === 0) {
     toast('❌ 当前剧本没有地图数据');
     return;
   }

--- a/web/tm-map-system.js
+++ b/web/tm-map-system.js
@@ -689,7 +689,9 @@ function createTerrainPattern(ctx, patternType) {
  * 实际游戏推演以行政区划（cities/territories）为准
  */
 function updateMapColors() {
-  if (!P.map) return;
+  var runtimeMap = getLiveMapData();
+  if (!runtimeMap) return;
+  var runtimeGM = (typeof GM !== 'undefined' && GM) ? GM : null;
 
   _dbg('[Map] 更新地图颜色...');
 
@@ -697,9 +699,10 @@ function updateMapColors() {
 
   // 建立 region.id → autonomy 类型 映射（若该地块映射了行政区划）
   var _regionAutonomyMap = {};
-  if (P.adminHierarchy) {
-    Object.keys(P.adminHierarchy).forEach(function(fk) {
-      var fh = P.adminHierarchy[fk]; if (!fh || !fh.divisions) return;
+  var runtimeAdminHierarchy = (runtimeGM && runtimeGM.adminHierarchy) || P.adminHierarchy;
+  if (runtimeAdminHierarchy) {
+    Object.keys(runtimeAdminHierarchy).forEach(function(fk) {
+      var fh = runtimeAdminHierarchy[fk]; if (!fh || !fh.divisions) return;
       (function _walk(ds) {
         ds.forEach(function(d) {
           if (d.mappedRegions && d.autonomy && d.autonomy.type) {
@@ -716,7 +719,8 @@ function updateMapColors() {
   // 双树防御走查：P 与 GM 的 adminHierarchy 通常同引用·若分叉则以任一侧有 occupiedBy 为准（占据只由
   // tm-revolt-inference 写在 GM 叶上·P 侧缺失=静默无覆色·安全失效不破图）。
   var _regionOccupiedMap = {};
-  [P.adminHierarchy, (typeof GM !== 'undefined' && GM && GM.adminHierarchy !== P.adminHierarchy) ? GM.adminHierarchy : null].forEach(function(ah) {
+  [runtimeGM ? runtimeGM.adminHierarchy : null,
+    (P.adminHierarchy && (!runtimeGM || runtimeGM.adminHierarchy !== P.adminHierarchy)) ? P.adminHierarchy : null].forEach(function(ah) {
     if (!ah) return;
     Object.keys(ah).forEach(function(fk) {
       var fh = ah[fk]; if (!fh || !fh.divisions) return;
@@ -736,8 +740,8 @@ function updateMapColors() {
   var _AUTONOMY_COLORS = { fanguo:'#9a7bd8', fanzhen:'#f87171', jimi:'#66bb6a', chaogong:'#f59e0b' };
 
   // 更新智能格式地块颜色
-  if (P.map.regions && Array.isArray(P.map.regions)) {
-    P.map.regions.forEach(function(region) {
+  if (runtimeMap.regions && Array.isArray(runtimeMap.regions)) {
+    runtimeMap.regions.forEach(function(region) {
       if (!region) return;
 
       // 根据 owner/currentOwner/ownerKey 查找对应势力
@@ -748,12 +752,12 @@ function updateMapColors() {
       }
 
       // 查找势力
-      var faction = GM.facs ? GM.facs.find(function(f) { return f.name === owner || f.id === owner || f.name === region.factionName || f.id === region.factionId; }) : null;
+      var faction = runtimeGM && runtimeGM.facs ? runtimeGM.facs.find(function(f) { return f.name === owner || f.id === owner || f.name === region.factionName || f.id === region.factionId; }) : null;
       var baseColor = null;
       if (faction && faction.color) baseColor = faction.color;
-      else if (GM.mapData && GM.mapData.factionColors && GM.mapData.factionColors[owner]) baseColor = GM.mapData.factionColors[owner].main;
-      else if (GM.mapData && GM.mapData.factionColors && region.factionName && GM.mapData.factionColors[region.factionName]) baseColor = GM.mapData.factionColors[region.factionName].main;
-      else if (GM.mapData && GM.mapData.factions && region.ownerKey && GM.mapData.factions[region.ownerKey]) baseColor = GM.mapData.factions[region.ownerKey].color;
+      else if (runtimeMap.factionColors && runtimeMap.factionColors[owner]) baseColor = runtimeMap.factionColors[owner].main;
+      else if (runtimeMap.factionColors && region.factionName && runtimeMap.factionColors[region.factionName]) baseColor = runtimeMap.factionColors[region.factionName].main;
+      else if (runtimeMap.factions && region.ownerKey && runtimeMap.factions[region.ownerKey]) baseColor = runtimeMap.factions[region.ownerKey].color;
       else if (region.factionColor) baseColor = region.factionColor;
       if (!baseColor) { region.color = '#cccccc'; return; }
       // 按 autonomy 覆盖或混合——非直辖显示管辖类型色
@@ -768,7 +772,7 @@ function updateMapColors() {
       // 批五·义军占据覆色压轴（占据是既成军事事实·压过 autonomy 显示·退据即自动还色）
       var _occ = _regionOccupiedMap[region.id];
       if (_occ) {
-        var _occC = (GM.mapData && GM.mapData.factionColors && GM.mapData.factionColors[_occ]) || null;
+        var _occC = (runtimeMap.factionColors && runtimeMap.factionColors[_occ]) || null;
         if (_occC && _occC.main) { region.color = _occC.main; region.occupiedBy = _occ; }
       } else if (region.occupiedBy) {
         delete region.occupiedBy;
@@ -778,8 +782,8 @@ function updateMapColors() {
   }
 
   // 更新传统格式地块颜色
-  if (P.map.items && Array.isArray(P.map.items)) {
-    P.map.items.forEach(function(item) {
+  if (runtimeMap.items && Array.isArray(runtimeMap.items)) {
+    runtimeMap.items.forEach(function(item) {
       if (!item) return;
 
       var owner = item.currentOwner || item.owner || item.factionId || item.ownerKey;
@@ -788,15 +792,15 @@ function updateMapColors() {
         return;
       }
 
-      var faction = GM.facs ? GM.facs.find(function(f) { return f.name === owner || f.id === owner || f.name === item.factionName || f.id === item.factionId; }) : null;
+      var faction = runtimeGM && runtimeGM.facs ? runtimeGM.facs.find(function(f) { return f.name === owner || f.id === owner || f.name === item.factionName || f.id === item.factionId; }) : null;
       if (faction && faction.color) {
         item.color = faction.color;
         updateCount++;
-      } else if (GM.mapData && GM.mapData.factionColors && GM.mapData.factionColors[owner]) {
-        item.color = GM.mapData.factionColors[owner].main;
+      } else if (runtimeMap.factionColors && runtimeMap.factionColors[owner]) {
+        item.color = runtimeMap.factionColors[owner].main;
         updateCount++;
-      } else if (GM.mapData && GM.mapData.factions && item.ownerKey && GM.mapData.factions[item.ownerKey]) {
-        item.color = GM.mapData.factions[item.ownerKey].color;
+      } else if (runtimeMap.factions && item.ownerKey && runtimeMap.factions[item.ownerKey]) {
+        item.color = runtimeMap.factions[item.ownerKey].color;
         updateCount++;
       } else if (item.factionColor) {
         item.color = item.factionColor;

--- a/web/tm-map-system.js
+++ b/web/tm-map-system.js
@@ -2102,38 +2102,90 @@ function findPath(from, to, options) {
   if (from === to) return { path: [from], cost: 0, distance: 0, hasPostRoad: false, terrainTypes: [] };
 
   options = options || {};
-  var openSet = [{ node: from, g: 0, f: 0, path: [from], terrains: [], postRoad: false }];
-  var closed = {};
+  var heap = [];
+  var sequence = 0;
+  var bestG = Object.create(null);
+  var previous = Object.create(null);
+  var regionByNode = Object.create(null);
+  if (options.avoidEnemy) {
+    var runtimeMap = getLiveMapData() || {};
+    (runtimeMap.regions || []).forEach(function(region) {
+      if (!region) return;
+      var id = region.id || region.name;
+      if (id != null) regionByNode[id] = region;
+    });
+  }
+  function less(a, b) { return a.f < b.f || (a.f === b.f && a.order < b.order); }
+  function heapPush(item) {
+    heap.push(item);
+    var index = heap.length - 1;
+    while (index > 0) {
+      var parent = Math.floor((index - 1) / 2);
+      if (!less(heap[index], heap[parent])) break;
+      var swap = heap[parent]; heap[parent] = heap[index]; heap[index] = swap;
+      index = parent;
+    }
+  }
+  function heapPop() {
+    if (!heap.length) return null;
+    var first = heap[0];
+    var last = heap.pop();
+    if (heap.length) {
+      heap[0] = last;
+      var index = 0;
+      while (true) {
+        var left = index * 2 + 1;
+        var right = left + 1;
+        var smallest = index;
+        if (left < heap.length && less(heap[left], heap[smallest])) smallest = left;
+        if (right < heap.length && less(heap[right], heap[smallest])) smallest = right;
+        if (smallest === index) break;
+        var swap = heap[index]; heap[index] = heap[smallest]; heap[smallest] = swap;
+        index = smallest;
+      }
+    }
+    return first;
+  }
+  bestG[from] = 0;
+  heapPush({ node: from, g: 0, f: 0, order: sequence++ });
 
-  while (openSet.length > 0) {
-    // 取f值最小的节点
-    openSet.sort(function(a, b) { return a.f - b.f; });
-    var current = openSet.shift();
+  while (heap.length > 0) {
+    var current = heapPop();
+    if (!current || current.g !== bestG[current.node]) continue;
 
     if (current.node === to) {
+      var path = [to];
+      var terrains = [];
+      var hasPostRoad = false;
+      var cursor = to;
+      while (cursor !== from) {
+        var step = previous[cursor];
+        if (!step) return null;
+        terrains.push(step.terrain);
+        hasPostRoad = hasPostRoad || step.hasPostRoad;
+        cursor = step.node;
+        path.push(cursor);
+      }
+      path.reverse();
+      terrains.reverse();
       return {
-        path: current.path,
+        path: path,
         cost: current.g,
-        distance: current.path.length - 1,
-        hasPostRoad: current.postRoad,
-        terrainTypes: current.terrains
+        distance: path.length - 1,
+        hasPostRoad: hasPostRoad,
+        terrainTypes: terrains
       };
     }
-
-    if (closed[current.node]) continue;
-    closed[current.node] = true;
 
     var edges = graph[current.node] || [];
     for (var i = 0; i < edges.length; i++) {
       var edge = edges[i];
-      if (closed[edge.target]) continue;
 
       if (options.waterOnly && edge.type !== 'water') continue;
 
       // avoidEnemy 是全节点约束，不只作用于关隘。
       if (options.avoidEnemy) {
-        var runtimeMap = GM.mapData || {};
-        var region = (runtimeMap.regions || []).find(function(r) { return (r.id || r.name) === edge.target; });
+        var region = regionByNode[edge.target];
         if (region) {
           var regionOwner = region.occupiedBy || region.controller || region.owner || '';
           if (regionOwner && options.faction && regionOwner !== options.faction) {
@@ -2148,18 +2200,14 @@ function findPath(from, to, options) {
       if (edge.type === 'mountain_pass') edgeCost *= 1.5;
       if (edge.hasPostRoad) edgeCost *= 0.7;
       var g = current.g + edgeCost;
-
-      var newTerrains = current.terrains.concat(edge.terrain);
-      var hasRoad = current.postRoad || edge.hasPostRoad;
-
-      openSet.push({
-        node: edge.target,
-        g: g,
-        f: g, // 无启发式（退化为Dijkstra，保证最优）
-        path: current.path.concat(edge.target),
-        terrains: newTerrains,
-        postRoad: hasRoad
-      });
+      if (bestG[edge.target] != null && g >= bestG[edge.target]) continue;
+      bestG[edge.target] = g;
+      previous[edge.target] = {
+        node: current.node,
+        terrain: edge.terrain,
+        hasPostRoad: !!edge.hasPostRoad
+      };
+      heapPush({ node: edge.target, g: g, f: g, order: sequence++ }); // Dijkstra·保证非负边最优
     }
   }
 

--- a/web/tm-negotiation.js
+++ b/web/tm-negotiation.js
@@ -35,9 +35,17 @@
   }
   function _turn(G) { return (G && G.turn) || 0; }
   function _norm(s) { return String(s == null ? '' : s).trim().toLowerCase(); }
+  function _normalizeRef(ref) {
+    if (!ref) return null;
+    var kind = String(ref.kind == null ? '' : ref.kind).trim();
+    var refId = String(ref.refId == null ? '' : ref.refId).trim();
+    return kind && refId ? { kind: kind, refId: refId } : null;
+  }
   function _sameRef(a, b) {
-    if (!a || !b) return false;
-    return _norm(a.kind) === _norm(b.kind) && _norm(a.refId) === _norm(b.refId);
+    var left = _normalizeRef(a);
+    var right = _normalizeRef(b);
+    if (!left || !right) return false;
+    return _norm(left.kind) === _norm(right.kind) && _norm(left.refId) === _norm(right.refId);
   }
   // 全局递增序号（GM 级·照 tm-faction-diplomacy._dipSeq 范式·防同回合多次 open 的本地 n 重置→id 碰撞）
   function _seq(G) {
@@ -68,7 +76,8 @@
     var G = _G();
     if (!G || !enabled()) return null;
     var turn = _turn(G);
-    var ref = spec.sourceRef || {};
+    var ref = _normalizeRef(spec.sourceRef);
+    if (!ref) return null; // 缺稳定来源时拒绝建会话，绝不把两个空引用误并为同一谈判。
     var list = _list(G);
     var existing = null;
     for (var i = 0; i < list.length; i++) {
@@ -83,7 +92,7 @@
       id: 'ng-' + turn + '-' + _seq(G),
       parties: { initiator: String(spec.initiator || ref.refId || '').slice(0, 40), responder: 'player' },
       topic: spec.topic || 'diplomacy',
-      sourceRef: { kind: String(ref.kind || ''), refId: String(ref.refId || '') },
+      sourceRef: { kind: ref.kind, refId: ref.refId },
       offers: off ? [off] : [],
       round: 1,
       status: 'open',
@@ -106,9 +115,11 @@
   function findOpenByRef(kind, refId) {
     var G = _G();
     if (!G) return null;
+    var ref = _normalizeRef({ kind: kind, refId: refId });
+    if (!ref) return null;
     var list = Array.isArray(G._negotiations) ? G._negotiations : [];
     for (var i = 0; i < list.length; i++) {
-      if (list[i] && list[i].status === 'open' && _sameRef(list[i].sourceRef, { kind: kind, refId: refId })) return list[i];
+      if (list[i] && list[i].status === 'open' && _sameRef(list[i].sourceRef, ref)) return list[i];
     }
     return null;
   }
@@ -132,7 +143,8 @@
   function resolve(id, status) {
     var ng = get(id);
     if (!ng || ng.status !== 'open') return null;
-    if (status === 'accepted' || status === 'rejected' || status === 'lapsed') ng.status = status;
+    if (status !== 'accepted' && status !== 'rejected' && status !== 'lapsed') return null;
+    ng.status = status;
     return ng;
   }
 

--- a/web/tm-online-client.js
+++ b/web/tm-online-client.js
@@ -65,12 +65,41 @@
   function createOnlineClient(opts) {
     opts = opts || {};
     var storage = makeStorage(opts.storage);
+    var desktopBridge = opts.desktopBridge || (typeof window !== 'undefined' && window.tianming && typeof window.tianming.onlineRequest === 'function' ? window.tianming : null);
+    var desktopSession = { loggedIn: false, user: null, loggedInAt: '' };
     var doFetch = opts.fetch || (typeof fetch !== 'undefined' ? fetch.bind(typeof window !== 'undefined' ? window : null) : null);
     // B2（批B）：上传进度需 XMLHttpRequest（fetch 无原生上传进度事件）。可注入便于测试。
     var XHR = opts.XMLHttpRequest || (typeof XMLHttpRequest !== 'undefined' ? XMLHttpRequest : null);
     var defaultApiUrl = normalizeApiUrl(opts.apiUrl || DEFAULT_API_URL);
 
+    function setDesktopSession(session) {
+      session = session && session.session ? session.session : session;
+      desktopSession = {
+        loggedIn: !!(session && (session.loggedIn || session.user)),
+        user: session && session.user && typeof session.user === 'object' ? session.user : null,
+        loggedInAt: session && session.loggedInAt || ''
+      };
+      return desktopSession;
+    }
+
+    if (desktopBridge && typeof desktopBridge.accountSession === 'function') {
+      // 清除旧版曾落在 renderer localStorage 的真实 token；桌面端今后只保留主进程会话。
+      try { storage.removeItem(SESSION_KEY); storage.removeItem(API_URL_KEY); } catch (e) {}
+      Promise.resolve(desktopBridge.accountSession()).then(function (res) {
+        if (res && res.success) setDesktopSession(res.session);
+      }).catch(function () {});
+    }
+
     function readSession() {
+      if (desktopBridge) {
+        return {
+          token: desktopSession.loggedIn ? '__main_process_session__' : '',
+          apiUrl: defaultApiUrl,
+          user: desktopSession.user,
+          loggedInAt: desktopSession.loggedInAt,
+          loggedIn: desktopSession.loggedIn
+        };
+      }
       try {
         var raw = storage.getItem(SESSION_KEY);
         if (!raw) return { token: '', apiUrl: getApiUrl(), user: null };
@@ -87,6 +116,10 @@
     }
 
     function writeSession(session) {
+      if (desktopBridge) {
+        setDesktopSession(session);
+        return getSession();
+      }
       var payload = {
         token: String((session && session.token) || ''),
         apiUrl: normalizeApiUrl((session && session.apiUrl) || getApiUrl()),
@@ -97,11 +130,20 @@
       return payload;
     }
 
-    function clearSession() {
+    function clearSession(localOnly) {
+      if (desktopBridge) {
+        setDesktopSession(null);
+        try { storage.removeItem(SESSION_KEY); } catch (e) {}
+        if (!localOnly && typeof desktopBridge.accountLogout === 'function') {
+          Promise.resolve(desktopBridge.accountLogout()).catch(function () {});
+        }
+        return;
+      }
       try { storage.removeItem(SESSION_KEY); } catch (e) {}
     }
 
     function getApiUrl() {
+      if (desktopBridge) return defaultApiUrl;
       try {
         var saved = storage.getItem(API_URL_KEY);
         if (saved) return normalizeApiUrl(saved);
@@ -110,20 +152,25 @@
     }
 
     function setApiUrl(url) {
+      if (desktopBridge) return defaultApiUrl;
       var norm = normalizeApiUrl(url) || defaultApiUrl;
       try { storage.setItem(API_URL_KEY, norm); } catch (e) {}
       return norm;
     }
 
-    function getToken() { return readSession().token; }
-    function getSession() { return readSession(); }
-    function isLoggedIn() { return !!readSession().token; }
+    function getToken() { return desktopBridge ? '' : readSession().token; }
+    function getSession() {
+      if (!desktopBridge) return readSession();
+      return { loggedIn: desktopSession.loggedIn, user: desktopSession.user, loggedInAt: desktopSession.loggedInAt };
+    }
+    function isLoggedIn() { return desktopBridge ? desktopSession.loggedIn : !!readSession().token; }
 
     // ---- core request ------------------------------------------------------
     // Returns parsed JSON (incl. { success:false, error } on handled 4xx).
     // Throws only on network failure or an unparseable error response.
     function request(method, pathname, reqOpts) {
       reqOpts = reqOpts || {};
+      if (desktopBridge) return Promise.resolve(desktopBridge.onlineRequest(method, pathname, reqOpts.body));
       if (!doFetch) return Promise.reject(new Error('当前环境不支持 fetch'));
       var apiUrl = normalizeApiUrl(reqOpts.apiUrl || readSession().apiUrl || getApiUrl());
       if (!apiUrl) return Promise.reject(new Error('缺少在线服务地址'));
@@ -161,7 +208,7 @@
         email: String(info.email || '').trim()
       };
       return request('POST', 'account/register', { body: payload, token: '', apiUrl: apiUrl }).then(function (res) {
-        if (res && res.success && res.token) writeSession({ token: res.token, apiUrl: normalizeApiUrl(apiUrl || getApiUrl()), user: res.user || null });
+        if (res && res.success && (res.token || desktopBridge)) writeSession(res.session || { token: res.token, apiUrl: normalizeApiUrl(apiUrl || getApiUrl()), user: res.user || null, loggedIn: true });
         return Object.assign({ success: false }, res || {});
       });
     }
@@ -174,7 +221,7 @@
     function emailLogin(email, code, apiUrl) {
       return request('POST', 'account/email-login', { body: { email: String(email || '').trim(), code: String(code || '').trim() }, token: '', apiUrl: apiUrl })
         .then(function (res) {
-          if (res && res.success && res.token) writeSession({ token: res.token, apiUrl: normalizeApiUrl(apiUrl || getApiUrl()), user: res.user || null });
+          if (res && res.success && (res.token || desktopBridge)) writeSession(res.session || { token: res.token, apiUrl: normalizeApiUrl(apiUrl || getApiUrl()), user: res.user || null, loggedIn: true });
           return Object.assign({ success: false }, res || {});
         });
     }
@@ -482,17 +529,17 @@
       info = info || {};
       var payload = { username: String(info.username || '').trim(), password: String(info.password || '') };
       return request('POST', 'account/login', { body: payload, token: '', apiUrl: apiUrl }).then(function (res) {
-        if (res && res.success && res.token) writeSession({ token: res.token, apiUrl: normalizeApiUrl(apiUrl || getApiUrl()), user: res.user || null });
+        if (res && res.success && (res.token || desktopBridge)) writeSession(res.session || { token: res.token, apiUrl: normalizeApiUrl(apiUrl || getApiUrl()), user: res.user || null, loggedIn: true });
         return Object.assign({ success: false }, res || {});
       });
     }
 
     function me(apiUrl) {
       var session = readSession();
-      if (!session.token) return Promise.resolve({ success: true, loggedIn: false, user: null, session: session });
+      if (!session.token && !desktopBridge) return Promise.resolve({ success: true, loggedIn: false, user: null, session: getSession() });
       return request('GET', 'account/me', { apiUrl: apiUrl || session.apiUrl, token: session.token }).then(function (res) {
-        if (res && res.success && res.user) writeSession({ token: session.token, apiUrl: normalizeApiUrl(apiUrl || session.apiUrl), user: res.user });
-        return Object.assign({ loggedIn: !!(res && res.user) }, res || {}, { session: readSession() });
+        if (res && res.success && res.user) writeSession(res.session || { token: session.token, apiUrl: normalizeApiUrl(apiUrl || session.apiUrl), user: res.user, loggedIn: true });
+        return Object.assign({ loggedIn: !!(res && res.user) }, res || {}, { session: getSession() });
       });
     }
 
@@ -502,10 +549,10 @@
       // 否则旧账号的网络回包会把新账号刚写入 localStorage 的会话一并删掉。
       var done = function () {
         var current = readSession();
-        if (!current.token || current.token === session.token) clearSession();
+        if (!current.token || current.token === session.token) clearSession(true);
         return { success: true };
       };
-      if (!session.token) return Promise.resolve(done());
+      if (!session.token && !desktopBridge) return Promise.resolve(done());
       return request('POST', 'account/logout', { body: {}, apiUrl: apiUrl || session.apiUrl, token: session.token })
         .then(done, function (e) { var result = done(); result.warning = e && e.message; return result; });
     }
@@ -514,7 +561,7 @@
     function catalog(catalogUrl) {
       var apiUrl = readSession().apiUrl || getApiUrl();
       var url = String(catalogUrl || '').trim();
-      if (url) {
+      if (url && !desktopBridge) {
         // full catalog URL given — fetch directly
         if (!doFetch) return Promise.reject(new Error('当前环境不支持 fetch'));
         return doFetch(url, { method: 'GET', mode: 'cors', cache: 'no-store', headers: { 'Accept': 'application/json' } })
@@ -563,6 +610,13 @@
     // 进度（xhr.upload.onprogress 的 loaded/total）；否则回落 request() 的 fetch 路（行为
     // 不变）。鉴权头/URL/body 构造与 request() 逐字一致（Accept + Content-Type + Bearer）。
     function sendUpload(payload, apiUrl, token, onProgress) {
+      if (desktopBridge) {
+        if (typeof onProgress === 'function') { try { onProgress({ loaded: 0, total: 1 }); } catch (_) {} }
+        return request('POST', 'workshop/upload', { body: payload }).then(function (res) {
+          if (typeof onProgress === 'function') { try { onProgress({ loaded: 1, total: 1 }); } catch (_) {} }
+          return res;
+        });
+      }
       if (typeof onProgress === 'function' && XHR) {
         var base = normalizeApiUrl(apiUrl || getApiUrl());
         if (!base) return Promise.reject(new Error('缺少在线服务地址'));

--- a/web/tm-post-turn-jobs.js
+++ b/web/tm-post-turn-jobs.js
@@ -424,14 +424,17 @@ function _enqueuePostTurnJob(id, fn, opts) {
   var dependsOn = (opts && Array.isArray(opts.dependsOn)) ? opts.dependsOn : null;
   var wrappedFn = async function() {
     if (dependsOn) {
-      try { await _awaitPostTurnJobsById(dependsOn); } catch(_dE) { _dbg('[PostTurn DAG] await deps fail for ' + id + ':', _dE); }
+      await _awaitPostTurnJobsById(dependsOn);
     }
     if (!_tmWorldLeaseCurrent(lease)) return { stale: true };
     return fn(lease);
   };
-  var p = Promise.resolve().then(wrappedFn).catch(function(e){
+  var p = Promise.resolve().then(wrappedFn).then(function(value) {
+    return { ok: true, value: value };
+  }, function(e) {
     try { if (typeof recordMemoryDiagnostic === 'function') recordMemoryDiagnostic('post_turn_job', { id: id, status: 'fail', error: String(e && e.message || e) }); } catch(_) {}
     _dbg('[PostTurn]' + id + ' failed:', e);
+    return { ok: false, error: e };
   });
   q.pending.push({ id: id, promise: p, dependsOn: dependsOn, lease: lease });
   return p;
@@ -444,7 +447,17 @@ async function _awaitPostTurnJobsById(ids) {
     return job && ids.indexOf(job.id) >= 0;
   });
   if (!waiting.length) return;
-  await Promise.all(waiting.map(function(job) { return job.promise; }));
+  var results = await Promise.all(waiting.map(function(job) { return job.promise; }));
+  var failed = [];
+  results.forEach(function(result, index) {
+    if (result && result.ok === false) failed.push({ id: waiting[index].id, error: result.error });
+  });
+  if (failed.length) {
+    var error = new Error('关键后台任务失败：' + failed.map(function(item) { return item.id; }).join(', '));
+    error.postTurnFailures = failed;
+    throw error;
+  }
+  return results;
 }
 
 function _launchPostTurnJobs() {
@@ -508,9 +521,24 @@ async function _awaitPostTurnJobs(opts) {
   var waiting = criticalOnly ? pending.filter(_isCriticalPostTurnJob) : pending.slice();
   var remaining = criticalOnly ? pending.filter(function(job) { return !_isCriticalPostTurnJob(job); }) : [];
   _dbg('[PostTurn] wait', waiting.length, criticalOnly ? 'critical jobs' : 'jobs', 'detach', remaining.length);
-  try {
-    if (waiting.length) await Promise.all(waiting.map(function(job) { return job.promise; }));
-  } catch(_e) {}
+  var results = waiting.length ? await Promise.all(waiting.map(function(job) { return job.promise; })) : [];
+  var failed = [];
+  results.forEach(function(result, index) {
+    if (result && result.ok === false) failed.push({ id: waiting[index].id, error: result.error });
+  });
+  if (failed.length) {
+    try {
+      if (typeof recordMemoryDiagnostic === 'function') recordMemoryDiagnostic('post_turn_await', {
+        status: 'failed',
+        count: waiting.length,
+        criticalOnly: criticalOnly,
+        failed: failed.map(function(item) { return item.id; })
+      });
+    } catch(_) {}
+    var failure = new Error('关键后台任务失败：' + failed.map(function(item) { return item.id; }).join(', '));
+    failure.postTurnFailures = failed;
+    throw failure;
+  }
   try {
     if (typeof recordMemoryDiagnostic === 'function') {
       recordMemoryDiagnostic('post_turn_await', {
@@ -539,7 +567,16 @@ async function _awaitPostTurnJobsForSave(ids) {
   }
   if (!wanted.length) return;
   _dbg('[PostTurn] wait before save:', wanted.map(function(job) { return job.id || '?'; }).join(','));
-  await Promise.all(wanted.map(function(job) { return job.promise; }));
+  var results = await Promise.all(wanted.map(function(job) { return job.promise; }));
+  var failed = [];
+  results.forEach(function(result, index) {
+    if (result && result.ok === false) failed.push({ id: wanted[index].id, error: result.error });
+  });
+  if (failed.length) {
+    var error = new Error('保存前关键后台任务失败：' + failed.map(function(item) { return item.id; }).join(', '));
+    error.postTurnFailures = failed;
+    throw error;
+  }
   if (!Array.isArray(ids) || !ids.length) {
     var saveIds = _postTurnSaveRequiredIds();
     if (Array.isArray(GM._postTurnDetachedJobs)) {

--- a/web/tm-storage.js
+++ b/web/tm-storage.js
@@ -285,7 +285,14 @@ var TM_SaveDB = (function() {
   /** 确保DB就绪后执行操作 */
   function _ensureOpen() {
     if (_db) return Promise.resolve();
-    return open();
+    return open().catch(function(error) {
+      // IndexedDB 被禁用、打开失败或升级被阻塞时，公开 API 仍应兑现
+      // “回退 localStorage”的契约；失败原因保留在控制台供诊断。
+      console.warn('[SaveDB] IndexedDB打开不可用，回退localStorage:', error);
+      _available = false;
+      _db = null;
+      return null;
+    });
   }
 
   /** 保存游戏存档（7.1: 支持gzip压缩） */
@@ -304,7 +311,9 @@ var TM_SaveDB = (function() {
     if (!_writeStillAllowed()) return Promise.resolve(false);
     return _ensureOpen().then(function() {
       return SaveCompression.compress(jsonStr).then(function(compressed) {
-        var isCompressed = compressed !== jsonStr; // Blob vs string
+        // Blob 只能由 IndexedDB 结构化克隆安全保存。localStorage 的 JSON.stringify
+        // 会把 Blob 变成 {}，因此降级路径必须保留原始 JSON 字符串。
+        var isCompressed = !!(_available && _db && compressed !== jsonStr);
         var record = {
           id: id,
           type: (meta && meta.type) || 'manual',
@@ -318,7 +327,7 @@ var TM_SaveDB = (function() {
           // pre_endturn 两阶段恢复校验元数据；普通/旧存档保持空值兼容。
           snapshotId: (meta && meta.snapshotId) || '',
           commitState: (meta && meta.commitState) || '',
-          gameState: compressed,
+          gameState: isCompressed ? compressed : jsonStr,
           _compressed: isCompressed
         };
         if (isCompressed) {
@@ -346,6 +355,12 @@ var TM_SaveDB = (function() {
           return record;
         });
       }
+      // 未压缩存档（包括 localStorage fallback）以 JSON 字符串保存；统一还原成对象，
+      // 避免调用方把一个合法降级存档误判为损坏。
+      if (typeof record.gameState === 'string') {
+        record.gameState = JSON.parse(record.gameState);
+      }
+      delete record._compressed;
       // 旧存档：gameState已经是对象，直接返回
       return record;
     });


### PR DESCRIPTION
## Summary

- eliminate interactive-map HTML injection and keep account bearer tokens inside the main process
- make end-turn calibration, critical systems, subticks, and post-turn jobs participate in transactional failure handling
- preserve localStorage fallback saves and consistently read the runtime map for economy, supply, and map UI
- enforce AI set type contracts, preflight and stream workshop ZIP extraction, and harden test-only production gates
- improve pathfinding and migrate negotiation, commander, and faction references toward stable IDs
- add focused regression coverage and refresh the complete 1.3.4.11 hot-update baseline without dropping assets

## Verification

- `npm ci --ignore-scripts`
- official scenario sync plus clean diff
- full smoke suite: CI PASS for 837 tests; only the two existing missing-untracked-asset allowlist entries were exempt locally
- architecture guards: 8/8 PASS
- official scenario parity: 27 assertions PASS
- cross-release contract: 165 assertions PASS
- hot-update builder gates: 27 assertions PASS
- complete hot baseline check: 1081 files PASS using the owner asset tree
- Windows PowerShell 5.1 mobile dry-run plus staged-web hash verification: 674 files PASS

No installer, release, hot update, or Pages deployment is performed by this PR.