### PR TITLE
fix: close third-round audit blockers

### DIFF
--- a/main-impl.js
+++ b/main-impl.js
@@ -1537,14 +1537,27 @@ function readAccountSession() {
   };
 }
 
+function toPublicAccountUser(user) {
+  if (!user || typeof user !== 'object' || Array.isArray(user)) return null;
+  const out = {};
+  ['id', 'username', 'nickname', 'avatarUrl', 'email', 'emailVerified'].forEach(key => {
+    if (Object.prototype.hasOwnProperty.call(user, key)) out[key] = user[key];
+  });
+  return out;
+}
+
 function toPublicAccountSession(session = readAccountSession()) {
-  const user = session && session.user && typeof session.user === 'object' ? session.user : null;
   return {
     loggedIn: !!(session && session.token),
-    user,
+    user: toPublicAccountUser(session && session.user),
     loggedInAt: session && session.loggedInAt || ''
   };
 }
+
+const ONLINE_SECRET_FIELD_NAMES = new Set([
+  'token', 'accesstoken', 'refreshtoken', 'idtoken', 'authorization', 'sessionsecret',
+  'jwt', 'password', 'passwordhash', 'verificationsecret', 'recoverycodes'
+]);
 
 function sanitizeOnlineResponse(value, seen = new WeakSet()) {
   if (value == null || typeof value !== 'object') return value;
@@ -1553,9 +1566,17 @@ function sanitizeOnlineResponse(value, seen = new WeakSet()) {
   if (Array.isArray(value)) return value.map(item => sanitizeOnlineResponse(item, seen));
   const out = {};
   Object.keys(value).forEach(key => {
-    if (/^(?:token|accessToken|refreshToken|idToken|authorization|sessionSecret)$/i.test(key)) return;
+    const normalized = String(key).replace(/[^a-z0-9]/gi, '').toLowerCase();
+    if (ONLINE_SECRET_FIELD_NAMES.has(normalized)) return;
     out[key] = sanitizeOnlineResponse(value[key], seen);
   });
+  return out;
+}
+
+function sanitizeAccountOnlineResponse(value) {
+  const source = value && typeof value === 'object' ? value : {};
+  const out = sanitizeOnlineResponse(source);
+  if (Object.prototype.hasOwnProperty.call(source, 'user')) out.user = toPublicAccountUser(source.user);
   return out;
 }
 
@@ -1620,6 +1641,27 @@ const ONLINE_RENDERER_ROUTES = Object.freeze({
   ])
 });
 
+const ONLINE_RENDERER_BODY_LIMIT_DEFAULT = 1024 * 1024;
+const ONLINE_RENDERER_BODY_LIMIT_LARGE = 4 * 1024 * 1024;
+const ONLINE_RENDERER_LARGE_BODY_ROUTES = new Set([
+  'arena/submit', 'chronicles/publish', 'revision/propose', 'workshop/upload'
+]);
+
+function getOnlineRendererBodyLimit(route) {
+  return ONLINE_RENDERER_LARGE_BODY_ROUTES.has(String(route || ''))
+    ? ONLINE_RENDERER_BODY_LIMIT_LARGE
+    : ONLINE_RENDERER_BODY_LIMIT_DEFAULT;
+}
+
+function assertOnlineRendererBodySize(route, body) {
+  if (body == null) return 0;
+  const encoded = JSON.stringify(body);
+  const bytes = Buffer.byteLength(encoded, 'utf8');
+  const limit = getOnlineRendererBodyLimit(route);
+  if (bytes > limit) throw new Error('在线请求内容超过 ' + Math.floor(limit / (1024 * 1024)) + 'MB 上限');
+  return bytes;
+}
+
 function normalizeOnlineRendererRoute(method, rawPathname) {
   const verb = String(method || '').toUpperCase();
   if (!ONLINE_RENDERER_ROUTES[verb]) throw new Error('在线请求方法不受支持');
@@ -1642,10 +1684,7 @@ function normalizeOnlineRendererRoute(method, rawPathname) {
 
 async function handleOnlineRendererRequest(method, pathname, body) {
   const req = normalizeOnlineRendererRoute(method, pathname);
-  if (body != null) {
-    const encoded = JSON.stringify(body);
-    if (Buffer.byteLength(encoded, 'utf8') > 260 * 1024 * 1024) throw new Error('在线请求内容超过 260MB 上限');
-  }
+  assertOnlineRendererBodySize(req.route, body);
   const noAuth = new Set([
     'health', 'account/email-code', 'account/email-login', 'account/login',
     'account/register', 'account/request-reset', 'account/reset'
@@ -1670,7 +1709,10 @@ async function handleOnlineRendererRequest(method, pathname, body) {
     if (current.token) writeAccountSession({ token: current.token, user: response.user });
   }
 
-  const publicResponse = Object.assign({ success: false }, sanitizeOnlineResponse(response || {}));
+  const publicResponse = Object.assign(
+    { success: false },
+    /^account\//.test(req.route) ? sanitizeAccountOnlineResponse(response || {}) : sanitizeOnlineResponse(response || {})
+  );
   if (/^account\//.test(req.route)) {
     publicResponse.session = toPublicAccountSession();
     publicResponse.loggedIn = publicResponse.session.loggedIn;
@@ -3490,7 +3532,7 @@ ipcMain.handle('account-register', async (event, options = {}) => {
     if (res && res.success && res.token) {
       writeAccountSession({ token: res.token, apiUrl: getAccountApiUrl(options), user: res.user || null });
     }
-    return Object.assign({ success: false }, sanitizeOnlineResponse(res || {}), { session: toPublicAccountSession() });
+    return Object.assign({ success: false }, sanitizeAccountOnlineResponse(res || {}), { session: toPublicAccountSession() });
   } catch (e) {
     return { success: false, error: e.message };
   }
@@ -3506,7 +3548,7 @@ ipcMain.handle('account-login', async (event, options = {}) => {
     if (res && res.success && res.token) {
       writeAccountSession({ token: res.token, apiUrl: getAccountApiUrl(options), user: res.user || null });
     }
-    return Object.assign({ success: false }, sanitizeOnlineResponse(res || {}), { session: toPublicAccountSession() });
+    return Object.assign({ success: false }, sanitizeAccountOnlineResponse(res || {}), { session: toPublicAccountSession() });
   } catch (e) {
     return { success: false, error: e.message };
   }
@@ -3518,7 +3560,7 @@ ipcMain.handle('account-me', async (event, options = {}) => {
     if (!session.token) return { success: true, loggedIn: false, session: toPublicAccountSession(session) };
     const res = await getOnlineApi('account/me', { apiUrl: options.apiUrl || session.apiUrl, token: session.token });
     if (res && res.success && res.user) writeAccountSession({ token: session.token, apiUrl: options.apiUrl || session.apiUrl, user: res.user });
-    return Object.assign({ loggedIn: !!(res && res.user) }, sanitizeOnlineResponse(res || {}), { session: toPublicAccountSession() });
+    return Object.assign({ loggedIn: !!(res && res.user) }, sanitizeAccountOnlineResponse(res || {}), { session: toPublicAccountSession() });
   } catch (e) {
     return { success: false, error: e.message, session: toPublicAccountSession() };
   }
@@ -3852,8 +3894,12 @@ if (TEST_MODE) {
     isTrustedRendererUrl,
     assertTrustedIpcSender,
     toPublicAccountSession,
+    toPublicAccountUser,
     sanitizeOnlineResponse,
+    sanitizeAccountOnlineResponse,
     normalizeOnlineRendererRoute,
+    getOnlineRendererBodyLimit,
+    assertOnlineRendererBodySize,
     preflightWorkshopZip,
     extractZipToTemp,
     WORKSHOP_ZIP_LIMITS,

--- a/preload-impl.js
+++ b/preload-impl.js
@@ -10,6 +10,27 @@
 
 const { contextBridge, ipcRenderer } = require('electron');
 
+const ONLINE_RENDERER_BODY_LIMIT_DEFAULT = 1024 * 1024;
+const ONLINE_RENDERER_BODY_LIMIT_LARGE = 4 * 1024 * 1024;
+const ONLINE_RENDERER_LARGE_BODY_ROUTES = new Set([
+  'arena/submit', 'chronicles/publish', 'revision/propose', 'workshop/upload'
+]);
+
+function _onlineRouteName(pathname) {
+  return String(pathname || '').replace(/^\/+/, '').split(/[?#]/)[0];
+}
+
+function _assertOnlineBodySize(pathname, body) {
+  if (body == null) return body;
+  const route = _onlineRouteName(pathname);
+  const limit = ONLINE_RENDERER_LARGE_BODY_ROUTES.has(route)
+    ? ONLINE_RENDERER_BODY_LIMIT_LARGE
+    : ONLINE_RENDERER_BODY_LIMIT_DEFAULT;
+  const bytes = Buffer.byteLength(JSON.stringify(body), 'utf8');
+  if (bytes > limit) throw new Error('在线请求内容超过 ' + Math.floor(limit / (1024 * 1024)) + 'MB 上限');
+  return body;
+}
+
 function _newSessionToken() {
   try {
     if (globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function') return globalThis.crypto.randomUUID();
@@ -136,8 +157,13 @@ contextBridge.exposeInMainWorld('tianming', {
     ipcRenderer.invoke('online-service-status'),
 
   // 在线账号与社区请求由主进程固定域名、固定路由代发；Bearer Token 永不进入 renderer。
-  onlineRequest: (method, pathname, body) =>
-    ipcRenderer.invoke('online-request', { method, pathname, body }),
+  onlineRequest: (method, pathname, body) => {
+    try {
+      return ipcRenderer.invoke('online-request', { method, pathname, body: _assertOnlineBodySize(pathname, body) });
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  },
 
   accountSession: () =>
     ipcRenderer.invoke('account-session'),

--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-19T03:06:50.652Z",
+  "generatedAt": "2026-08-19T05:50:48.150Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -2061,8 +2061,8 @@
     },
     {
       "path": "editor-details.js",
-      "sha256": "53f5e1a553c45297619b3ba0ef470eb801d57ad75a5664e7fcbb712d4a5f7030",
-      "size": 32306
+      "sha256": "01ce6ef2e5e8c8d663a5508da947aa9129b3fef57599d6751b758e10a0ef5cff",
+      "size": 33120
     },
     {
       "path": "editor-division-deep.js",
@@ -2176,8 +2176,8 @@
     },
     {
       "path": "map-display.js",
-      "sha256": "781e1561320c26ef151239fb699172803eeea3f9170a65ffa4e85312a0804808",
-      "size": 17017
+      "sha256": "750389c4077a898a99ea6dc0193ea29d9de6cfc5d143ce51e79e369df0fc3d39",
+      "size": 17373
     },
     {
       "path": "map-editor-ai.js",
@@ -3391,8 +3391,8 @@
     },
     {
       "path": "tm-ai-change-pathutils.js",
-      "sha256": "1f77d45c532c46f73b9af9ce9915112ced98954362f9beec1906f0d348f6d959",
-      "size": 35615
+      "sha256": "b7c568723f10399c7a07bad4aa8bc3c5c3ae741d00a7b29226ba1d783f389fd3",
+      "size": 36556
     },
     {
       "path": "tm-ai-infra-json.js",
@@ -3826,8 +3826,8 @@
     },
     {
       "path": "tm-economy.js",
-      "sha256": "8702ebf826c8ff77c7d6a210782fddbde6d992f595c4e129663aa966d97a302f",
-      "size": 31854
+      "sha256": "3ac6faf1bc8292fd30bd59ed9e12b6cf88728924c1b35e250ab4a189cb0bfafa",
+      "size": 34830
     },
     {
       "path": "tm-edict-complete.js",
@@ -3921,13 +3921,13 @@
     },
     {
       "path": "tm-endturn-core.js",
-      "sha256": "97807c75dbae3c9f4d7511c468564715b86fd99d7dc7f644521e7fce9eec16f5",
-      "size": 89806
+      "sha256": "4848475fe95f4f246a9226f4fec52b94641f2816308a9fa179a2ef0a76303e71",
+      "size": 87971
     },
     {
       "path": "tm-endturn-edict.js",
-      "sha256": "ba550f30ff27e51d12b874d1f3a7a8ae9d05ad5e8b503bc608b7ea5611036442",
-      "size": 83037
+      "sha256": "ad2a4e9a34f6d78d7eb4314bc25f924f2792cb0116406a67ce3aebee233eb71e",
+      "size": 84564
     },
     {
       "path": "tm-endturn-followup-helpers.js",
@@ -3936,8 +3936,8 @@
     },
     {
       "path": "tm-endturn-followup.js",
-      "sha256": "552d95351ed5c8547fda8970e2699afb55bcfc355b5afdeb8a97f16f657eef8b",
-      "size": 296225
+      "sha256": "459edcf9c35137aa49cec49e3f055ba63cee79abbdb139b976c819822dee9f8f",
+      "size": 299227
     },
     {
       "path": "tm-endturn-helpers.js",
@@ -3961,8 +3961,8 @@
     },
     {
       "path": "tm-endturn-pipeline-steps.js",
-      "sha256": "b65ce05bf7fd81049fef3d538713ea99b26d7be0e8673bd4b8e2c93ede7e441d",
-      "size": 63959
+      "sha256": "3aacd4a1d30b5414b0e1f0af2648bcd2ddde30a9bc2fc21fd1cf4590b5317245",
+      "size": 63066
     },
     {
       "path": "tm-endturn-pipeline-types.js",
@@ -4226,8 +4226,8 @@
     },
     {
       "path": "tm-game-loop.js",
-      "sha256": "4b42579f3d59269415eee8db6a1546a90ffc1f3cda89ce530d910d972cee6508",
-      "size": 106034
+      "sha256": "32c2276d5d2702b75595a45affd9a7639d4f6dca889dd68e867152f0d6ff995b",
+      "size": 106627
     },
     {
       "path": "tm-game-ui-shell.js",
@@ -4591,8 +4591,8 @@
     },
     {
       "path": "tm-map-system.js",
-      "sha256": "139f14c739ab45991cea5b9c246f76c82af0ae46e86a6024ba13a3e2e6a04557",
-      "size": 88692
+      "sha256": "351c19b8e58c460a2bd3bff5dd0b611001f575ba1dc48e9e3e299830b7ca9a0b",
+      "size": 91077
     },
     {
       "path": "tm-mapeditor-fit.js",
@@ -4826,8 +4826,8 @@
     },
     {
       "path": "tm-office-editor.js",
-      "sha256": "b86b78f2c2712498a220134db57b5334878cc88e9b3082dc0ef1cc8aa74ec4e6",
-      "size": 119847
+      "sha256": "d2d801df170318bc1d9333e1ebfa631d9b1488fdd207fc128bed6c414864d0ef",
+      "size": 120965
     },
     {
       "path": "tm-office-fallback.js",
@@ -5001,8 +5001,8 @@
     },
     {
       "path": "tm-post-turn-jobs.js",
-      "sha256": "75b1618594952cdff9c343092d6ce9d0dc07fd497d5dbabeb5d5102cea90664c",
-      "size": 30838
+      "sha256": "541eece45036ab52eef199ecd4b3dbba4dd07637bdddd7bc69b58b248dfeac8d",
+      "size": 32708
     },
     {
       "path": "tm-promotion.js",
@@ -5131,8 +5131,8 @@
     },
     {
       "path": "tm-sidebar-ui.js",
-      "sha256": "c3f9964226a1917a48b5a1f3d6e45701594a988d2c6b1b8b8913fa6db84c9380",
-      "size": 61702
+      "sha256": "d0074c968d204b5e62c540deadc21c8b7262de573a482e9754afb2463113a6fd",
+      "size": 62888
     },
     {
       "path": "tm-social-foundation.js",
@@ -5156,8 +5156,8 @@
     },
     {
       "path": "tm-storage.js",
-      "sha256": "e24584dff3cdd1f64db1b8baaafea2921876265ea1ddaf0c9ecd20ed28bb1fbe",
-      "size": 24045
+      "sha256": "3f5c46b8315632880db8b9fa6012eec91c1eb416e3d212ece579f6a9c3d986c9",
+      "size": 31096
     },
     {
       "path": "tm-talent-backlash.js",

--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-19T05:50:48.150Z",
+  "generatedAt": "2026-08-19T05:58:56.534Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -3936,8 +3936,8 @@
     },
     {
       "path": "tm-endturn-followup.js",
-      "sha256": "459edcf9c35137aa49cec49e3f055ba63cee79abbdb139b976c819822dee9f8f",
-      "size": 299227
+      "sha256": "a83e8788d52e95608f670078881794f2379471e26f14eaf7371347f87bb5c867",
+      "size": 298856
     },
     {
       "path": "tm-endturn-helpers.js",
@@ -4591,8 +4591,8 @@
     },
     {
       "path": "tm-map-system.js",
-      "sha256": "351c19b8e58c460a2bd3bff5dd0b611001f575ba1dc48e9e3e299830b7ca9a0b",
-      "size": 91077
+      "sha256": "8545c876666670699672a93b317bc917b0716076064ed49ae6b6fb79522e844b",
+      "size": 91150
     },
     {
       "path": "tm-mapeditor-fit.js",

--- a/web/editor-details.js
+++ b/web/editor-details.js
@@ -34,12 +34,18 @@
 (function(){
   'use strict';
   if (typeof window === 'undefined') return;
+  function _edEsc(value) {
+    if (typeof escHtml === 'function') return escHtml(String(value == null ? '' : value));
+    return String(value == null ? '' : value)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
 
   // 角色详细编辑（覆盖简版） - 含五维滑块
   window.editChr = function(i){
     var ch=P.characters[i];
     var ss=Object.entries(ch.stats||{}).map(function(e){return e[0]+":"+e[1];}).join(",");
-    function sl(label,key,val){return '<div class="slider-group"><label>'+label+'</label><input type="range" min="0" max="100" value="'+val+'" id="chr-sl-'+key+'" oninput="this.nextElementSibling.textContent=this.value"><span class="slider-val">'+val+'</span></div>';}
+    function sl(label,key,val){return '<div class="slider-group"><label>'+_edEsc(label)+'</label><input type="range" min="0" max="100" value="'+_edEsc(val)+'" id="chr-sl-'+_edEsc(key)+'" oninput="this.nextElementSibling.textContent=this.value"><span class="slider-val">'+_edEsc(val)+'</span></div>';}
     var sliders=sl("忠诚","loyalty",ch.loyalty!=null?ch.loyalty:70)+
       sl("士气","morale",ch.morale!=null?ch.morale:70)+
       sl("野心","ambition",ch.ambition!=null?ch.ambition:50)+
@@ -50,22 +56,22 @@
       sl("政务","administration",ch.administration!=null?ch.administration:50)+
       sl("魅力","charisma",ch.charisma!=null?ch.charisma:50)+
       sl("外交","diplomacy",ch.diplomacy!=null?ch.diplomacy:50);
-    _$("em").innerHTML="<div class=\"cd\"><h4>编辑角色: "+ch.name+"</h4>"+
-      "<div class=\"rw\"><div class=\"fd\"><label>名称</label><input id=\"chr-ed-name\" value=\""+ch.name+"\"></div><div class=\"fd\"><label>头衔</label><input id=\"chr-ed-title\" value=\""+ch.title+"\"></div><div class=\"fd\"><label>阵营</label><input id=\"chr-ed-faction\" value=\""+(ch.faction||"")+"\"></div></div>"+
-      "<div class=\"rw\"><div class=\"fd\"><label>立场</label><input id=\"chr-ed-stance\" value=\""+(ch.stance||"")+"\"></div><div class=\"fd q\"><label>年龄</label><input type=\"number\" id=\"chr-ed-age\" value=\""+(ch.age||30)+"\"></div><div class=\"fd q\"><label>性别</label><select id=\"chr-ed-gender\"><option "+(ch.gender==="男"?"selected":"")+">男</option><option "+(ch.gender==="女"?"selected":"")+">女</option></select></div><div class=\"fd q\"><label>类型</label><select id=\"chr-ed-hist\"><option value=\"false\" "+(ch.isHistorical?"":"selected")+">虚构</option><option value=\"true\" "+(ch.isHistorical?"selected":"")+">历史名臣</option></select></div></div>"+
+    _$("em").innerHTML="<div class=\"cd\"><h4>编辑角色: "+_edEsc(ch.name)+"</h4>"+
+      "<div class=\"rw\"><div class=\"fd\"><label>名称</label><input id=\"chr-ed-name\" value=\""+_edEsc(ch.name)+"\"></div><div class=\"fd\"><label>头衔</label><input id=\"chr-ed-title\" value=\""+_edEsc(ch.title)+"\"></div><div class=\"fd\"><label>阵营</label><input id=\"chr-ed-faction\" value=\""+_edEsc(ch.faction||"")+"\"></div></div>"+
+      "<div class=\"rw\"><div class=\"fd\"><label>立场</label><input id=\"chr-ed-stance\" value=\""+_edEsc(ch.stance||"")+"\"></div><div class=\"fd q\"><label>年龄</label><input type=\"number\" id=\"chr-ed-age\" value=\""+_edEsc(ch.age||30)+"\"></div><div class=\"fd q\"><label>性别</label><select id=\"chr-ed-gender\"><option "+(ch.gender==="男"?"selected":"")+">男</option><option "+(ch.gender==="女"?"selected":"")+">女</option></select></div><div class=\"fd q\"><label>类型</label><select id=\"chr-ed-hist\"><option value=\"false\" "+(ch.isHistorical?"":"selected")+">虚构</option><option value=\"true\" "+(ch.isHistorical?"selected":"")+">历史名臣</option></select></div></div>"+
       "<div style=\"background:var(--bg-3);border:1px solid var(--bdr);border-radius:8px;padding:0.6rem;margin:0.5rem 0;\"><div style=\"font-size:0.85rem;font-weight:700;color:var(--gold);margin-bottom:0.3rem;\">五维属性</div>"+sliders+"</div>"+
-      "<div class=\"fd full\"><label>描述</label><textarea rows=\"2\" id=\"chr-ed-desc\">"+ch.desc+"</textarea></div>"+
-      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>性格</label><textarea rows=\"2\" id=\"chr-ed-personality\">"+(ch.personality||"")+"</textarea></div>"+
-      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>外貌</label><input id=\"chr-ed-appearance\" value=\""+(ch.appearance||"")+"\"></div>"+
-      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>属性(k:v,k:v)</label><input id=\"chr-ed-stats\" value=\""+ss+"\"></div>"+
-      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>技能(逗号)</label><input id=\"chr-ed-skills\" value=\""+(ch.skills||[]).join(",")+"\"></div>"+
-      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>台词(每行)</label><textarea rows=\"2\" id=\"chr-ed-dialogues\">"+(ch.dialogues||[]).join("\n")+"</textarea></div>"+
-      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>秘密目标</label><input id=\"chr-ed-secret\" value=\""+(ch.secret||"")+"\"></div>"+
+      "<div class=\"fd full\"><label>描述</label><textarea rows=\"2\" id=\"chr-ed-desc\">"+_edEsc(ch.desc)+"</textarea></div>"+
+      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>性格</label><textarea rows=\"2\" id=\"chr-ed-personality\">"+_edEsc(ch.personality||"")+"</textarea></div>"+
+      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>外貌</label><input id=\"chr-ed-appearance\" value=\""+_edEsc(ch.appearance||"")+"\"></div>"+
+      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>属性(k:v,k:v)</label><input id=\"chr-ed-stats\" value=\""+_edEsc(ss)+"\"></div>"+
+      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>技能(逗号)</label><input id=\"chr-ed-skills\" value=\""+_edEsc((ch.skills||[]).join(","))+"\"></div>"+
+      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>台词(每行)</label><textarea rows=\"2\" id=\"chr-ed-dialogues\">"+_edEsc((ch.dialogues||[]).join("\n"))+"</textarea></div>"+
+      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>秘密目标</label><input id=\"chr-ed-secret\" value=\""+_edEsc(ch.secret||"")+"\"></div>"+
       "<hr class=\"dv\"><div style=\"font-size:0.88rem;font-weight:700;color:var(--purple);margin-bottom:0.5rem;\">AI深度设定</div>"+
-      "<div class=\"fd full\"><label>AI人设文本</label><textarea rows=\"3\" id=\"chr-ed-aiPersona\" placeholder=\"详细描述供AI判断角色行为\">"+(ch.aiPersonaText||"")+"</textarea></div>"+
-      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>行为模式</label><textarea rows=\"2\" id=\"chr-ed-behavior\" placeholder=\"AI如何决定行动\">"+(ch.behaviorMode||"")+"</textarea></div>"+
-      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>价值观</label><textarea rows=\"2\" id=\"chr-ed-values\">"+(ch.valueSystem||"")+"</textarea></div>"+
-      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>说话风格</label><textarea rows=\"2\" id=\"chr-ed-speech\">"+(ch.speechStyle||"")+"</textarea></div>"+
+      "<div class=\"fd full\"><label>AI人设文本</label><textarea rows=\"3\" id=\"chr-ed-aiPersona\" placeholder=\"详细描述供AI判断角色行为\">"+_edEsc(ch.aiPersonaText||"")+"</textarea></div>"+
+      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>行为模式</label><textarea rows=\"2\" id=\"chr-ed-behavior\" placeholder=\"AI如何决定行动\">"+_edEsc(ch.behaviorMode||"")+"</textarea></div>"+
+      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>价值观</label><textarea rows=\"2\" id=\"chr-ed-values\">"+_edEsc(ch.valueSystem||"")+"</textarea></div>"+
+      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>说话风格</label><textarea rows=\"2\" id=\"chr-ed-speech\">"+_edEsc(ch.speechStyle||"")+"</textarea></div>"+
       "<button class=\"bt bp\" onclick=\"saveChrEdit("+i+")\" style=\"margin-top:0.5rem;\">完成</button></div>";
   };
 
@@ -104,16 +110,16 @@
     em.innerHTML="<h4 style=\"color:var(--gold);\">物品/科技/政策 ("+list.length+")</h4>"+
       "<div style=\"display:flex;gap:0.3rem;margin-bottom:0.8rem;\"><button class=\"bt bp bsm\" onclick=\"P.items.push({sid:editingScenarioId,name:'新',type:'item',desc:'',effect:{},prereq:'',acquired:false});renderEdTab('t-itm');\">＋物品</button><button class=\"bt bp bsm\" onclick=\"P.items.push({sid:editingScenarioId,name:'新',type:'tech',desc:'',effect:{},prereq:'',acquired:false});renderEdTab('t-itm');\">＋科技</button><button class=\"bt bp bsm\" onclick=\"P.items.push({sid:editingScenarioId,name:'新',type:'policy',desc:'',effect:{},prereq:'',acquired:false});renderEdTab('t-itm');\">＋政策</button><button class=\"bai\" onclick=\"aiGenItems()\">🤖</button></div>"+
       list.map(function(t){var i=P.items.indexOf(t);var eff=Object.entries(t.effect||{}).map(function(e){return(e[1]>0?"+":"")+e[1]+" "+e[0];}).join(", ");
-        return "<div class=\"cd\"><div style=\"display:flex;justify-content:space-between;\"><div><span class=\"tg\">"+t.type+"</span> <strong>"+t.name+"</strong></div><div><button class=\"bs bsm\" onclick=\"editItm("+i+")\">编辑</button> <button class=\"bd bsm\" onclick=\"P.items.splice("+i+",1);renderEdTab('t-itm');\">✕</button></div></div><div style=\"font-size:0.78rem;color:var(--txt-s);\">"+t.desc+"</div>"+(eff?"<div style=\"margin-top:0.2rem;\">"+eff+"</div>":"")+(t.prereq?"<div style=\"font-size:0.7rem;color:var(--txt-d);\">前置: "+t.prereq+"</div>":"")+"</div>";}).join("")||"<div style=\"color:var(--txt-d);\">暂无</div>";
+        return "<div class=\"cd\"><div style=\"display:flex;justify-content:space-between;\"><div><span class=\"tg\">"+_edEsc(t.type)+"</span> <strong>"+_edEsc(t.name)+"</strong></div><div><button class=\"bs bsm\" onclick=\"editItm("+i+")\">编辑</button> <button class=\"bd bsm\" onclick=\"P.items.splice("+i+",1);renderEdTab('t-itm');\">✕</button></div></div><div style=\"font-size:0.78rem;color:var(--txt-s);\">"+_edEsc(t.desc)+"</div>"+(eff?"<div style=\"margin-top:0.2rem;\">"+_edEsc(eff)+"</div>":"")+(t.prereq?"<div style=\"font-size:0.7rem;color:var(--txt-d);\">前置: "+_edEsc(t.prereq)+"</div>":"")+"</div>";}).join("")||"<div style=\"color:var(--txt-d);\">暂无</div>";
   };
 
   window.editItm = function(i){
     var t=P.items[i];var effStr=Object.entries(t.effect||{}).map(function(e){return e[0]+":"+e[1];}).join(",");
     _$("em").innerHTML="<div class=\"cd\"><h4>编辑</h4>"+
-      "<div class=\"rw\"><div class=\"fd\"><label>名称</label><input value=\""+t.name+"\" onchange=\"P.items["+i+"].name=this.value\"></div><div class=\"fd q\"><label>类型</label><select onchange=\"P.items["+i+"].type=this.value\"><option "+(t.type==="item"?"selected":"")+">物品</option><option value=\"tech\" "+(t.type==="tech"?"selected":"")+">科技</option><option value=\"policy\" "+(t.type==="policy"?"selected":"")+">政策</option></select></div></div>"+
-      "<div class=\"fd full\"><label>描述</label><textarea rows=\"3\" onchange=\"P.items["+i+"].desc=this.value\">"+t.desc+"</textarea></div>"+
-      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>效果(变量:值,逗号)</label><input value=\""+effStr+"\" onchange=\"var o={};this.value.split(',').forEach(function(p){var kv=p.split(':');if(kv[0]&&kv[1])o[kv[0].trim()]=parseInt(kv[1])||0;});P.items["+i+"].effect=o;\"></div>"+
-      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>前置条件</label><input value=\""+(t.prereq||"")+"\" onchange=\"P.items["+i+"].prereq=this.value\" placeholder=\"如: 变法支持>50\"></div>"+
+      "<div class=\"rw\"><div class=\"fd\"><label>名称</label><input value=\""+_edEsc(t.name)+"\" onchange=\"P.items["+i+"].name=this.value\"></div><div class=\"fd q\"><label>类型</label><select onchange=\"P.items["+i+"].type=this.value\"><option "+(t.type==="item"?"selected":"")+">物品</option><option value=\"tech\" "+(t.type==="tech"?"selected":"")+">科技</option><option value=\"policy\" "+(t.type==="policy"?"selected":"")+">政策</option></select></div></div>"+
+      "<div class=\"fd full\"><label>描述</label><textarea rows=\"3\" onchange=\"P.items["+i+"].desc=this.value\">"+_edEsc(t.desc)+"</textarea></div>"+
+      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>效果(变量:值,逗号)</label><input value=\""+_edEsc(effStr)+"\" onchange=\"var o={};this.value.split(',').forEach(function(p){var kv=p.split(':');if(kv[0]&&kv[1])o[kv[0].trim()]=parseInt(kv[1])||0;});P.items["+i+"].effect=o;\"></div>"+
+      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>前置条件</label><input value=\""+_edEsc(t.prereq||"")+"\" onchange=\"P.items["+i+"].prereq=this.value\" placeholder=\"如: 变法支持>50\"></div>"+
       "<button class=\"bt bp\" onclick=\"renderEdTab('t-itm');toast('已保存')\" style=\"margin-top:0.5rem;\">完成</button></div>";
   };
 
@@ -147,11 +153,11 @@
     em.innerHTML="<h4 style=\"color:var(--gold);\">规则 ("+list.length+")</h4>"+
       "<div style=\"display:flex;gap:0.3rem;margin-bottom:0.8rem;\"><button class=\"bt bp\" onclick=\"P.rules.push({sid:editingScenarioId,name:'新',enabled:true,trigger:{type:'threshold',variable:'',op:'<',value:20},effect:{narrative:'',varChg:{},event:null}});renderEdTab('t-rul');\">＋</button><button class=\"bai\" onclick=\"aiGenRules()\">🤖</button></div>"+
       list.map(function(r){var i=P.rules.indexOf(r);var t=r.trigger;
-        return "<div class=\"cd\" style=\"border-left:3px solid "+(r.enabled?"var(--green)":"var(--red)")+"\"><div style=\"display:flex;justify-content:space-between;margin-bottom:0.3rem;\"><div style=\"display:flex;gap:0.3rem;align-items:center;\"><input type=\"checkbox\" "+(r.enabled?"checked":"")+" onchange=\"P.rules["+i+"].enabled=this.checked;renderEdTab('t-rul');\"><input value=\""+r.name+"\" style=\"background:transparent;border:none;color:var(--txt);font-weight:700;\" onchange=\"P.rules["+i+"].name=this.value\"></div><button class=\"bd bsm\" onclick=\"P.rules.splice("+i+",1);renderEdTab('t-rul');\">✕</button></div>"+
+        return "<div class=\"cd\" style=\"border-left:3px solid "+(r.enabled?"var(--green)":"var(--red)")+"\"><div style=\"display:flex;justify-content:space-between;margin-bottom:0.3rem;\"><div style=\"display:flex;gap:0.3rem;align-items:center;\"><input type=\"checkbox\" "+(r.enabled?"checked":"")+" onchange=\"P.rules["+i+"].enabled=this.checked;renderEdTab('t-rul');\"><input value=\""+_edEsc(r.name)+"\" style=\"background:transparent;border:none;color:var(--txt);font-weight:700;\" onchange=\"P.rules["+i+"].name=this.value\"></div><button class=\"bd bsm\" onclick=\"P.rules.splice("+i+",1);renderEdTab('t-rul');\">✕</button></div>"+
         "<div style=\"background:var(--bg-1);border-radius:4px;padding:0.4rem;font-size:0.8rem;\"><select onchange=\"P.rules["+i+"].trigger.type=this.value;renderEdTab('t-rul');\"><option value=\"threshold\" "+(t.type==="threshold"?"selected":"")+">阈值</option><option value=\"keyword\" "+(t.type==="keyword"?"selected":"")+">关键词</option><option value=\"turn\" "+(t.type==="turn"?"selected":"")+">回合</option><option value=\"random\" "+(t.type==="random"?"selected":"")+">随机</option></select>"+
-        (t.type==="threshold"?" <select onchange=\"P.rules["+i+"].trigger.variable=this.value\">"+vn.map(function(n){return "<option "+(t.variable===n?"selected":"")+">"+n+"</option>";}).join("")+"</select><select onchange=\"P.rules["+i+"].trigger.op=this.value\"><option "+(t.op==="<"?"selected":"")+">&lt;</option><option "+(t.op===">"?"selected":"")+">&gt;</option></select><input type=\"number\" value=\""+(t.value||0)+"\" style=\"width:45px;\" onchange=\"P.rules["+i+"].trigger.value=+this.value\">":"")+
-        (t.type==="keyword"?"<input value=\""+(t.keywords||[]).join(",")+"\" placeholder=\"关键词,逗号\" onchange=\"P.rules["+i+"].trigger.keywords=this.value.split(',').map(function(s){return s.trim();})\">":"")+
-        "</div><div style=\"background:var(--bg-1);border-radius:4px;padding:0.4rem;margin-top:0.3rem;\"><label style=\"font-size:0.72rem;color:var(--txt-d);\">触发效果</label><textarea rows=\"2\" style=\"width:100%;\" onchange=\"P.rules["+i+"].effect.narrative=this.value\">"+(r.effect.narrative||"")+"</textarea></div></div>";}).join("");
+        (t.type==="threshold"?" <select onchange=\"P.rules["+i+"].trigger.variable=this.value\">"+vn.map(function(n){return "<option "+(t.variable===n?"selected":"")+">"+_edEsc(n)+"</option>";}).join("")+"</select><select onchange=\"P.rules["+i+"].trigger.op=this.value\"><option "+(t.op==="<"?"selected":"")+">&lt;</option><option "+(t.op===">"?"selected":"")+">&gt;</option></select><input type=\"number\" value=\""+_edEsc(t.value||0)+"\" style=\"width:45px;\" onchange=\"P.rules["+i+"].trigger.value=+this.value\">":"")+
+        (t.type==="keyword"?"<input value=\""+_edEsc((t.keywords||[]).join(","))+"\" placeholder=\"关键词,逗号\" onchange=\"P.rules["+i+"].trigger.keywords=this.value.split(',').map(function(s){return s.trim();})\">":"")+
+        "</div><div style=\"background:var(--bg-1);border-radius:4px;padding:0.4rem;margin-top:0.3rem;\"><label style=\"font-size:0.72rem;color:var(--txt-d);\">触发效果</label><textarea rows=\"2\" style=\"width:100%;\" onchange=\"P.rules["+i+"].effect.narrative=this.value\">"+_edEsc(r.effect.narrative||"")+"</textarea></div></div>";}).join("");
   };
 
   window.aiGenRules = async function(){
@@ -176,7 +182,7 @@
     var list=P.events.filter(function(e){return e.sid===sid;});
     em.innerHTML="<h4 style=\"color:var(--gold);\">事件 ("+list.length+")</h4>"+
       "<div style=\"display:flex;gap:0.3rem;margin-bottom:0.8rem;\"><button class=\"bt bp\" onclick=\"P.events.push({sid:editingScenarioId,id:uid(),name:'新',type:'scripted',triggerTurn:0,oneTime:true,triggered:false,narrative:'',choices:[]});renderEdTab('t-evt');\">＋</button><button class=\"bai\" onclick=\"aiGenEvents()\">🤖</button></div>"+
-      list.map(function(ev){var i=P.events.indexOf(ev);return "<div class=\"cd\"><div style=\"display:flex;justify-content:space-between;\"><strong>"+ev.name+"</strong><div><button class=\"bs bsm\" onclick=\"editEvt("+i+")\">编辑</button> <button class=\"bd bsm\" onclick=\"P.events.splice("+i+",1);renderEdTab('t-evt');\">✕</button></div></div><div style=\"font-size:0.78rem;color:var(--txt-s);\">"+(ev.narrative||"").slice(0,60)+"…</div>"+(ev.choices&&ev.choices.length?"<div style=\"font-size:0.7rem;color:var(--txt-d);\">"+ev.choices.length+" 选项</div>":"")+"</div>";}).join("");
+      list.map(function(ev){var i=P.events.indexOf(ev);return "<div class=\"cd\"><div style=\"display:flex;justify-content:space-between;\"><strong>"+_edEsc(ev.name)+"</strong><div><button class=\"bs bsm\" onclick=\"editEvt("+i+")\">编辑</button> <button class=\"bd bsm\" onclick=\"P.events.splice("+i+",1);renderEdTab('t-evt');\">✕</button></div></div><div style=\"font-size:0.78rem;color:var(--txt-s);\">"+_edEsc((ev.narrative||"").slice(0,60))+"…</div>"+(ev.choices&&ev.choices.length?"<div style=\"font-size:0.7rem;color:var(--txt-d);\">"+ev.choices.length+" 选项</div>":"")+"</div>";}).join("");
   };
 
   window.aiGenEvents = async function(){
@@ -202,7 +208,7 @@
     var list=P.factions.filter(function(f){return f.sid===sid;});
     em.innerHTML="<h4 style=\"color:var(--gold);\">党派 ("+list.length+")</h4>"+
       "<div style=\"display:flex;gap:0.3rem;margin-bottom:0.8rem;\"><button class=\"bt bp\" onclick=\"P.factions.push({sid:editingScenarioId,name:'新',leader:'',desc:'',color:'#888',traits:[],strength:50,territory:'',ideology:'',courtInfluence:50,popularInfluence:30,members:'',partyRelations:''});renderEdTab('t-fac');\">＋</button><button class=\"bai\" onclick=\"aiGenFac()\">🤖</button></div>"+
-      list.map(function(f){var i=P.factions.indexOf(f);return "<div class=\"cd\"><div style=\"display:flex;justify-content:space-between;\"><strong>"+f.name+"</strong><div><button class=\"bs bsm\" onclick=\"editFac("+i+")\">编辑</button> <button class=\"bd bsm\" onclick=\"P.factions.splice("+i+",1);renderEdTab('t-fac');\">✕</button></div></div><div style=\"font-size:0.78rem;color:var(--txt-s);\">"+f.desc+"</div></div>";}).join("")||"<div style=\"color:var(--txt-d);\">暂无</div>";
+      list.map(function(f){var i=P.factions.indexOf(f);return "<div class=\"cd\"><div style=\"display:flex;justify-content:space-between;\"><strong>"+_edEsc(f.name)+"</strong><div><button class=\"bs bsm\" onclick=\"editFac("+i+")\">编辑</button> <button class=\"bd bsm\" onclick=\"P.factions.splice("+i+",1);renderEdTab('t-fac');\">✕</button></div></div><div style=\"font-size:0.78rem;color:var(--txt-s);\">"+_edEsc(f.desc)+"</div></div>";}).join("")||"<div style=\"color:var(--txt-d);\">暂无</div>";
   };
 
   // 阶层详细编辑
@@ -210,17 +216,17 @@
     var list=P.classes.filter(function(c){return c.sid===sid;});
     em.innerHTML="<h4 style=\"color:var(--gold);\">阶层 ("+list.length+")</h4>"+
       "<div style=\"display:flex;gap:0.3rem;margin-bottom:0.8rem;\"><button class=\"bt bp\" onclick=\"P.classes.push({sid:editingScenarioId,name:'新',desc:'',privileges:'',restrictions:'',population:'',influence:50});renderEdTab('t-class');\">＋</button><button class=\"bai\" onclick=\"aiGenClasses()\">🤖</button></div>"+
-      list.map(function(c){var i=P.classes.indexOf(c);return "<div class=\"cd\"><div style=\"display:flex;justify-content:space-between;\"><strong>"+c.name+"</strong><div><button class=\"bs bsm\" onclick=\"editClass2("+i+")\">编辑</button> <button class=\"bd bsm\" onclick=\"P.classes.splice("+i+",1);renderEdTab('t-class');\">✕</button></div></div><div style=\"font-size:0.78rem;color:var(--txt-s);\">"+c.desc+" | 影响:"+c.influence+"</div></div>";}).join("")||"<div style=\"color:var(--txt-d);\">暂无</div>";
+      list.map(function(c){var i=P.classes.indexOf(c);return "<div class=\"cd\"><div style=\"display:flex;justify-content:space-between;\"><strong>"+_edEsc(c.name)+"</strong><div><button class=\"bs bsm\" onclick=\"editClass2("+i+")\">编辑</button> <button class=\"bd bsm\" onclick=\"P.classes.splice("+i+",1);renderEdTab('t-class');\">✕</button></div></div><div style=\"font-size:0.78rem;color:var(--txt-s);\">"+_edEsc(c.desc)+" | 影响:"+_edEsc(c.influence)+"</div></div>";}).join("")||"<div style=\"color:var(--txt-d);\">暂无</div>";
   };
 
   window.editClass2 = function(i){
     var c=P.classes[i];
     _$("em").innerHTML="<div class=\"cd\"><h4>编辑阶层</h4>"+
-      "<div class=\"rw\"><div class=\"fd\"><label>名称</label><input value=\""+c.name+"\" onchange=\"P.classes["+i+"].name=this.value\"></div><div class=\"fd q\"><label>影响力</label><input type=\"number\" value=\""+c.influence+"\" onchange=\"P.classes["+i+"].influence=+this.value\"></div></div>"+
-      "<div class=\"fd full\"><label>描述</label><textarea rows=\"2\" onchange=\"P.classes["+i+"].desc=this.value\">"+c.desc+"</textarea></div>"+
-      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>特权</label><textarea rows=\"2\" onchange=\"P.classes["+i+"].privileges=this.value\">"+(c.privileges||"")+"</textarea></div>"+
-      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>限制</label><textarea rows=\"2\" onchange=\"P.classes["+i+"].restrictions=this.value\">"+(c.restrictions||"")+"</textarea></div>"+
-      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>人口比例</label><input value=\""+(c.population||"")+"\" onchange=\"P.classes["+i+"].population=this.value\"></div>"+
+      "<div class=\"rw\"><div class=\"fd\"><label>名称</label><input value=\""+_edEsc(c.name)+"\" onchange=\"P.classes["+i+"].name=this.value\"></div><div class=\"fd q\"><label>影响力</label><input type=\"number\" value=\""+_edEsc(c.influence)+"\" onchange=\"P.classes["+i+"].influence=+this.value\"></div></div>"+
+      "<div class=\"fd full\"><label>描述</label><textarea rows=\"2\" onchange=\"P.classes["+i+"].desc=this.value\">"+_edEsc(c.desc)+"</textarea></div>"+
+      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>特权</label><textarea rows=\"2\" onchange=\"P.classes["+i+"].privileges=this.value\">"+_edEsc(c.privileges||"")+"</textarea></div>"+
+      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>限制</label><textarea rows=\"2\" onchange=\"P.classes["+i+"].restrictions=this.value\">"+_edEsc(c.restrictions||"")+"</textarea></div>"+
+      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>人口比例</label><input value=\""+_edEsc(c.population||"")+"\" onchange=\"P.classes["+i+"].population=this.value\"></div>"+
       "<button class=\"bt bp\" onclick=\"renderEdTab('t-class');toast('已保存')\" style=\"margin-top:0.5rem;\">完成</button></div>";
   };
 
@@ -253,9 +259,9 @@
     var entries=P.world.entries.filter(function(e){return!e.sid||e.sid===sid;});
     em.innerHTML="<h4 style=\"color:var(--gold);\">世界设定</h4><div style=\"font-size:0.8rem;color:var(--txt-d);margin-bottom:0.8rem;\">自由编辑，每条可自定义分类。AI推演时全部读取。</div>"+
       "<div style=\"display:flex;gap:0.3rem;margin-bottom:0.8rem;\"><button class=\"bt bp\" onclick=\"if(!P.world.entries)P.world.entries=[];P.world.entries.push({sid:editingScenarioId,category:'新',content:'',tags:[]});renderEdTab('t-wld');\">＋ 新增</button><button class=\"bai\" onclick=\"aiGenWorld()\">🤖 AI生成</button></div>"+
-      entries.map(function(entry){var i=P.world.entries.indexOf(entry);return "<div class=\"cd\"><div style=\"display:flex;justify-content:space-between;margin-bottom:0.3rem;\"><input value=\""+(entry.category||"")+"\" placeholder=\"分类\" style=\"width:120px;font-weight:700;\" onchange=\"P.world.entries["+i+"].category=this.value\"><button class=\"bd bsm\" onclick=\"P.world.entries.splice("+i+",1);renderEdTab('t-wld');\">✕</button></div><textarea rows=\"4\" style=\"width:100%;\" onchange=\"P.world.entries["+i+"].content=this.value\">"+entry.content+"</textarea></div>";}).join("")+
+      entries.map(function(entry){var i=P.world.entries.indexOf(entry);return "<div class=\"cd\"><div style=\"display:flex;justify-content:space-between;margin-bottom:0.3rem;\"><input value=\""+_edEsc(entry.category||"")+"\" placeholder=\"分类\" style=\"width:120px;font-weight:700;\" onchange=\"P.world.entries["+i+"].category=this.value\"><button class=\"bd bsm\" onclick=\"P.world.entries.splice("+i+",1);renderEdTab('t-wld');\">✕</button></div><textarea rows=\"4\" style=\"width:100%;\" onchange=\"P.world.entries["+i+"].content=this.value\">"+_edEsc(entry.content)+"</textarea></div>";}).join("")+
       "<hr class=\"dv\"><div style=\"font-size:0.95rem;font-weight:700;color:var(--gold);margin-bottom:0.5rem;\">运行逻辑</div>"+
-      "<div class=\"fd full\"><label>世界规则</label><textarea rows=\"5\" onchange=\"P.world.rules=this.value\" placeholder=\"定义世界运作规则\">"+(P.world.rules||"")+"</textarea></div>";
+      "<div class=\"fd full\"><label>世界规则</label><textarea rows=\"5\" onchange=\"P.world.rules=this.value\" placeholder=\"定义世界运作规则\">"+_edEsc(P.world.rules||"")+"</textarea></div>";
   };
 
   window.aiGenWorld = async function(){
@@ -283,20 +289,20 @@
     em.innerHTML="<h4 style=\"color:var(--gold);\">科技树 ("+list.length+")</h4>"+
       "<div style=\"display:flex;gap:0.3rem;margin-bottom:0.8rem;\"><button class=\"bt bp\" onclick=\"P.techTree.push({sid:editingScenarioId,name:'新',desc:'',prereqs:[],costs:[],effect:{},era:'初级',unlocked:false});renderEdTab('t-tech');\">＋</button><button class=\"bai\" onclick=\"aiGenTech()\">🤖</button></div>"+
       list.map(function(t){var i=P.techTree.indexOf(t);var costStr=(t.costs||[]).map(function(c){return c.variable+":"+c.amount;}).join(", ");
-        return "<div class=\"cd\"><div style=\"display:flex;justify-content:space-between;\"><strong>"+t.name+"</strong> <span class=\"tg\">"+t.era+"</span><div><button class=\"bs bsm\" onclick=\"editTech2("+i+")\">编辑</button> <button class=\"bd bsm\" onclick=\"P.techTree.splice("+i+",1);renderEdTab('t-tech');\">✕</button></div></div><div style=\"font-size:0.78rem;color:var(--txt-s);\">"+t.desc+"</div>"+(costStr?"<div style=\"font-size:0.7rem;color:var(--txt-d);\">消耗: "+costStr+"</div>":"")+"</div>";}).join("")||"<div style=\"color:var(--txt-d);\">暂无</div>";
+        return "<div class=\"cd\"><div style=\"display:flex;justify-content:space-between;\"><strong>"+_edEsc(t.name)+"</strong> <span class=\"tg\">"+_edEsc(t.era)+"</span><div><button class=\"bs bsm\" onclick=\"editTech2("+i+")\">编辑</button> <button class=\"bd bsm\" onclick=\"P.techTree.splice("+i+",1);renderEdTab('t-tech');\">✕</button></div></div><div style=\"font-size:0.78rem;color:var(--txt-s);\">"+_edEsc(t.desc)+"</div>"+(costStr?"<div style=\"font-size:0.7rem;color:var(--txt-d);\">消耗: "+_edEsc(costStr)+"</div>":"")+"</div>";}).join("")||"<div style=\"color:var(--txt-d);\">暂无</div>";
   };
 
   window.editTech2 = function(i){
     var t=P.techTree[i];var sid=editingScenarioId;var vars=P.variables.filter(function(v){return v.sid===sid;});
     if(!t.costs)t.costs=[];
-    var costsHtml=t.costs.map(function(c,ci){var opts=vars.map(function(v){return "<option "+(v.name===c.variable?"selected":"")+">"+v.name+"</option>";}).join("");return "<div style=\"display:flex;gap:0.3rem;margin-bottom:0.2rem;\"><select onchange=\"P.techTree["+i+"].costs["+ci+"].variable=this.value\" style=\"flex:1;\">"+opts+"</select><input type=\"number\" value=\""+c.amount+"\" style=\"width:60px;\" onchange=\"P.techTree["+i+"].costs["+ci+"].amount=+this.value\"><button class=\"bd bsm\" onclick=\"P.techTree["+i+"].costs.splice("+ci+",1);editTech2("+i+");\">✕</button></div>";}).join("");
+    var costsHtml=t.costs.map(function(c,ci){var opts=vars.map(function(v){return "<option "+(v.name===c.variable?"selected":"")+">"+_edEsc(v.name)+"</option>";}).join("");return "<div style=\"display:flex;gap:0.3rem;margin-bottom:0.2rem;\"><select onchange=\"P.techTree["+i+"].costs["+ci+"].variable=this.value\" style=\"flex:1;\">"+opts+"</select><input type=\"number\" value=\""+_edEsc(c.amount)+"\" style=\"width:60px;\" onchange=\"P.techTree["+i+"].costs["+ci+"].amount=+this.value\"><button class=\"bd bsm\" onclick=\"P.techTree["+i+"].costs.splice("+ci+",1);editTech2("+i+");\">✕</button></div>";}).join("");
     _$("em").innerHTML="<div class=\"cd\"><h4>编辑科技</h4>"+
-      "<div class=\"rw\"><div class=\"fd\"><label>名称</label><input value=\""+t.name+"\" onchange=\"P.techTree["+i+"].name=this.value\"></div><div class=\"fd q\"><label>时代</label><select onchange=\"P.techTree["+i+"].era=this.value\"><option "+(t.era==="初级"?"selected":"")+">初级</option><option "+(t.era==="中级"?"selected":"")+">中级</option><option "+(t.era==="高级"?"selected":"")+">高级</option></select></div></div>"+
-      "<div class=\"fd full\"><label>描述</label><textarea rows=\"2\" onchange=\"P.techTree["+i+"].desc=this.value\">"+t.desc+"</textarea></div>"+
-      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>前置(逗号)</label><input value=\""+(t.prereqs||[]).join(",")+"\" onchange=\"P.techTree["+i+"].prereqs=this.value.split(',').map(function(s){return s.trim();}).filter(Boolean)\"></div>"+
-      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>效果(变量:值)</label><input value=\""+Object.entries(t.effect||{}).map(function(e){return e[0]+":"+e[1];}).join(",")+"\" onchange=\"var o={};this.value.split(',').forEach(function(p){var kv=p.split(':');if(kv[0]&&kv[1])o[kv[0].trim()]=parseInt(kv[1])||0;});P.techTree["+i+"].effect=o;\"></div>"+
+      "<div class=\"rw\"><div class=\"fd\"><label>名称</label><input value=\""+_edEsc(t.name)+"\" onchange=\"P.techTree["+i+"].name=this.value\"></div><div class=\"fd q\"><label>时代</label><select onchange=\"P.techTree["+i+"].era=this.value\"><option "+(t.era==="初级"?"selected":"")+">初级</option><option "+(t.era==="中级"?"selected":"")+">中级</option><option "+(t.era==="高级"?"selected":"")+">高级</option></select></div></div>"+
+      "<div class=\"fd full\"><label>描述</label><textarea rows=\"2\" onchange=\"P.techTree["+i+"].desc=this.value\">"+_edEsc(t.desc)+"</textarea></div>"+
+      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>前置(逗号)</label><input value=\""+_edEsc((t.prereqs||[]).join(","))+"\" onchange=\"P.techTree["+i+"].prereqs=this.value.split(',').map(function(s){return s.trim();}).filter(Boolean)\"></div>"+
+      "<div class=\"fd full\" style=\"margin-top:0.3rem;\"><label>效果(变量:值)</label><input value=\""+_edEsc(Object.entries(t.effect||{}).map(function(e){return e[0]+":"+e[1];}).join(","))+"\" onchange=\"var o={};this.value.split(',').forEach(function(p){var kv=p.split(':');if(kv[0]&&kv[1])o[kv[0].trim()]=parseInt(kv[1])||0;});P.techTree["+i+"].effect=o;\"></div>"+
       "<hr class=\"dv\"><div style=\"font-weight:700;color:var(--gold);margin-bottom:0.3rem;\">解锁消耗</div>"+costsHtml+
-      "<button class=\"bt bs bsm\" onclick=\"P.techTree["+i+"].costs.push({variable:'"+(vars[0]?vars[0].name:"")+"',amount:10});editTech2("+i+");\">＋ 添加</button>"+
+      "<button class=\"bt bs bsm\" onclick=\"var _v=(P.variables||[]).filter(function(v){return v.sid===editingScenarioId;})[0];P.techTree["+i+"].costs.push({variable:_v?_v.name:'',amount:10});editTech2("+i+");\">＋ 添加</button>"+
       "<br><button class=\"bt bp\" onclick=\"renderEdTab('t-tech');toast('已保存')\" style=\"margin-top:0.5rem;\">完成</button></div>";
   };
 

--- a/web/map-display.js
+++ b/web/map-display.js
@@ -276,9 +276,14 @@ function showProvinceDetails(region) {
  * 在游戏主界面显示地图
  */
 function showMapInGame() {
-    // R107·AI 地理志模式 P.map.enabled===false 时直接归为无数据·占位提示
-    var isAIGeo = (P.map && P.map.enabled === false) || (typeof GM !== 'undefined' && GM._useAIGeo === true);
-    var hasMapData = !isAIGeo && P.map && P.map.regions && P.map.regions.length > 0;
+    // 游戏内地图必须读取运行态；P 仅在尚未创建 GM 地图时作为兼容回退。
+    var liveMap = typeof getLiveMapData === 'function'
+        ? getLiveMapData()
+        : ((typeof GM !== 'undefined' && GM && (GM.mapData || GM.map)) ||
+            (typeof P !== 'undefined' && P && (P.mapData || P.map)) || null);
+    // R107·AI 地理志模式 enabled===false 时直接归为无数据·占位提示
+    var isAIGeo = (liveMap && liveMap.enabled === false) || (typeof GM !== 'undefined' && GM._useAIGeo === true);
+    var hasMapData = !isAIGeo && liveMap && Array.isArray(liveMap.regions) && liveMap.regions.length > 0;
 
     // 2.4方案B：无数据时显示占位提示而非alert
     if (!hasMapData) {
@@ -332,7 +337,7 @@ function showMapInGame() {
         const mode = document.getElementById('game-map-mode').value;
         const showLabels = document.getElementById('game-map-labels').checked;
 
-        renderGameMap('game-map-canvas', P.map, {
+        renderGameMap('game-map-canvas', liveMap, {
             displayMode: mode,
             showLabels: showLabels,
             onProvinceClick: function(region) {

--- a/web/scripts/smoke-ai-writeback-integrity.js
+++ b/web/scripts/smoke-ai-writeback-integrity.js
@@ -183,6 +183,33 @@ async function main() {
   check(typeMismatch.applied.failed.filter((row) => /type does not match existing schema/.test(row.reason || '')).length === 3,
     'each schema type mismatch must be visible in applied.failed');
 
+  // B4. 粗粒度类型相同也不能整体覆盖结构；否则完整人物→{}、战争数组→畸形数组仍可绕过领域 sink。
+  ctx.GM = baseGM({
+    chars: [{ name: '真人', id: 'char-real', alive: true, loyalty: 60 }],
+    activeWars: [{ id: 'war-1', attacker: '甲', defender: '乙', status: 'active' }],
+    custom: { score: 40, settings: { enabled: true, nested: { level: 1 } } }
+  });
+  const structuralMismatch = ctx.applyAITurnChanges({
+    changes: [
+      { path: 'custom.score', op: 'delta', delta: 5, reason: '合法兄弟项也须回滚' },
+      { path: 'chars.真人', op: 'set', value: {} },
+      { path: 'activeWars', op: 'set', value: [{ wrongField: true }] },
+      { path: 'custom.settings', op: 'merge', value: { enabled: 'yes' } }
+    ]
+  });
+  check(structuralMismatch.ok === false && structuralMismatch.rolledBack === true, 'structured set/merge schema violations must reject the whole batch');
+  check(ctx.GM.custom.score === 40 && ctx.GM.chars[0].alive === true && ctx.GM.activeWars[0].id === 'war-1',
+    'structured schema rejection must restore every sibling mutation');
+  check(structuralMismatch.applied.failed.some((row) => /structured set requires/.test(row.reason || '')) &&
+    structuralMismatch.applied.failed.some((row) => /merge value type does not match/.test(row.reason || '')),
+    'structured replacement and nested merge type errors must remain observable');
+
+  const compatibleMerge = ctx.applyAITurnChanges({
+    changes: [{ path: 'custom.settings', op: 'merge', value: { enabled: false, nested: { level: 2 } } }]
+  });
+  check(compatibleMerge.ok === true && ctx.GM.custom.settings.enabled === false && ctx.GM.custom.settings.nested.level === 2,
+    'schema-compatible scalar leaf merge must remain available');
+
   // C. faction leader 与 army commander 的最终 sink 只接受真实活人，并同步所有镜像。
   ctx.GM = baseGM({
     chars: [{ name: '韩旷', id: 'char_hankuang', alive: true }, { name: '亡将', alive: false, dead: true }],

--- a/web/scripts/smoke-deepen2.js
+++ b/web/scripts/smoke-deepen2.js
@@ -30,11 +30,11 @@ ok(outNorm.indexOf('35.0%') >= 0 && outNorm.indexOf('55.0%') >= 0 && outNorm.ind
 // ══ B. 城市信息 / 粮价 / 逃户 守卫(源契约) ══
 const mapS = read('tm-map-system.js');
 ok(/_mapSystemFiniteNumberOr\(city\.population,\s*0\)\.toLocaleString\(\)/.test(mapS), '★城市人口经有限数值守卫(防 undefined/NaN.toLocaleString 污染)');
-ok(/\(city\.income\|\|0\)\.toLocaleString\(\)/.test(mapS), '城市收入 ||0 守卫');
+ok(/_mapSystemFiniteNumberOr\(city\.income,\s*0\)\.toLocaleString\(\)/.test(mapS), '城市收入经有限数值守卫（保留合法 0）');
 // 2026-07-06 驻军守卫被并行会话重构为 Number(city.garrison||0) 中转变量形(游牧机动兵力兜底改造)·断言随语义锚两形通吃
 ok(/Number\(city\.garrison \|\| 0\)/.test(mapS) || /\(city\.garrison\|\|0\)\.toLocaleString\(\)/.test(mapS), '城市驻军 ||0 守卫(直用或 Number 中转形)');
-ok(/if \(\(city\.neighbors\|\|\[\]\)\.length > 0\)/.test(mapS), '★相邻城市 ||[] 守卫(防 .length 崩)');
-ok(/\(city\.neighbors\|\|\[\]\)\.forEach/.test(mapS), '相邻城市遍历 ||[] 守卫');
+ok(/if \(neighborLabels\.length > 0\)/.test(mapS), '★相邻城市仅在安全标签非空时渲染');
+ok(/\(city\.neighbors\s*\|\|\s*\[\]\)\.forEach/.test(mapS), '相邻城市遍历 ||[] 守卫');
 
 const econ = (read('tm-economy-engine-currency.js') + '\n' + read('tm-economy-engine.js'));
 ok((econ.match(/Math\.max\(0\.5, m\.yearFortune/g) || []).length === 2, '★粮价行加 Math.max(0.5,yearFortune) 守卫(与通胀行一致·共2处)');

--- a/web/scripts/smoke-edict-npc-atomicity.js
+++ b/web/scripts/smoke-edict-npc-atomicity.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.resolve(__dirname, '..');
+const edictSource = fs.readFileSync(path.join(ROOT, 'tm-endturn-edict.js'), 'utf8');
+const followupSource = fs.readFileSync(path.join(ROOT, 'tm-endturn-followup.js'), 'utf8');
+const pipelineSource = fs.readFileSync(path.join(ROOT, 'tm-endturn-pipeline-steps.js'), 'utf8');
+let assertions = 0;
+
+function check(value, label) {
+  if (!value) throw new Error('[smoke-edict-npc-atomicity] ' + label);
+  assertions += 1;
+}
+function snapshot(value) { return JSON.stringify(value); }
+
+const ctx = {
+  console,
+  Math, Date, JSON, Object, Array, Number, String, Boolean, Promise,
+  parseInt, parseFloat, isFinite, isNaN,
+  deepClone(value) { return JSON.parse(JSON.stringify(value)); },
+  clamp(value, min, max) { return Math.max(min, Math.min(max, value)); },
+  GM: {
+    turn: 9,
+    marker: 'clean',
+    chars: [{ name: '甲', loyalty: 50, officialTitle: '', position: '', careerHistory: [] }],
+    officeTree: [{ name: '中枢', positions: [{ name: '尚书', holder: '' }] }],
+    armies: [],
+    evtLog: [],
+    _turnAiResults: { subcall15: { immutable: true } }
+  },
+  P: { marker: 'template', playerInfo: { characterName: '天子', factionName: '朝廷' } },
+  addEB(type, text) { ctx.GM.evtLog.push({ type, text }); },
+  findCharByName(name) { return ctx.GM.chars.find((char) => char.name === name) || null; },
+  TM: {
+    errors: { capture() {} },
+    AIChange: {
+      Army: {
+        applyAIArmyChange(change) {
+          ctx.GM.armies.push({ name: change.name });
+          ctx.P.marker = 'partial-army';
+          throw new Error('forced-army-create-failure');
+        }
+      }
+    },
+    Endturn: { AI: { followup: {} } }
+  }
+};
+ctx.window = ctx;
+ctx.global = ctx;
+ctx.globalThis = ctx;
+vm.createContext(ctx);
+vm.runInContext(edictSource, ctx, { filename: 'tm-endturn-edict.js' });
+
+const beforeGM = snapshot(ctx.GM);
+const beforeP = snapshot(ctx.P);
+let edictError = null;
+try {
+  ctx.applyEdictActions({
+    appointments: [{ character: '甲', position: '尚书' }],
+    armyBuilds: [{ name: '新军', strength: 1000 }]
+  });
+} catch (error) { edictError = error; }
+check(edictError && /forced-army-create-failure/.test(edictError.message), 'a later edict action failure is surfaced');
+check(snapshot(ctx.GM) === beforeGM && snapshot(ctx.P) === beforeP,
+  'appointment, event log, army and template writes all roll back when the edict batch fails');
+
+ctx.TM.AIChange.Army.applyAIArmyChange = function(change) {
+  const army = { name: change.name };
+  ctx.GM.armies.push(army);
+  return { ok: true, army };
+};
+const success = ctx.applyEdictActions({
+  appointments: [{ character: '甲', position: '尚书' }],
+  armyBuilds: [{ name: '新军', strength: 1000 }]
+});
+check(success && success.ok && ctx.GM.officeTree[0].positions[0].holder === '甲' && ctx.GM.armies.length === 1,
+  'a fully valid edict batch commits all actions together');
+
+vm.runInContext(followupSource, ctx, { filename: 'tm-endturn-followup.js' });
+const atomicApply = ctx.TM.Endturn.AI.followup._applyNpcDeepResultAtomic;
+check(typeof atomicApply === 'function', 'NPC deep-result atomic helper is exported for the shared sc15/sc15n path');
+
+ctx.GM = {
+  turn: 10,
+  chars: [{ name: '乙', loyalty: 60, nested: { mood: '平' } }],
+  relations: { '乙/丙': 5 },
+  _turnAiResults: { subcall15: { parsed: 'immutable-result' } }
+};
+ctx.P = { marker: 'npc-template' };
+const npcBeforeGM = snapshot(ctx.GM);
+const npcBeforeP = snapshot(ctx.P);
+const charRef = ctx.GM.chars[0];
+let applyCalls = 0;
+const npcOutcome = atomicApply(function() {
+  applyCalls += 1;
+  ctx.GM.chars[0].loyalty = 1;
+  ctx.GM.chars[0].nested.mood = '怒';
+  ctx.GM.relations['乙/丙'] = -100;
+  ctx.P.marker = 'partial-npc';
+  throw new Error('forced-npc-apply-failure');
+}, { mood_shifts: [] });
+check(!npcOutcome.ok && applyCalls === 1, 'NPC apply failure is returned without a second model/application attempt');
+check(snapshot(ctx.GM) === npcBeforeGM && snapshot(ctx.P) === npcBeforeP,
+  'NPC mood, relationship, parsed result and P state return to the pre-apply snapshot');
+check(ctx.GM.chars[0] === charRef, 'recursive rollback preserves existing nested object identity for concurrent readers');
+
+const postStart = pipelineSource.indexOf("name: 'post-ai-edict'");
+const postEnd = pipelineSource.indexOf("name: 'systems'", postStart);
+const postSlice = pipelineSource.slice(postStart, postEnd);
+check(postStart >= 0 && postEnd > postStart && /onError:\s*'abort'/.test(postSlice) && !/catch\s*\(/.test(postSlice),
+  'post-ai-edict no longer converts state-mutating failures into a successful pipeline step');
+
+console.log('[smoke-edict-npc-atomicity] PASS assertions=' + assertions);

--- a/web/scripts/smoke-endturn-transaction-failures.js
+++ b/web/scripts/smoke-endturn-transaction-failures.js
@@ -41,6 +41,7 @@ const ctx = {
 };
 ctx.window = ctx;
 vm.createContext(ctx);
+vm.runInContext(sourceBetween(coreSource, 'async function _tmRunCriticalEndTurnSystem', 'async function _runPreSubmitPartyClassCalibration'), ctx);
 vm.runInContext(sourceBetween(coreSource, 'async function _runPreSubmitPartyClassCalibration()', 'async function _endTurnInternal'), ctx);
 vm.runInContext(sourceBetween(coreSource, 'function _tmCaptureEndTurnObject', 'async function _tmFinalizeEndTurnTransaction'), ctx);
 vm.runInContext(systemsSource, ctx);
@@ -48,6 +49,7 @@ vm.runInContext(systemsSource, ctx);
 function resetWorld(extra) {
   ctx.GM = Object.assign({ turn: 4, sid: 's1', _campaignId: 'c1', busy: false, marker: 10, armies: [{ soldiers: 100 }], treasury: 50 }, extra || {});
   ctx.P = { marker: 'template', conf: {}, ai: {}, battleConfig: {} };
+  ctx.TM = { errors: { capture() {} } };
   ctx._tmLoadGen = 0;
   delete ctx.BattleEngine;
   delete ctx.GuokuEngine;
@@ -55,6 +57,7 @@ function resetWorld(extra) {
   delete ctx.HujiEngine;
   delete ctx.HujiDeepFill;
   delete ctx.updateProvinceEconomy;
+  delete ctx.IntegrationBridge;
   ctx.SubTickRunner = { run() {} };
 }
 
@@ -62,6 +65,13 @@ async function expectFailure(promise, text) {
   try { await promise; }
   catch (error) { return !text || String(error && error.message || error).includes(text); }
   return false;
+}
+
+function comparableWorld(value) {
+  const copy = JSON.parse(JSON.stringify(value));
+  delete copy._lastEndTurnRollback;
+  delete copy._endTurnBusy;
+  return JSON.stringify(copy);
 }
 
 async function main() {
@@ -109,6 +119,33 @@ async function main() {
   releaseSubticks();
   await expectFailure(pending);
   ok(ctx.GM.turn === 9, 'systems continue only after asynchronous subticks resolve');
+
+  const tailCallIndex = coreSource.indexOf('await _tmRunEndTurnDeterministicTail();');
+  const tailFinalizeIndex = coreSource.indexOf('await _tmFinalizeEndTurnTransaction(_obsCtx, _turnTxn);', tailCallIndex);
+  ok(tailCallIndex >= 0 && tailFinalizeIndex > tailCallIndex, 'deterministic state tail is awaited before transaction commit');
+
+  const tailFailures = [
+    ['BuildingWorks', () => { ctx.TM.BuildingWorks = { tick() { ctx.GM.marker = 21; throw new Error('tail-building'); } }; }],
+    ['TalentCohorts', () => { ctx.TM.TalentCohorts = { enabled() { return true; }, tick() { ctx.GM.marker = 22; throw new Error('tail-talent'); } }; }],
+    ['RegionStatus', () => { ctx.TM.RegionStatus = { tick() { ctx.GM.marker = 23; throw new Error('tail-region'); } }; }],
+    ['FieldPipes', () => { ctx.TM.FieldPipes = { tick() { ctx.GM.marker = 24; throw new Error('tail-fields'); } }; }],
+    ['SocialFoundation', () => { ctx.TM.SocialFoundation = { tick() { ctx.GM.marker = 25; throw new Error('tail-social'); } }; }],
+    ['Renli', () => { ctx.TM.Renli = { endturnTick() { ctx.GM.marker = 26; throw new Error('tail-renli'); } }; }],
+    ['OfficeFallback', () => { ctx.TM.OfficeFallback = { tick() { ctx.P.marker = 'partial-office'; throw new Error('tail-office'); } }; }],
+    ['IntegrationBridge', () => { ctx.IntegrationBridge = { aggregateRegionsToVariables() { ctx.GM.marker = 28; throw new Error('tail-aggregate'); } }; }],
+    ['ArmyReconcile', () => { ctx.TM.AIChange = { Army: { reconcileArmyCommanders() { ctx.GM.armies[0].soldiers = 1; throw new Error('tail-army'); } } }; }]
+  ];
+  for (const entry of tailFailures) {
+    resetWorld();
+    const beforeGM = comparableWorld(ctx.GM);
+    const beforeP = comparableWorld(ctx.P);
+    txn = ctx._tmCaptureEndTurnTransaction();
+    entry[1]();
+    ok(await expectFailure(ctx._tmRunEndTurnDeterministicTail(), 'tail-'), entry[0] + ' failure reaches the transaction boundary');
+    ctx._tmRollbackEndTurnTransaction(txn, new Error('forced ' + entry[0] + ' failure'));
+    ok(comparableWorld(ctx.GM) === beforeGM && comparableWorld(ctx.P) === beforeP,
+      entry[0] + ' partial GM/P writes roll back to the pre-turn snapshot');
+  }
 
   console.log('[smoke-endturn-transaction-failures] PASS assertions=' + assertions);
 }

--- a/web/scripts/smoke-legacy-city-info-security.js
+++ b/web/scripts/smoke-legacy-city-info-security.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.resolve(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'tm-map-system.js'), 'utf8');
+let assertions = 0;
+
+function check(value, label) {
+  if (!value) throw new Error('[smoke-legacy-city-info-security] ' + label);
+  assertions += 1;
+}
+
+class FakeNode {
+  constructor(tagName, text) {
+    this.tagName = tagName || '';
+    this.children = [];
+    this.parentNode = null;
+    this.style = {};
+    this.dataset = {};
+    this.textContent = text || '';
+    this.id = '';
+    this.className = '';
+    this.listeners = {};
+  }
+  appendChild(child) {
+    child.parentNode = this;
+    this.children.push(child);
+    return child;
+  }
+  append() {
+    Array.prototype.slice.call(arguments).forEach((child) => this.appendChild(child));
+  }
+  addEventListener(type, fn) { this.listeners[type] = fn; }
+  remove() {
+    if (!this.parentNode) return;
+    this.parentNode.children = this.parentNode.children.filter((child) => child !== this);
+  }
+  set innerHTML(_) { throw new Error('legacy city detail must not assign innerHTML'); }
+}
+
+const body = new FakeNode('BODY');
+function findById(node, id) {
+  if (node.id === id) return node;
+  for (const child of node.children) {
+    const found = findById(child, id);
+    if (found) return found;
+  }
+  return null;
+}
+function allText(node) {
+  return String(node.textContent || '') + node.children.map(allText).join('');
+}
+function allTags(node) {
+  return [node.tagName].concat(node.children.flatMap(allTags));
+}
+
+const attack = '<img src=x onerror="document.documentElement.dataset.tmCityXss=\'triggered\'">';
+const context = {
+  console,
+  Math, Date, JSON, Object, Array, Number, String, Boolean,
+  parseInt, parseFloat, isFinite,
+  GM: {
+    mapData: {
+      state: { scale: 1, offsetX: 0, offsetY: 0, hoveredCityId: null, selectedCityId: null },
+      cities: {
+        'city-uuid': { id: 'city-uuid', name: attack, owner: attack, population: 0, income: 0, neighbors: ['near-uuid'] },
+        'near-uuid': { id: 'near-uuid', name: attack, owner: attack }
+      },
+      polygons: {}
+    }
+  },
+  P: {},
+  findFacByName() { return null; },
+  document: {
+    documentElement: { dataset: {} },
+    body,
+    createElement(tag) { return new FakeNode(String(tag).toUpperCase()); },
+    createTextNode(text) { return new FakeNode('#text', String(text)); },
+    getElementById(id) { return findById(body, id); }
+  }
+};
+context.window = context;
+context.globalThis = context;
+vm.createContext(context);
+vm.runInContext(source, context, { filename: 'tm-map-system.js' });
+
+context.showCityInfo('city-uuid');
+const overlay = context.document.getElementById('city-info-overlay');
+check(overlay && allText(overlay).includes(attack), 'malicious city and neighbour fields are rendered as literal text');
+check(!context.document.documentElement.dataset.tmCityXss, 'legacy city detail does not execute inline event payloads');
+check(!allTags(overlay).includes('IMG'), 'attacker text never creates an IMG element');
+check(allText(overlay).includes('人口：0') && allText(overlay).includes('收入：0 金/月'), 'legal zero population and income remain visible');
+
+context.GM.mapData.polygons = {
+  0: { points: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 0, y: 10 }] }
+};
+check(context.getCityAtPosition(1, 1) === '0', 'city id 0 remains selectable as its original key');
+context.GM.mapData.polygons = {
+  '550e8400-e29b-41d4-a716-446655440000': { points: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 0, y: 10 }] }
+};
+check(context.getCityAtPosition(1, 1) === '550e8400-e29b-41d4-a716-446655440000', 'UUID city ids are not coerced to NaN');
+
+console.log('[smoke-legacy-city-info-security] PASS assertions=' + assertions);

--- a/web/scripts/smoke-npc-cluster-repair.js
+++ b/web/scripts/smoke-npc-cluster-repair.js
@@ -30,8 +30,8 @@ function extractFn(anchor) {
 
 // ① 应用同源
 ok(/var _applyNpcDeepResult = function\(pND\) \{/.test(src), '① _applyNpcDeepResult 已定义');
-ok(/_applyNpcDeepResult\(p15\);/.test(src), '① sc15 走共享应用');
-ok(/_applyNpcDeepResult\(p15n\);/.test(src), '① sc15n 走共享应用(原只存不用)');
+ok(/_applyNpcDeepResultAtomic\(_applyNpcDeepResult,\s*p15\)/.test(src), '① sc15 走共享原子应用');
+ok(/_applyNpcDeepResultAtomic\(_applyNpcDeepResult,\s*p15n\)/.test(src), '① sc15n 走共享原子应用(原只存不用)');
 ok(src.indexOf('p15.mood_shifts.forEach') < 0 && src.indexOf('p15.cascade_effects') < 0, '① sc15 旧内联应用块已删(无双算)');
 ok(src.indexOf('GM._factionUndercurrents.push(Object.assign({ turn: GM.turn||1, _fromSc15n: true }, fu))') < 0, '① sc15n 旧 append 版 undercurrents 已删(共享函数接管)');
 

--- a/web/scripts/smoke-postturn-critical-failures.js
+++ b/web/scripts/smoke-postturn-critical-failures.js
@@ -51,6 +51,20 @@ async function main() {
   ok(childResult && childResult.ok === false && childRan === false, 'dependency failure prevents child task execution');
 
   resetWorld();
+  let attempts = 0;
+  ctx._enqueuePostTurnJob('sc25c', async function() {
+    attempts++;
+    if (attempts === 1) throw new Error('temporary sc25c failure');
+    return { recovered: true };
+  });
+  const firstFailure = await rejects(() => ctx._awaitPostTurnJobs());
+  ok(firstFailure && attempts === 1 && ctx.GM._postTurnJobs.pending[0].status === 'retryable',
+    'first critical failure remains visible and records a retryable task instead of a dead Promise');
+  await ctx._awaitPostTurnJobs();
+  ok(attempts === 2 && ctx.GM._postTurnJobs === null && !Object.prototype.hasOwnProperty.call(ctx.GM, '_turnAiResults'),
+    'next save/turn wait rebuilds the task Promise and clears source data only after success');
+
+  resetWorld();
   ctx._enqueuePostTurnJob('sc25c', async function() { return { tactical: true, strategic: true }; });
   await ctx._awaitPostTurnJobs();
   ok(ctx.GM._postTurnJobs === null && !Object.prototype.hasOwnProperty.call(ctx.GM, '_turnAiResults'), 'successful critical jobs clear queue and source data');

--- a/web/scripts/smoke-preload-online-request-limit.js
+++ b/web/scripts/smoke-preload-online-request-limit.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+'use strict';
+
+const Module = require('module');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+let exposed = null;
+const invokes = [];
+let assertions = 0;
+
+function check(value, label) {
+  if (!value) throw new Error('[smoke-preload-online-request-limit] ' + label);
+  assertions += 1;
+}
+
+const electronStub = {
+  contextBridge: { exposeInMainWorld(_name, api) { exposed = api; } },
+  ipcRenderer: {
+    sendSync() { return { success: true, token: 'test-session' }; },
+    invoke(channel, payload) { invokes.push({ channel, payload }); return Promise.resolve({ success: true }); },
+    on() {}
+  }
+};
+
+const originalLoad = Module._load;
+Module._load = function(request) {
+  if (request === 'electron') return electronStub;
+  return originalLoad.apply(this, arguments);
+};
+
+(async function main() {
+  require(path.join(ROOT, 'preload-impl.js'));
+  check(exposed && typeof exposed.onlineRequest === 'function', 'preload exposes the bounded online request bridge');
+
+  await exposed.onlineRequest('POST', 'feed/post', { text: 'small' });
+  check(invokes.length === 1 && invokes[0].channel === 'online-request', 'small JSON request crosses IPC');
+
+  let rejected = null;
+  try { await exposed.onlineRequest('POST', 'feed/post', { text: 'x'.repeat(2 * 1024 * 1024) }); }
+  catch (error) { rejected = error; }
+  check(rejected && /1MB/.test(rejected.message) && invokes.length === 1, 'ordinary oversized JSON is rejected before ipcRenderer.invoke');
+
+  await exposed.onlineRequest('POST', 'workshop/upload', { text: 'x'.repeat(2 * 1024 * 1024) });
+  check(invokes.length === 2, 'explicit large-payload route accepts a request below 4MB');
+
+  rejected = null;
+  try { await exposed.onlineRequest('POST', 'workshop/upload', { text: 'x'.repeat(5 * 1024 * 1024) }); }
+  catch (error) { rejected = error; }
+  check(rejected && /4MB/.test(rejected.message) && invokes.length === 2, '10MB-class payloads cannot cross the preload IPC boundary');
+
+  console.log('[smoke-preload-online-request-limit] PASS assertions=' + assertions);
+})().finally(() => {
+  Module._load = originalLoad;
+}).catch((error) => {
+  console.error(error && error.stack || error);
+  process.exit(1);
+});

--- a/web/scripts/smoke-runtime-map-economy.js
+++ b/web/scripts/smoke-runtime-map-economy.js
@@ -8,6 +8,7 @@ const vm = require('vm');
 const ROOT = path.resolve(__dirname, '..');
 const source = fs.readFileSync(path.join(ROOT, 'tm-economy.js'), 'utf8');
 const mapSource = fs.readFileSync(path.join(ROOT, 'tm-map-system.js'), 'utf8');
+const gameLoopSource = fs.readFileSync(path.join(ROOT, 'tm-game-loop.js'), 'utf8');
 let assertions = 0;
 
 function check(condition, message) {
@@ -99,5 +100,114 @@ vm.runInContext(extractFunction(mapSource, 'updateMapColors'), mapContext, { fil
 mapContext.updateMapColors();
 check(mapContext.GM.mapData.regions[0].color === '#abcdef', 'map color refresh must update the runtime GM region');
 check(mapContext.P.map.regions[0].color === '#111111', 'map color refresh must not mutate or display the scenario template region');
+
+function runEconomyCase(P, GM) {
+  const localChanges = [];
+  const local = {
+    console: { log() {}, warn() {}, error() {} },
+    Math, Date, JSON, Object, Array, Number, String, Boolean,
+    parseInt, parseFloat, isFinite,
+    finiteNumberOr(value, fallback) { return typeof value === 'number' && Number.isFinite(value) ? value : fallback; },
+    clamp(value, min, max) { return Math.max(min, Math.min(max, value)); },
+    recordChange() { localChanges.push(Array.from(arguments)); },
+    addEB() {},
+    P,
+    GM
+  };
+  local.getLiveMapData = () => local.GM.mapData || local.GM.map || null;
+  local.window = local;
+  local.global = local;
+  local.globalThis = local;
+  vm.createContext(local);
+  vm.runInContext(source, local, { filename: 'tm-economy.js' });
+  return { local, localChanges };
+}
+
+const zeroTax = runEconomyCase(
+  { economyConfig: { baseIncome: 1, redistributionRate: 0, dualTreasury: true, privateIncomeRatio: 0 } },
+  {
+    classes: [], eraState: { centralControl: 0.5, economicProsperity: 1, socialStability: 1 },
+    stateTreasury: 0, privateTreasury: 0,
+    mapData: { regions: [{ id: 'zero-tax', name: '免税州', owner: 'player' }] },
+    provinceStats: { 旧省: { taxRevenue: 1000 } }
+  }
+);
+zeroTax.local.updateEconomy(1);
+check(zeroTax.local.GM.stateTreasury === 0, 'a legitimate zero runtime-map tax must not activate provinceStats fallback income');
+check(zeroTax.localChanges.every((row) => row[1] !== '旧省'), 'province fallback ledger must stay untouched when runtime regions exist');
+
+const ownedOnly = runEconomyCase(
+  {
+    playerInfo: { factionName: '玩家国' },
+    factions: [{ id: 'fac-player', name: '玩家国' }, { id: 'fac-enemy', name: '敌国' }],
+    economyConfig: { baseIncome: 100, redistributionRate: 0 }
+  },
+  {
+    classes: [], facs: [{ id: 'fac-player', name: '玩家国', isPlayer: true }, { id: 'fac-enemy', name: '敌国' }],
+    eraState: { centralControl: 0.5, economicProsperity: 1, socialStability: 1 },
+    mapData: { regions: [
+      { id: 'ours', name: '我方州', owner: 'fac-player' },
+      { id: 'theirs', name: '敌方州', owner: 'fac-enemy' }
+    ] }
+  }
+);
+ownedOnly.local.updateEconomy(1);
+const ownedTributes = ownedOnly.localChanges.filter((row) => row[0] === 'economy' && row[2] === 'tribute');
+check(ownedTributes.length === 1 && ownedTributes[0][1] === '我方州', 'central revenue must exclude explicitly enemy-controlled runtime regions');
+
+[-0.1, 1.2].forEach((invalidRatio) => {
+  const invalid = runEconomyCase(
+    { economyConfig: { redistributionRate: invalidRatio } },
+    { classes: [], eraState: { centralControl: 0.5, economicProsperity: 1, socialStability: 1 }, mapData: { regions: [] } }
+  );
+  let rejected = false;
+  try { invalid.local.updateEconomy(1); } catch (error) { rejected = error && error.name === 'RangeError' && /between 0 and 1/.test(String(error)); }
+  check(rejected, 'out-of-range redistribution ratio ' + invalidRatio + ' must be rejected before settlement');
+});
+
+const zeroBankruptcy = runEconomyCase(
+  { economyConfig: { baseIncome: 1, redistributionRate: 0, dualTreasury: true, privateIncomeRatio: 0, bankruptcyThreshold: 0 } },
+  {
+    classes: [], eraState: { centralControl: 0.5, economicProsperity: 1, socialStability: 1 },
+    stateTreasury: -1, privateTreasury: 0, mapData: { regions: [{ id: 'zero', name: '零税州' }] }
+  }
+);
+zeroBankruptcy.local.updateEconomy(1);
+check(zeroBankruptcy.local.GM._bankruptcyTurns === 1, 'bankruptcyThreshold=0 must remain a valid configured threshold');
+
+const validationContext = {
+  P: { characters: [], factions: [], variables: [], relations: [], time: { year: 1 } },
+  clamp(value, min, max) { return Math.max(min, Math.min(max, value)); },
+  Number, Array, Object
+};
+vm.createContext(validationContext);
+vm.runInContext(extractFunction(gameLoopSource, 'validateScenario'), validationContext, { filename: 'validateScenario.js' });
+const invalidScenario = validationContext.validateScenario({
+  name: '非法财政配置',
+  economyConfig: { redistributionRate: -0.1, privateIncomeRatio: 1.2 }
+});
+check(invalidScenario.valid === false && invalidScenario.errors.length === 2, 'scenario validation must reject invalid fiscal ratios at import/start boundary');
+
+const migrationContext = {
+  console: { log() {}, warn() {}, error() {} },
+  Math, Date, JSON, Object, Array, Number, String, Boolean,
+  P: { map: { regions: [{ id: 'template', name: '模板州' }] } },
+  GM: {
+    mapData: { regions: [], cities: {}, polygons: {}, edges: {}, items: [], roads: [] },
+    map: { regions: [{ id: 'legacy', name: '旧档州', owner: '旧主' }], items: [] },
+    facs: []
+  },
+  _dbg() {}
+};
+migrationContext.window = migrationContext;
+migrationContext.globalThis = migrationContext;
+vm.createContext(migrationContext);
+vm.runInContext(mapSource, migrationContext, { filename: 'tm-map-system.js' });
+const migratedMap = migrationContext.getLiveMapData();
+check(migratedMap === migrationContext.GM.mapData && migratedMap.regions[0].id === 'legacy', 'empty GM.mapData scaffold must not hide populated legacy GM.map');
+check(migratedMap.mapSchemaVersion === 1, 'legacy runtime map migration must stamp a schema version');
+check(migratedMap !== migrationContext.GM.map, 'legacy map migration must detach the authoritative runtime object');
+migratedMap.regions[0].name = '运行州';
+check(migrationContext.GM.map.regions[0].name === '旧档州', 'legacy map source must remain isolated after migration');
 
 console.log('[smoke-runtime-map-economy] PASS assertions=' + assertions);

--- a/web/scripts/smoke-runtime-save-consistency.js
+++ b/web/scripts/smoke-runtime-save-consistency.js
@@ -191,8 +191,9 @@ async function runDynamicLeaseSmokes() {
       objectStoreNames: { contains: () => true },
       transaction() {
         const tx = {};
-        tx.objectStore = () => ({
+        tx.objectStore = (storeName) => ({
           put() {
+            if (storeName !== 'saves') return;
             writeAttempts++;
             if (writeAttempts === 1) setTimeout(() => tx.onerror({ target: { error: { name: 'QuotaExceededError' } } }), 0);
             else { committed++; setTimeout(() => tx.oncomplete(), 0); }

--- a/web/scripts/smoke-scenario-renderer-html-boundary.js
+++ b/web/scripts/smoke-scenario-renderer-html-boundary.js
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const WEB = path.resolve(__dirname, '..');
+const attack = '<img src=x onerror="document.documentElement.dataset.tmScenarioXss=\'triggered\'">';
+let assertions = 0;
+
+function check(value, label) {
+  if (!value) throw new Error('[smoke-scenario-renderer-html-boundary] ' + label);
+  assertions += 1;
+}
+
+function escapeHtml(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function assertEscapedHtml(html, label) {
+  check(!String(html).includes('<img'), label + ' does not create attacker markup');
+  check(String(html).includes('&lt;img'), label + ' preserves attacker content as text');
+}
+
+function baseContext() {
+  const em = { innerHTML: '' };
+  const modal = { html: '' };
+  const context = {
+    console,
+    JSON,
+    Object,
+    Array,
+    Number,
+    String,
+    Boolean,
+    Math,
+    Date,
+    parseInt,
+    parseFloat,
+    isFinite,
+    editingScenarioId: 'scenario-1',
+    escHtml: escapeHtml,
+    uid() { return 'id-1'; },
+    _$(id) { return id === 'em' ? em : null; },
+    openGenericModal(_title, html) { modal.html = String(html); },
+    closeGenericModal() {},
+    gv() { return ''; },
+    renderEdTab() {},
+    toast() {},
+    showLoading() {},
+    hideLoading() {},
+    callAISmart() { throw new Error('AI must not run in renderer boundary smoke'); },
+    extractJSONMatch() { return null; }
+  };
+  context.window = context;
+  context.globalThis = context;
+  context.__em = em;
+  context.__modal = modal;
+  return context;
+}
+
+const editorContext = baseContext();
+editorContext.P = {
+  characters: [{
+    name: attack,
+    title: attack,
+    faction: attack,
+    stance: attack,
+    desc: attack,
+    personality: attack,
+    appearance: attack,
+    skills: [attack],
+    dialogues: [attack],
+    secret: attack,
+    stats: { [attack]: 1 }
+  }],
+  items: [{ sid: 'scenario-1', type: attack, name: attack, desc: attack, effect: { [attack]: 1 }, prereq: attack }],
+  rules: [{ sid: 'scenario-1', name: attack, enabled: true, trigger: { type: 'keyword', keywords: [attack] }, effect: { narrative: attack } }],
+  events: [{ sid: 'scenario-1', name: attack, narrative: attack, choices: [] }],
+  factions: [{ sid: 'scenario-1', name: attack, desc: attack }],
+  classes: [{ sid: 'scenario-1', name: attack, desc: attack, privileges: attack, restrictions: attack, population: attack, influence: 0 }],
+  world: { entries: [{ sid: 'scenario-1', category: attack, content: attack }], rules: attack },
+  techTree: [{ sid: 'scenario-1', name: attack, desc: attack, era: attack, costs: [{ variable: attack, amount: 1 }] }],
+  variables: [],
+  scenarios: []
+};
+vm.createContext(editorContext);
+vm.runInContext(fs.readFileSync(path.join(WEB, 'editor-details.js'), 'utf8'), editorContext, { filename: 'editor-details.js' });
+
+editorContext.editChr(0);
+assertEscapedHtml(editorContext.__em.innerHTML, 'character editor');
+[
+  'renderItmTab',
+  'renderRulTab',
+  'renderEvtTab',
+  'renderFacTab',
+  'renderClassTab',
+  'renderWldTab',
+  'renderTechTab'
+].forEach((name) => {
+  editorContext.__em.innerHTML = '';
+  editorContext[name](editorContext.__em, 'scenario-1');
+  assertEscapedHtml(editorContext.__em.innerHTML, name);
+});
+
+const officeSource = fs.readFileSync(path.join(WEB, 'tm-office-editor.js'), 'utf8');
+const officeContext = baseContext();
+officeContext.P = {
+  conf: { style: attack, refText: attack },
+  techTree: [{ sid: 'scenario-1', name: attack, desc: attack, era: attack, prereqs: [attack], effect: { value: attack } }],
+  factions: [{ sid: 'scenario-1', name: attack, leader: attack, desc: attack, ideology: attack, territory: attack, strength: 50 }],
+  rules: [{ sid: 'scenario-1', name: attack, enabled: true, trigger: { variable: attack, op: '<', value: 1 }, effect: { narrative: attack } }],
+  events: [{ sid: 'scenario-1', name: attack, triggerTurn: 1, type: attack, narrative: attack, oneTime: true }],
+  civicTree: [{ sid: 'scenario-1', name: attack, desc: attack }]
+};
+officeContext.document = { getElementById() { return null; }, createElement() { return { innerHTML: '', appendChild() {} }; } };
+vm.createContext(officeContext);
+
+const phase6Start = officeSource.indexOf('function _officeEditorEsc');
+const phase6End = officeSource.indexOf('// ---- Feature 7', phase6Start);
+check(phase6Start >= 0 && phase6End > phase6Start, 'office phase 6 source is discoverable');
+vm.runInContext(officeSource.slice(phase6Start, phase6End), officeContext, { filename: 'tm-office-editor-phase6.js' });
+
+['editTech', 'editFac', 'editRul', 'editEvt'].forEach((name) => {
+  officeContext.__modal.html = '';
+  officeContext[name](0);
+  assertEscapedHtml(officeContext.__modal.html, name);
+});
+['renderTechTab', 'renderFacTab', 'renderRulTab', 'renderEvtTab'].forEach((name) => {
+  officeContext.__em.innerHTML = '';
+  officeContext[name](officeContext.__em, 'scenario-1');
+  assertEscapedHtml(officeContext.__em.innerHTML, name);
+});
+
+const civicStart = officeSource.indexOf('function renderCivicTab');
+const civicEnd = officeSource.indexOf('// _addCivic', civicStart);
+check(civicStart >= 0 && civicEnd > civicStart, 'civic renderer source is discoverable');
+vm.runInContext(officeSource.slice(civicStart, civicEnd), officeContext, { filename: 'tm-office-editor-civic.js' });
+officeContext.renderCivicTab(officeContext.__em);
+assertEscapedHtml(officeContext.__em.innerHTML, 'renderCivicTab');
+
+const deptStart = officeSource.indexOf('function _renderOfficeDept');
+const deptEnd = officeSource.indexOf('function _officeAddTopDept', deptStart);
+check(deptStart >= 0 && deptEnd > deptStart, 'office department renderer source is discoverable');
+vm.runInContext(officeSource.slice(deptStart, deptEnd), officeContext, { filename: 'tm-office-editor-dept.js' });
+const deptHtml = officeContext._renderOfficeDept({
+  name: attack,
+  desc: attack,
+  functions: [attack],
+  positions: [{ name: attack, rank: attack, holder: attack, desc: attack }],
+  subs: []
+}, [0], 0);
+assertEscapedHtml(deptHtml, 'office tree renderer');
+check(officeSource.includes('_officeEditorEsc(nd.name || \'?\')'), 'active office canvas escapes department names');
+check(officeSource.includes('_officeEditorEsc(nd.holder)'), 'active office canvas escapes position holders');
+
+function sidebarNode() {
+  return {
+    id: '',
+    style: {},
+    children: [],
+    innerHTML: '',
+    appendChild(child) { this.children.push(child); return child; },
+    remove() { this.removed = true; }
+  };
+}
+function sidebarHtml(node) {
+  return String(node.innerHTML || '') + (node.children || []).map(sidebarHtml).join('');
+}
+const sidebarRoot = sidebarNode();
+const sidebarContext = {
+  console,
+  JSON,
+  Object,
+  Array,
+  Number,
+  String,
+  Boolean,
+  Math,
+  Date,
+  parseInt,
+  parseFloat,
+  isFinite,
+  escHtml: escapeHtml,
+  GameHooks: { on() {} },
+  P: {
+    goals: [{ name: attack, desc: attack, type: 'win', progress: 0 }],
+    playerInfo: { coreContradictions: [] },
+    adminHierarchy: { root: { divisions: [{ name: attack, terrain: attack, level: attack, prosperity: 0, governor: attack, children: [] }] } },
+    officeConfig: { costVariables: [{ variable: attack, perDept: 1, perOfficial: 1 }] },
+    palaceSystem: { enabled: true, capitalName: attack, palaces: [{ type: attack, subHalls: [] }] }
+  },
+  GM: {
+    facs: [{ name: attack, type: attack, attitude: attack, color: attack, strength: 50 }],
+    factionRelations: [{ from: attack, to: attack, type: attack, value: 0 }],
+    armies: [{ name: attack, armyType: attack, commander: attack, garrison: attack, soldiers: 10, morale: 50, training: 50 }],
+    classes: [{ name: attack, influence: 50, satisfaction: 50 }],
+    parties: [{ name: attack, status: attack, influence: 50 }],
+    items: [{ name: attack, type: attack, rarity: attack, effect: attack, owner: attack }],
+    chars: [{ name: attack, alive: true, spouse: true, spouseRank: attack, loyalty: 50, favor: 0, children: [] }],
+    harem: { heirs: [attack], pregnancies: [{ mother: attack }] },
+    buildings: [{ category: attack, type: attack }],
+    buildingQueue: [],
+    events: [{ name: attack, type: attack, triggered: false }, { name: attack, type: attack, triggered: true }],
+    officeTree: [{ positions: [{ holder: attack }], subs: [] }],
+    vars: { [attack]: { value: 100 } },
+    _indices: {}
+  },
+  _$(id) { return id === 'gl' ? sidebarRoot : null; },
+  document: {
+    createElement() { return sidebarNode(); },
+    getElementById() { return null; }
+  },
+  findCharByName() { return null; },
+  getHaremRankLevel() { return 1; },
+  getHaremRankName() { return attack; },
+  getHaremRankIcon() { return attack; }
+};
+sidebarContext.window = sidebarContext;
+sidebarContext.globalThis = sidebarContext;
+vm.createContext(sidebarContext);
+vm.runInContext(fs.readFileSync(path.join(WEB, 'tm-sidebar-ui.js'), 'utf8'), sidebarContext, { filename: 'tm-sidebar-ui.js' });
+sidebarContext.renderSidePanels();
+assertEscapedHtml(sidebarHtml(sidebarRoot), 'game sidebar renderer');
+
+const mapContext = {
+  console,
+  JSON,
+  Object,
+  Array,
+  Number,
+  String,
+  Boolean,
+  Math,
+  Date,
+  parseInt,
+  parseFloat,
+  isFinite,
+  P: { map: { regions: [{ id: 'template-region' }] } },
+  GM: { mapData: { enabled: true, regions: [{ id: 'runtime-region' }] }, facs: [], chars: [], _useAIGeo: false },
+  getLiveMapData() { return mapContext.GM.mapData; },
+  getTerrainName(value) { return value; },
+  document: {
+    body: { appendChild() {} },
+    documentElement: { dataset: {} },
+    createElement() { return { id: '', innerHTML: '', addEventListener() {} }; },
+    addEventListener() {},
+    getElementById(id) {
+      if (id === 'game-map-mode') return { value: 'owner', onchange: null };
+      if (id === 'game-map-labels') return { checked: false, onchange: null };
+      if (id === 'game-map-info') return { innerHTML: '' };
+      return null;
+    }
+  }
+};
+mapContext.window = mapContext;
+mapContext.globalThis = mapContext;
+vm.createContext(mapContext);
+vm.runInContext(fs.readFileSync(path.join(WEB, 'map-display.js'), 'utf8'), mapContext, { filename: 'map-display.js' });
+let renderedMap = null;
+mapContext.renderGameMap = function(_container, map) { renderedMap = map; };
+mapContext.showMapInGame();
+check(renderedMap === mapContext.GM.mapData, 'game map UI renders the live GM map rather than the P template');
+const provinceHtml = mapContext.showProvinceDetails({
+  name: attack,
+  owner: attack,
+  terrain: attack,
+  resources: [attack],
+  development: 0,
+  troops: 0,
+  characters: []
+});
+assertEscapedHtml(provinceHtml, 'province detail renderer');
+check(!mapContext.document.documentElement.dataset.tmScenarioXss, 'scenario payload never executes during renderer smoke');
+
+console.log('[smoke-scenario-renderer-html-boundary] PASS assertions=' + assertions);

--- a/web/scripts/smoke-security-trust-boundary.js
+++ b/web/scripts/smoke-security-trust-boundary.js
@@ -139,16 +139,34 @@ async function main() {
   try { await T.assertSafeRemoteUrl('https://10.0.0.1/path'); } catch (error) { ipError = error; }
   check(ipError && /IP/.test(ipError.message), 'production remote requests reject IP literals before fetch');
 
-  const publicSession = T.toPublicAccountSession({ token: 'secret', user: { id: 7 }, loggedInAt: 'now' });
-  check(publicSession.loggedIn === true && publicSession.user.id === 7 && !Object.prototype.hasOwnProperty.call(publicSession, 'token'),
-    'renderer account session exposes identity without bearer token');
-  const sanitized = T.sanitizeOnlineResponse({ success: true, token: 'secret', nested: { refreshToken: 'refresh', value: 1 } });
-  check(sanitized.success && sanitized.nested.value === 1 && !('token' in sanitized) && !('refreshToken' in sanitized.nested),
+  const publicSession = T.toPublicAccountSession({
+    token: 'secret',
+    user: { id: 7, username: '史官', nickname: '史官', email: 'user@example.invalid', passwordHash: 'hash', internalFlags: ['admin'], access_token: 'nested-secret' },
+    loggedInAt: 'now'
+  });
+  check(publicSession.loggedIn === true && publicSession.user.id === 7 && publicSession.user.email === 'user@example.invalid'
+    && !Object.prototype.hasOwnProperty.call(publicSession, 'token') && !('passwordHash' in publicSession.user)
+    && !('internalFlags' in publicSession.user) && !('access_token' in publicSession.user),
+    'renderer account session exposes only allowlisted identity fields without bearer or future internal fields');
+  const sanitized = T.sanitizeOnlineResponse({ success: true, token: 'secret', nested: { refreshToken: 'refresh', access_token: 'snake', passwordHash: 'hash', value: 1 } });
+  check(sanitized.success && sanitized.nested.value === 1 && !('token' in sanitized) && !('refreshToken' in sanitized.nested)
+    && !('access_token' in sanitized.nested) && !('passwordHash' in sanitized.nested),
     'account responses recursively remove session secrets');
+  const publicAccountResponse = T.sanitizeAccountOnlineResponse({ success: true, user: { id: 8, username: '公开', internalFlags: ['secret'], recoveryCodes: ['x'] } });
+  check(publicAccountResponse.user.id === 8 && publicAccountResponse.user.username === '公开'
+    && !('internalFlags' in publicAccountResponse.user) && !('recoveryCodes' in publicAccountResponse.user),
+    'login/register/me response user uses the same explicit public DTO');
   check(T.normalizeOnlineRendererRoute('GET', 'workshop/pack?id=x').route === 'workshop/pack'
     && throws(() => T.normalizeOnlineRendererRoute('GET', 'https://attacker.invalid/steal'), /非法|授权/)
     && throws(() => T.normalizeOnlineRendererRoute('POST', '../account/login'), /非法|授权/),
     'renderer online proxy accepts only fixed methods and routes');
+  check(T.getOnlineRendererBodyLimit('feed/post') === 1024 * 1024
+    && T.getOnlineRendererBodyLimit('workshop/upload') === 4 * 1024 * 1024,
+    'online proxy applies route-specific JSON body limits');
+  check(throws(() => T.assertOnlineRendererBodySize('feed/post', { text: 'x'.repeat(2 * 1024 * 1024) }), /1MB/)
+    && !throws(() => T.assertOnlineRendererBodySize('workshop/upload', { text: 'x'.repeat(2 * 1024 * 1024) }))
+    && throws(() => T.assertOnlineRendererBodySize('workshop/upload', { text: 'x'.repeat(5 * 1024 * 1024) }), /4MB/),
+    'main process repeats body-size validation even if preload is bypassed');
 
   const oversizedHeaders = { get: name => name === 'content-length' ? '20' : null };
   let bodyError = null;

--- a/web/scripts/smoke-storage-local-fallback.js
+++ b/web/scripts/smoke-storage-local-fallback.js
@@ -71,6 +71,13 @@ async function exerciseFallback(indexedDB, label) {
   check(raw._compressed === false, label + ': localStorage record must not claim gzip compression');
   check(typeof raw.gameState === 'string' && raw.gameState.indexOf('fallback-smoke') >= 0,
     label + ': localStorage record must retain the JSON payload instead of serializing Blob to {}');
+  const metadata = JSON.parse(context.localStorage.getItem('tm_idb_saveMetadata_fallback'));
+  check(metadata && metadata.id === 'fallback' && !Object.prototype.hasOwnProperty.call(metadata, 'gameState'),
+    label + ': fallback save must maintain a payload-free metadata record');
+
+  const listed = await context.TM_SaveDB.list();
+  check(listed.length === 1 && listed[0].id === 'fallback' && !Object.prototype.hasOwnProperty.call(listed[0], 'gameState'),
+    label + ': fallback list must read the lightweight metadata view');
 
   const loaded = await context.TM_SaveDB.load('fallback');
   check(JSON.stringify(loaded.gameState) === JSON.stringify(expected), label + ': save/load must round-trip deeply');

--- a/web/scripts/smoke-storage-metadata-index.js
+++ b/web/scripts/smoke-storage-metadata-index.js
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.resolve(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'tm-storage.js'), 'utf8');
+let assertions = 0;
+
+function check(condition, message) {
+  if (!condition) throw new Error('[smoke-storage-metadata-index] ' + message);
+  assertions += 1;
+}
+
+function makeFakeIndexedDB(legacySaves) {
+  const stores = new Map();
+  if (Array.isArray(legacySaves)) {
+    stores.set('saves', new Map(legacySaves.map((record) => [String(record.id), JSON.parse(JSON.stringify(record))])));
+    stores.set('projects', new Map());
+  }
+  const oldVersion = Array.isArray(legacySaves) ? 2 : 0;
+  const counters = { openedVersion: 0, getAll: Object.create(null), get: Object.create(null) };
+
+  function clone(value) {
+    return value == null ? value : JSON.parse(JSON.stringify(value));
+  }
+
+  function objectStore(name) {
+    if (!stores.has(name)) throw new Error('missing store ' + name);
+    const rows = stores.get(name);
+    return {
+      createIndex() {},
+      put(value) { rows.set(String(value.id), clone(value)); },
+      delete(id) { rows.delete(String(id)); },
+      get(id) {
+        counters.get[name] = (counters.get[name] || 0) + 1;
+        const request = {};
+        setTimeout(() => {
+          request.result = clone(rows.get(String(id)));
+          if (request.onsuccess) request.onsuccess({ target: request });
+        }, 0);
+        return request;
+      },
+      getAll() {
+        counters.getAll[name] = (counters.getAll[name] || 0) + 1;
+        const request = {};
+        setTimeout(() => {
+          request.result = Array.from(rows.values()).map(clone);
+          if (request.onsuccess) request.onsuccess({ target: request });
+        }, 0);
+        return request;
+      },
+      openCursor() {
+        const request = {};
+        const values = Array.from(rows.values()).map(clone);
+        let index = 0;
+        function advance() {
+          setTimeout(() => {
+            request.result = index < values.length ? {
+              value: values[index++],
+              continue: advance
+            } : null;
+            if (request.onsuccess) request.onsuccess({ target: request });
+          }, 0);
+        }
+        advance();
+        return request;
+      }
+    };
+  }
+
+  const db = {
+    objectStoreNames: { contains(name) { return stores.has(name); } },
+    createObjectStore(name) {
+      stores.set(name, new Map());
+      return objectStore(name);
+    },
+    transaction(names) {
+      const tx = {
+        objectStore,
+        error: null,
+        oncomplete: null,
+        onerror: null,
+        onabort: null
+      };
+      setTimeout(() => { if (tx.oncomplete) tx.oncomplete({ target: tx }); }, 0);
+      return tx;
+    }
+  };
+
+  return {
+    stores,
+    counters,
+    open(name, version) {
+      counters.openedVersion = version;
+      const request = {};
+      setTimeout(() => {
+        const upgradeTx = db.transaction([]);
+        if (request.onupgradeneeded) {
+          request.onupgradeneeded({ oldVersion, target: { result: db, transaction: upgradeTx } });
+        }
+        setTimeout(() => {
+          request.result = db;
+          if (request.onsuccess) request.onsuccess({ target: request });
+        }, oldVersion ? 20 : 0);
+      }, 0);
+      return request;
+    }
+  };
+}
+
+function makeLocalStorage() {
+  const rows = new Map();
+  return {
+    get length() { return rows.size; },
+    key(index) { return Array.from(rows.keys())[index] || null; },
+    getItem(key) { return rows.has(String(key)) ? rows.get(String(key)) : null; },
+    setItem(key, value) { rows.set(String(key), String(value)); },
+    removeItem(key) { rows.delete(String(key)); }
+  };
+}
+
+(async function main() {
+  const indexedDB = makeFakeIndexedDB();
+  const context = {
+    console: { log() {}, warn() {}, error() {}, info() {} },
+    Promise, Math, Date, JSON, Object, Array, Number, String, Boolean, Error,
+    Blob, Response, CompressionStream, DecompressionStream, TextDecoder,
+    setTimeout, clearTimeout,
+    localStorage: makeLocalStorage(),
+    navigator: { storage: null },
+    indexedDB
+  };
+  context.window = context;
+  context.globalThis = context;
+  vm.createContext(context);
+  const bootAt = source.lastIndexOf('\nTM_SaveDB.open().then');
+  vm.runInContext(bootAt > 0 ? source.slice(0, bootAt) : source, context, { filename: 'tm-storage.js' });
+  context.SaveCompression.compress = (text) => Promise.resolve(text);
+
+  await context.TM_SaveDB.open();
+  check(indexedDB.counters.openedVersion === 3, 'storage schema must open IndexedDB version 3');
+
+  const payload = 'x'.repeat(64 * 1024);
+  await Promise.all(Array.from({ length: 100 }, (_, index) => context.TM_SaveDB.save(
+    'slot_' + index,
+    { GM: { turn: index, payload }, P: { name: 'scenario-' + index } },
+    { name: '存档' + index, type: index % 2 ? 'manual' : 'auto', turn: index, scenarioName: '剧本' + index }
+  )));
+
+  indexedDB.counters.getAll = Object.create(null);
+  const listed = await context.TM_SaveDB.list();
+  check(listed.length === 100, 'metadata list must return every saved slot');
+  check((indexedDB.counters.getAll.saveMetadata || 0) === 1, 'list must query the metadata store exactly once');
+  check((indexedDB.counters.getAll.saves || 0) === 0, 'list must never materialize payload records');
+  check(Array.from(indexedDB.stores.get('saveMetadata').values()).every((row) => !Object.prototype.hasOwnProperty.call(row, 'gameState')),
+    'metadata store must contain no gameState payload');
+
+  const loaded = await context.TM_SaveDB.load('slot_42');
+  check(loaded.gameState.GM.turn === 42 && loaded.gameState.GM.payload.length === payload.length,
+    'payload must remain loadable by id after metadata separation');
+  check((indexedDB.counters.get.saves || 0) === 1, 'loading one slot must read exactly one payload record');
+
+  await context.TM_SaveDB.delete('slot_42');
+  check(!indexedDB.stores.get('saves').has('slot_42') && !indexedDB.stores.get('saveMetadata').has('slot_42'),
+    'delete must atomically remove payload and metadata records');
+
+  const legacyIndexedDB = makeFakeIndexedDB([
+    { id: 'legacy-a', name: '旧档甲', type: 'manual', timestamp: 10, turn: 3, gameState: '{"GM":{"turn":3},"P":{}}' },
+    { id: 'legacy-b', name: '旧档乙', type: 'auto', timestamp: 20, turn: 4, gameState: '{"GM":{"turn":4},"P":{}}' }
+  ]);
+  const legacyContext = {
+    console: { log() {}, warn() {}, error() {}, info() {} },
+    Promise, Math, Date, JSON, Object, Array, Number, String, Boolean, Error,
+    Blob, Response, CompressionStream, DecompressionStream, TextDecoder,
+    setTimeout, clearTimeout,
+    localStorage: makeLocalStorage(), navigator: { storage: null }, indexedDB: legacyIndexedDB
+  };
+  legacyContext.window = legacyContext;
+  legacyContext.globalThis = legacyContext;
+  vm.createContext(legacyContext);
+  vm.runInContext(bootAt > 0 ? source.slice(0, bootAt) : source, legacyContext, { filename: 'tm-storage-legacy.js' });
+  await legacyContext.TM_SaveDB.open();
+  const migratedList = await legacyContext.TM_SaveDB.list();
+  check(migratedList.length === 2 && migratedList[0].id === 'legacy-b', 'v2 upgrade must backfill and sort metadata for existing saves');
+  check(Array.from(legacyIndexedDB.stores.get('saveMetadata').values()).every((row) => !Object.prototype.hasOwnProperty.call(row, 'gameState')),
+    'v2 metadata backfill must not duplicate legacy payloads');
+
+  console.log('[smoke-storage-metadata-index] PASS assertions=' + assertions);
+})().catch((error) => {
+  console.error(error && error.stack || error);
+  process.exit(1);
+});

--- a/web/tm-ai-change-pathutils.js
+++ b/web/tm-ai-change-pathutils.js
@@ -453,13 +453,13 @@
     var declaredDynamic = /^corruption\.byDept\.(central|provincial|county|military|palace|technical)$/.test(path);
     if (!r.parent || (!r.exists && !declaredDynamic)) return { ok: false, path: path, reason: 'path not declared in state schema' };
     var old = r.value;
-    function valueType(input) {
-      if (Array.isArray(input)) return 'array';
-      if (input === null) return 'null';
-      return typeof input;
-    }
-    if (r.exists && valueType(old) !== valueType(value)) {
+    if (r.exists && _jsonSchemaType(old) !== _jsonSchemaType(value)) {
       return { ok: false, path: path, reason: 'set value type does not match existing schema' };
+    }
+    // 通用 set 只允许叶子标量。整体替换人物、战争、财政配置等对象/数组，会绕过
+    // 领域 sink 的身份、存亡和不变量校验；复杂结构必须走语义操作或受形状约束的 merge/push。
+    if (r.exists && (_jsonSchemaType(old) === 'object' || _jsonSchemaType(old) === 'array')) {
+      return { ok: false, path: path, reason: 'structured set requires a domain operation or schema-aware merge' };
     }
     if (/^chars\.[^.]+\.loyalty$/.test(String(path)) && typeof global.setCharacterLoyalty === 'function') {
       var loySet = global.setCharacterLoyalty(r.parent, value, reason, {
@@ -508,6 +508,12 @@
     // vm/iframe 跨 realm 的 Object.prototype 引用不同；仍只接受构造器名为 Object 的普通 JSON 对象。
     return proto === null || !!(proto && Object.prototype.hasOwnProperty.call(proto, 'constructor') &&
       typeof proto.constructor === 'function' && proto.constructor.name === 'Object');
+  }
+
+  function _jsonSchemaType(value) {
+    if (Array.isArray(value)) return 'array';
+    if (value === null) return 'null';
+    return typeof value;
   }
 
   function _validateMergePatch(basePath, patch, depth) {
@@ -563,6 +569,15 @@
       if (_isPlainObject(patch[key])) {
         var nested = _validateMergeShape(target[key], patch[key], childPath);
         if (!nested.ok) return nested;
+      } else {
+        var targetType = _jsonSchemaType(target[key]);
+        var patchType = _jsonSchemaType(patch[key]);
+        if (targetType !== patchType) {
+          return { ok: false, reason: 'merge value type does not match existing schema: ' + childPath };
+        }
+        if (targetType === 'array' || targetType === 'object') {
+          return { ok: false, reason: 'merge cannot replace structured field without a domain operation: ' + childPath };
+        }
       }
     }
     return { ok: true };

--- a/web/tm-economy.js
+++ b/web/tm-economy.js
@@ -87,12 +87,75 @@ function calculateMonthlyIncome(region, eraState) {
   return Math.floor(baseIncome);
 }
 
+function requireEconomyRatio(value, field, fallback) {
+  if (value === undefined || value === null || value === '') return fallback;
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 1) {
+    throw new RangeError(field + ' must be between 0 and 1');
+  }
+  return value;
+}
+
+function collectPlayerEconomyFactionAliases(runtimeMap) {
+  var aliases = Object.create(null);
+  function add(value) {
+    var normalized = String(value == null ? '' : value).replace(/\s+/g, '').toLowerCase();
+    if (normalized) aliases[normalized] = true;
+  }
+  function matches(value) {
+    var normalized = String(value == null ? '' : value).replace(/\s+/g, '').toLowerCase();
+    return !!(normalized && aliases[normalized]);
+  }
+
+  add(P && P.playerInfo && P.playerInfo.factionName);
+  add(P && P.playerFaction);
+  add(GM && GM.playerFaction);
+
+  var factions = [];
+  if (GM && Array.isArray(GM.facs)) factions = factions.concat(GM.facs);
+  if (P && Array.isArray(P.factions)) factions = factions.concat(P.factions);
+  factions.forEach(function(faction) {
+    if (!faction) return;
+    if (faction.isPlayer || matches(faction.id) || matches(faction.name) || matches(faction.key)) {
+      add(faction.id);
+      add(faction.name);
+      add(faction.key);
+    }
+  });
+
+  var mapFactions = runtimeMap && runtimeMap.factions;
+  if (mapFactions && typeof mapFactions === 'object') {
+    Object.keys(mapFactions).forEach(function(key) {
+      var meta = mapFactions[key] || {};
+      var values = [key, meta.id, meta.key, meta.label, meta.short, meta.scenarioFactionId, meta.scenarioFactionName];
+      if (values.some(matches)) values.forEach(add);
+    });
+  }
+
+  return aliases;
+}
+
+function runtimeRegionBelongsToPlayer(region, aliases) {
+  if (!region) return false;
+  var values = [
+    region.occupiedBy, region.controller, region.currentOwner, region.owner,
+    region.factionId, region.ownerKey, region.currentOwnerKey, region.controllerKey,
+    region.stableFactionId, region.factionName, region.ownerName
+  ];
+  return values.some(function(value) {
+    var normalized = String(value == null ? '' : value).replace(/\s+/g, '').toLowerCase();
+    return !!(normalized && aliases[normalized]);
+  });
+}
+
 // 更新经济系统（在 endTurn 中调用）
 function updateEconomy(timeRatio) {
   if (!GM.eraState) return;
 
   var es = GM.eraState;
   var centralControl = finiteNumberOr(es.centralControl, 0.5);
+  var ecCfg = P.economyConfig || {};
+  var redistributionRate = requireEconomyRatio(ecCfg.redistributionRate, 'economyConfig.redistributionRate', 0.3);
+  var privateRatio = requireEconomyRatio(ecCfg.privateIncomeRatio, 'economyConfig.privateIncomeRatio', 0.15);
 
   // 1. 计算各地区的收入和贡奉
   var totalTribute = 0;
@@ -104,11 +167,19 @@ function updateEconomy(timeRatio) {
   if (!runtimeMap && GM) runtimeMap = GM.mapData || GM.map || null;
   if (!runtimeMap && P) runtimeMap = P.mapData || P.map || null;
   var runtimeRegions = runtimeMap && Array.isArray(runtimeMap.regions) ? runtimeMap.regions : [];
+  var playerAliases = collectPlayerEconomyFactionAliases(runtimeMap);
+  var hasPlayerAlias = Object.keys(playerAliases).length > 0;
+  var hasExplicitPlayerRegion = hasPlayerAlias && runtimeRegions.some(function(region) {
+    return runtimeRegionBelongsToPlayer(region, playerAliases);
+  });
 
   // 如果有地图系统
   if (runtimeRegions.length > 0) {
     runtimeRegions.forEach(function(region) {
       if (!region || (!region.id && !region.name)) return;
+      // 新地图明确标出了玩家领地时，只征收玩家控制区。无法识别归属的旧地图
+      // 保留原来的全图兼容行为，避免旧档突然失去全部收入。
+      if (hasExplicitPlayerRegion && !runtimeRegionBelongsToPlayer(region, playerAliases)) return;
       var regionKey = String(region.id || region.name);
       var regionName = String(region.name || region.id);
 
@@ -148,7 +219,7 @@ function updateEconomy(timeRatio) {
   }
 
   // 1b. 无地图模式：从 GM.provinceStats 计算贡奉（地方区划已由 updateProvinceEconomy 维护）
-  if (totalTribute === 0 && GM.provinceStats && Object.keys(GM.provinceStats).length > 0) {
+  if (runtimeRegions.length === 0 && GM.provinceStats && Object.keys(GM.provinceStats).length > 0) {
     Object.keys(GM.provinceStats).forEach(function(provName) {
       var prov = GM.provinceStats[provName];
       if (!prov) return;
@@ -163,7 +234,6 @@ function updateEconomy(timeRatio) {
 
   // 2. 中央收到贡奉后，按比例回拨
   // 从配置读取回拨比例，默认 0.3
-  var redistributionRate = finiteNumberOr(P.economyConfig && P.economyConfig.redistributionRate, 0.3);
   var redistributed = Math.floor(totalTribute * redistributionRate);
 
   // 3. 按贡献占比分配回拨
@@ -181,9 +251,7 @@ function updateEconomy(timeRatio) {
 
   // 4. 更新中央财政——双层国库（国库/内库分离）
   var netRevenue = totalTribute - redistributed;
-  var ecCfg = P.economyConfig || {};
   var dualTreasury = ecCfg.dualTreasury === true;
-  var privateRatio = finiteNumberOr(ecCfg.privateIncomeRatio, 0.15);
 
   if (dualTreasury) {
     // ═══ 双层国库模式 ═══
@@ -203,7 +271,9 @@ function updateEconomy(timeRatio) {
     }
 
     // 破产检测
-    var bankruptThreshold = ecCfg.bankruptcyThreshold || -5000;
+    var bankruptThreshold = (ecCfg.bankruptcyThreshold === undefined || ecCfg.bankruptcyThreshold === null)
+      ? -5000
+      : finiteNumberOr(ecCfg.bankruptcyThreshold, -5000);
     if (GM.stateTreasury < bankruptThreshold) {
       if (!GM._bankruptcyTurns) GM._bankruptcyTurns = 0;
       GM._bankruptcyTurns++;

--- a/web/tm-endturn-core.js
+++ b/web/tm-endturn-core.js
@@ -12,6 +12,83 @@
 // 见 web/docs/architecture-map.md §1 行 5
 // ============================================================
 
+async function _tmRunCriticalEndTurnSystem(label, fn) {
+  try {
+    return await Promise.resolve(fn());
+  } catch (error) {
+    try {
+      if (typeof window !== 'undefined' && window.TM && TM.errors && typeof TM.errors.capture === 'function') {
+        TM.errors.capture(error, label);
+      } else if (typeof console !== 'undefined' && console.warn) {
+        console.warn('[' + label + ']', error);
+      }
+    } catch (_) {}
+    throw error;
+  }
+}
+
+async function _tmRunEndTurnDeterministicTail() {
+  await _tmRunCriticalEndTurnSystem('endTurn] building works tick', function() {
+    if (typeof window !== 'undefined' && window.TM && TM.BuildingWorks && typeof TM.BuildingWorks.tick === 'function') {
+      return TM.BuildingWorks.tick(GM, P);
+    }
+  });
+
+  await _tmRunCriticalEndTurnSystem('endTurn] talent cohorts tick', function() {
+    if (typeof window === 'undefined' || !window.TM || !TM.TalentCohorts || typeof TM.TalentCohorts.tick !== 'function') return;
+    if (typeof TM.TalentCohorts.enabled === 'function' && !TM.TalentCohorts.enabled(P)) return;
+    var talentCtx = (TM.TalentBottlenecks && typeof TM.TalentBottlenecks.buildCtx === 'function')
+      ? TM.TalentBottlenecks.buildCtx(GM, P)
+      : null;
+    TM.TalentCohorts.tick(GM, P, talentCtx);
+    if (TM.TalentBacklash && typeof TM.TalentBacklash.tick === 'function') {
+      return TM.TalentBacklash.tick(GM, P, talentCtx);
+    }
+  });
+
+  await _tmRunCriticalEndTurnSystem('endTurn] region status tick', function() {
+    if (typeof window !== 'undefined' && window.TM && TM.RegionStatus && typeof TM.RegionStatus.tick === 'function') {
+      return TM.RegionStatus.tick(GM, P);
+    }
+  });
+
+  await _tmRunCriticalEndTurnSystem('endTurn] field pipelines tick', function() {
+    if (typeof window !== 'undefined' && window.TM && TM.FieldPipes && typeof TM.FieldPipes.tick === 'function') {
+      return TM.FieldPipes.tick(GM, P);
+    }
+  });
+
+  await _tmRunCriticalEndTurnSystem('endTurn] social foundation tick', function() {
+    if (typeof window !== 'undefined' && window.TM && TM.SocialFoundation && typeof TM.SocialFoundation.tick === 'function') {
+      return TM.SocialFoundation.tick(GM, P);
+    }
+  });
+
+  await _tmRunCriticalEndTurnSystem('endTurn] renli tick', function() {
+    if (typeof window !== 'undefined' && window.TM && TM.Renli && typeof TM.Renli.endturnTick === 'function') {
+      return TM.Renli.endturnTick(GM, P);
+    }
+  });
+
+  await _tmRunCriticalEndTurnSystem('endTurn] office fallback tick', function() {
+    if (typeof window !== 'undefined' && window.TM && TM.OfficeFallback && typeof TM.OfficeFallback.tick === 'function') {
+      return TM.OfficeFallback.tick(GM, P);
+    }
+  });
+
+  await _tmRunCriticalEndTurnSystem('endTurn] final aggregate', function() {
+    if (typeof IntegrationBridge !== 'undefined' && IntegrationBridge && typeof IntegrationBridge.aggregateRegionsToVariables === 'function') {
+      return IntegrationBridge.aggregateRegionsToVariables();
+    }
+  });
+
+  await _tmRunCriticalEndTurnSystem('endTurn] reconcileArmyCommanders', function() {
+    if (typeof TM !== 'undefined' && TM.AIChange && TM.AIChange.Army && typeof TM.AIChange.Army.reconcileArmyCommanders === 'function') {
+      return TM.AIChange.Army.reconcileArmyCommanders();
+    }
+  });
+}
+
 async function _runPreSubmitPartyClassCalibration() {
   try {
     var _pcSchedulerRan = false;
@@ -717,43 +794,8 @@ async function _endTurnCore(options){
 
   // 建筑工役 tick（2026-06-12·确定性步·每回合恰一次）：在建递减→完工把效果写进 economyBase/fortLevel/民心叶子，
   // 维护费扣地方库银。须在 final aggregate 之前——完工改的叶子当回合即被聚合。
-  try { if (window.TM && TM.BuildingWorks && typeof TM.BuildingWorks.tick === 'function') TM.BuildingWorks.tick(GM, P); } catch(_bwTickE) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_bwTickE, 'endTurn] building works tick') : console.warn('[endTurn] building works tick', _bwTickE); }
-
-  // S3a·人才范式渗透引擎 tick：须在 BuildingWorks.tick 之后（本回合完工的新式学校已注册人才源），多瓶颈漏斗推进一回合。
-  // 瓶颈 ctx 由 tm-talent-bottlenecks 据全国真实 economyBase/政区/驻军实算（没产业=没岗位=毕业即失业）。flag talentCohortEnabled 默认关 → no-op。
-  try {
-    if (window.TM && TM.TalentCohorts && typeof TM.TalentCohorts.tick === 'function' && TM.TalentCohorts.enabled(P)) {
-      var _talentCtx = (TM.TalentBottlenecks && typeof TM.TalentBottlenecks.buildCtx === 'function') ? TM.TalentBottlenecks.buildCtx(GM, P) : null;
-      TM.TalentCohorts.tick(GM, P, _talentCtx);
-      // S5·全局阻力：渗透反弹 → 御案时政政治事件(请罢新学/失业学潮) + 临界旧式瓦解 + 写 _lastBacklash 供动态 room
-      if (TM.TalentBacklash && typeof TM.TalentBacklash.tick === 'function') TM.TalentBacklash.tick(GM, P, _talentCtx);
-    }
-  } catch(_tcTickE) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_tcTickE, 'endTurn] talent cohorts tick') : console.warn('[endTurn] talent cohorts tick', _tcTickE); }
-
-  // 地块状态 tick（2026-06-12·确定性步）：过期清除 + 状态民心摊叶 + 繁荣度缓变。
-  // 须在 BuildingWorks.tick 之后（完工状态当回合生效）、final aggregate 之前。
-  try { if (window.TM && TM.RegionStatus && typeof TM.RegionStatus.tick === 'function') TM.RegionStatus.tick(GM, P); } catch(_rsTickE) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_rsTickE, 'endTurn] region status tick') : console.warn('[endTurn] region status tick', _rsTickE); }
-
-  // 字段活化 tick（2026-06-12·S6·确定性步）：重税之地民心叶账缓跌（地板 25）+ _fieldLedger 近账。
-  // 同样须在 final aggregate 之前——叶子变更当回合即被聚合。
-  try { if (window.TM && TM.FieldPipes && typeof TM.FieldPipes.tick === 'function') TM.FieldPipes.tick(GM, P); } catch(_fpTickE) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_fpTickE, 'endTurn] field pipelines tick') : console.warn('[endTurn] field pipelines tick', _fpTickE); }
-
-  // 社会层地基 tick（2026-06-12·确定性步）：阶层结构基线缓变回归 + 议程引擎消长 + 党派双账合流。
-  // 须在 RegionStatus/FieldPipes 之后（要读灾域/税负实况）、final aggregate 之前。
-  try { if (window.TM && TM.SocialFoundation && typeof TM.SocialFoundation.tick === 'function') TM.SocialFoundation.tick(GM, P); } catch(_sfTickE) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_sfTickE, 'endTurn] social foundation tick') : console.warn('[endTurn] social foundation tick', _sfTickE); }
-
-  // 人力/徭役农政 tick（R2·2026-06-16·确定性步）：劳动力分流→双边际(在耕/地力)→粮产，写叶子 alloc + GM.renli 派生。
-  // 须在 SocialFoundation 之后、final aggregate 之前。R2 只写 alloc/派生·不动 ding/mouths·暂无消费方读 alloc（良性休眠）。
-  try { if (window.TM && TM.Renli && typeof TM.Renli.endturnTick === 'function') TM.Renli.endturnTick(GM, P); } catch(_rlTickE) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_rlTickE, 'endTurn] renli tick') : console.warn('[endTurn] renli tick', _rlTickE); }
-  // 官制占位·久悬补缺 tick(2026-06-18·确定性步)：冷门空占位挂太久→引擎铨选虚拟官员补上(flag useOfficeFallback·前12回合给AI office_spawn机会)。
-  try { if (window.TM && TM.OfficeFallback && typeof TM.OfficeFallback.tick === 'function') TM.OfficeFallback.tick(GM, P); } catch(_ofTickE) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_ofTickE, 'endTurn] office fallback tick') : console.warn('[endTurn] office fallback tick', _ofTickE); }
-
-  // 回合结束前最后一次聚合：确保 七变量(national) 严格等于 各区划叶子之和
-  // （因 AI 推演/各 engine.tick 都可能修改 division.population.mouths，需重新累计）
-  try { if (typeof IntegrationBridge !== 'undefined' && typeof IntegrationBridge.aggregateRegionsToVariables === 'function') IntegrationBridge.aggregateRegionsToVariables(); } catch(_aggFinalE) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_aggFinalE, 'endTurn] final aggregate') : console.warn('[endTurn] final aggregate', _aggFinalE); }
-
-  // 回合末·按统帅死活校正各军主帅引用：摘掉挂着死人(赐死/AI死/战死各路)的帅、留空缺待补任。须在赐死(applyEdictActions)+AI死(applyCharacterDeaths)都跑完之后
-  try { if (typeof TM !== 'undefined' && TM.AIChange && TM.AIChange.Army && typeof TM.AIChange.Army.reconcileArmyCommanders === 'function') TM.AIChange.Army.reconcileArmyCommanders(); } catch(_recACE) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_recACE, 'endTurn] reconcileArmyCommanders') : console.warn('[endTurn] reconcileArmyCommanders', _recACE); }
+  // 以上确定性结算都属于账本写入；任何一步失败必须到达外层事务边界，不能提交半个回合。
+  await _tmRunEndTurnDeterministicTail();
 
   // 亡国终局（2026-07-02）：消费民变改朝/权臣篡位/起义颠覆的终局信号（此前只写不读）→「天命已绝」终局屏。
   // 软终局：置于全部结算 tick 之后不打断管线，关屏后可继续观史/存档。新鲜度护栏在 _consumeDynastyEndSignal 内。

--- a/web/tm-endturn-edict.js
+++ b/web/tm-endturn-edict.js
@@ -456,9 +456,55 @@ function _findPositionInOfficeTree(posName) {
   return found;
 }
 
+function _edictCloneState(value) {
+  if (value == null || typeof value !== 'object') return value;
+  if (typeof deepClone === 'function') return deepClone(value);
+  return JSON.parse(JSON.stringify(value));
+}
+
+function _edictRestoreState(target, snapshot) {
+  if (Array.isArray(target) && Array.isArray(snapshot)) {
+    while (target.length > snapshot.length) target.pop();
+    for (var i = 0; i < snapshot.length; i++) {
+      var srcItem = snapshot[i], dstItem = target[i];
+      if (srcItem && dstItem && typeof srcItem === 'object' && typeof dstItem === 'object'
+          && Array.isArray(srcItem) === Array.isArray(dstItem)) {
+        _edictRestoreState(dstItem, srcItem);
+      } else {
+        target[i] = _edictCloneState(srcItem);
+      }
+    }
+    return target;
+  }
+  Object.keys(target || {}).forEach(function(key) {
+    if (!Object.prototype.hasOwnProperty.call(snapshot || {}, key)) delete target[key];
+  });
+  Object.keys(snapshot || {}).forEach(function(key) {
+    var src = snapshot[key], dst = target[key];
+    if (src && dst && typeof src === 'object' && typeof dst === 'object'
+        && Array.isArray(src) === Array.isArray(dst)) {
+      _edictRestoreState(dst, src);
+    } else {
+      target[key] = _edictCloneState(src);
+    }
+  });
+  return target;
+}
+
 /** 执行从诏令中提取的操作（在AI推演前执行，确保状态一致） */
 function applyEdictActions(actions) {
-  if (!actions) return;
+  if (!actions) return { ok: true, applied: false };
+  var _edictTxn = {
+    gmRef: GM,
+    pRef: P,
+    gm: _edictCloneState(GM),
+    p: _edictCloneState(P)
+  };
+  actions = Object.assign({}, actions);
+  ['appointments', 'dismissals', 'deaths', 'armyBuilds', 'rewards', 'payArrears', 'pardons'].forEach(function(key) {
+    actions[key] = Array.isArray(actions[key]) ? actions[key].slice() : [];
+  });
+  try {
   var appointedThisEdict = {};
   (actions.appointments || []).forEach(function(a){
     if (a && a.character) appointedThisEdict[a.character] = true;
@@ -500,7 +546,7 @@ function applyEdictActions(actions) {
         var prevHolder = hit.pos.holder || ((typeof _offAllHolders === 'function' && _offAllHolders(hit.pos)[0]) || '');
         var isConcurrent = !!a.concurrent || (typeof _offIsConcurrentAppointment === 'function' && _offIsConcurrentAppointment(a, a.raw || ''));
         if (!isConcurrent && typeof _offVacateByCharName === 'function') {
-          try { _offVacateByCharName(a.character, 'edict-appointment'); } catch(_vacE) {}
+          _offVacateByCharName(a.character, 'edict-appointment');
         }
         if (typeof _offSeatPersonInPosition === 'function') {
           _offSeatPersonInPosition(hit.pos, a.character, { oldHolder: prevHolder, replace: true });
@@ -544,7 +590,7 @@ function applyEdictActions(actions) {
         if (hit.pos.publicTreasury) hit.pos.publicTreasury.currentHead = a.character;
         if (typeof recordCharacterArc === 'function') recordCharacterArc(a.character, 'appointment', '奉诏就任' + a.position);
         // ★2026-07-04 交互双向性·受任者留一条"奉诏就任"知情记忆(imp7)·此前只进 careerHistory/arc/AffinityMap 不入 _memory→推演看不到这桩定义性擢升。relatedPerson=天子(玩家)
-        if (typeof NpcMemorySystem !== 'undefined') { try { NpcMemorySystem.remember(a.character, '奉诏' + (isConcurrent ? '加兼' : '就任') + a.position, '敬', 7, (P.playerInfo && P.playerInfo.characterName) || '天子', { source: 'witnessed', type: 'career', _noMirror: true }); } catch(_apM) {} }
+        if (typeof NpcMemorySystem !== 'undefined') NpcMemorySystem.remember(a.character, '奉诏' + (isConcurrent ? '加兼' : '就任') + a.position, '敬', 7, (P.playerInfo && P.playerInfo.characterName) || '天子', { source: 'witnessed', type: 'career', _noMirror: true });
         if (typeof CorruptionEngine !== 'undefined' && CorruptionEngine.markAsRecentAppointment) CorruptionEngine.markAsRecentAppointment(char);
         addEB('人事', a.character + (isConcurrent ? '奉诏加兼' : '奉诏就任') + a.position + '（' + hit.deptPath + '）', { credibility: 'high' });
         if (typeof AffinityMap !== 'undefined') AffinityMap.add(a.character, P.playerInfo.characterName || '玩家', 5, '被委以重任');
@@ -599,38 +645,31 @@ function applyEdictActions(actions) {
     }
   });
   // 1a·奉诏任命/委以重任 → 确定性小幅抬该员 loyalty（被信用则效忠·君恩进"驱动抗命"的那本账·与 affinity 同步累积）
-  try {
-    if (typeof adjustCharacterLoyalty === 'function') actions.appointments.forEach(function(_ap) {
-      var _ac = (_ap && _ap.character) ? findCharByName(_ap.character) : null;
-      if (_ac) adjustCharacterLoyalty(_ac, 3, '奉诏委以重任·君恩', { source: 'edict-appointment-loyalty', oncePerTurn: true });
-    });
-  } catch (_apLoyE) {}
+  if (typeof adjustCharacterLoyalty === 'function') actions.appointments.forEach(function(_ap) {
+    var _ac = (_ap && _ap.character) ? findCharByName(_ap.character) : null;
+    if (_ac) adjustCharacterLoyalty(_ac, 3, '奉诏委以重任·君恩', { source: 'edict-appointment-loyalty', oncePerTurn: true });
+  });
   // 1b·奉诏犒赏/封赏/加俸 → 玩家亲自施恩确定性抬该员 loyalty + affinity（让"发钱真有用"·不再全靠 AI 看心情演 reward）
-  try {
-    var _pNameRw = (P.playerInfo && P.playerInfo.characterName) || '玩家';
-    (actions.rewards || []).forEach(function(_rw) {
-      var _rc = (_rw && _rw.character) ? findCharByName(_rw.character) : null;
-      if (!_rc) return;
-      if (typeof adjustCharacterLoyalty === 'function') adjustCharacterLoyalty(_rc, 4, '奉诏受赏·君恩', { source: 'edict-reward-loyalty', oncePerTurn: true });
-      else _rc.loyalty = Math.min(100, ((typeof _rc.loyalty === 'number' && isFinite(_rc.loyalty)) ? _rc.loyalty : 50) + 4);
-      if (typeof AffinityMap !== 'undefined') AffinityMap.add(_rw.character, _pNameRw, 8, '奉诏受赏');
-      if (typeof recordCharacterArc === 'function') recordCharacterArc(_rw.character, 'reward', '奉诏受赏·君恩');
-      addEB('人事', _rw.character + ' 奉诏受赏，感恩戴德', { credibility: 'high' });
-    });
-  } catch (_rwLoyE) {}
+  var _pNameRw = (P.playerInfo && P.playerInfo.characterName) || '玩家';
+  actions.rewards.forEach(function(_rw) {
+    var _rc = (_rw && _rw.character) ? findCharByName(_rw.character) : null;
+    if (!_rc) return;
+    if (typeof adjustCharacterLoyalty === 'function') adjustCharacterLoyalty(_rc, 4, '奉诏受赏·君恩', { source: 'edict-reward-loyalty', oncePerTurn: true });
+    else _rc.loyalty = Math.min(100, ((typeof _rc.loyalty === 'number' && isFinite(_rc.loyalty)) ? _rc.loyalty : 50) + 4);
+    if (typeof AffinityMap !== 'undefined') AffinityMap.add(_rw.character, _pNameRw, 8, '奉诏受赏');
+    if (typeof recordCharacterArc === 'function') recordCharacterArc(_rw.character, 'reward', '奉诏受赏·君恩');
+    addEB('人事', _rw.character + ' 奉诏受赏，感恩戴德', { credibility: 'high' });
+  });
   // 下诏任免主帅·确定性补绑：含军职(督师/总兵/提督…)的任命，额外把 army.commander 绑到对应部队（不取代官制任命·在其上补绑兵权）
-  try {
-    if (typeof TM !== 'undefined' && TM.AIChange && TM.AIChange.Army && typeof TM.AIChange.Army.bindCommanderFromAppointment === 'function') {
-      actions.appointments.forEach(function(_ap) {
-        if (_ap && _ap.character && _ap.position) {
-          try { TM.AIChange.Army.bindCommanderFromAppointment(_ap.character, _ap.position, { source: 'edict.appoint_commander' }); } catch (_bcOneE) {}
-        }
-      });
-    }
-  } catch (_bcE) {}
+  if (typeof TM !== 'undefined' && TM.AIChange && TM.AIChange.Army && typeof TM.AIChange.Army.bindCommanderFromAppointment === 'function') {
+    actions.appointments.forEach(function(_ap) {
+      if (_ap && _ap.character && _ap.position) {
+        TM.AIChange.Army.bindCommanderFromAppointment(_ap.character, _ap.position, { source: 'edict.appoint_commander' });
+      }
+    });
+  }
   // 下诏建军·确定性落名册（操作不蒸发；实际兵力规模与招募成本交回合内 sc18 军事推演 AI 估）
-  try {
-    var _ab = (actions && Array.isArray(actions.armyBuilds)) ? actions.armyBuilds : [];
+    var _ab = actions.armyBuilds;
     var _applyArmy = (typeof TM !== 'undefined' && TM.AIChange && TM.AIChange.Army && TM.AIChange.Army.applyAIArmyChange)
       ? TM.AIChange.Army.applyAIArmyChange
       : (typeof applyAIArmyChange === 'function' ? applyAIArmyChange : null);
@@ -638,16 +677,14 @@ function applyEdictActions(actions) {
       _ab.forEach(function(b) {
         if (!b || !b.name) return;
         var _pending = (b.strength == null);
-        var _res = null;
-        try {
-          _res = _applyArmy({
+        var _res = _applyArmy({
             name: b.name, action: 'create',
             soldiers: _pending ? 0 : b.strength,
             branch: '募兵',
             state: _pending ? 'recruiting' : 'garrison',
             reason: '奉诏组建'
           }, { source: 'edict.build_army', silentEB: true });
-        } catch (_aE) {}
+        if (!_res || _res.ok === false || !_res.army) throw new Error('奉诏建军失败: ' + b.name + '·' + String(_res && _res.reason || '未创建军队'));
         var _army = _res && _res.army;
         if (_army) {
           _army._edictBuilt = true;
@@ -660,10 +697,8 @@ function applyEdictActions(actions) {
         }
       });
     }
-  } catch (_abErr) {}
   // 下诏补饷·确定性结算欠饷（走 settleArmyArrears 真扣国库·不再免费清欠；与 UI 发饷按钮靠 settleArmyArrears 读当前欠饷月数幂等·不双结算）
-  try {
-    var _pa = (actions && Array.isArray(actions.payArrears)) ? actions.payArrears : [];
+    var _pa = actions.payArrears;
     var _paMS = (typeof MilitarySystems !== 'undefined' && MilitarySystems) || (typeof TM !== 'undefined' && TM.MilitarySystems) || (typeof global !== 'undefined' && global.MilitarySystems) || null;
     if (_pa.length && _paMS && typeof _paMS.settleArmyArrears === 'function' && Array.isArray(GM.armies)) {
       var _pfPay = (P.playerInfo && P.playerInfo.factionName) || '';
@@ -682,6 +717,7 @@ function applyEdictActions(actions) {
         _targets.forEach(function(a) {
           if (!a || (a.payArrearsMonths || 0) <= 0) return;
           var _r = _paMS.settleArmyArrears(a, {});
+          if (!_r || _r.ok === false) throw new Error('奉诏补饷失败: ' + a.name + '·' + String(_r && _r.reason || '未知错误'));
           if (_r && _r.monthsCleared > 0 && typeof addEB === 'function') {
             var _c = _r.cost || {};
             addEB('军务', '奉诏补饷·' + a.name + '·清欠 ' + _r.monthsCleared + ' 月·耗银 ' + (_c.money || 0) + (_r.shortfall > 0 ? '（国库不足·欠 ' + Math.round(_r.shortfall) + '）' : ''), { credibility: 'high' });
@@ -689,13 +725,13 @@ function applyEdictActions(actions) {
         });
       });
     }
-  } catch (_paErr) {}
   // 免职——双路径：postSystem + officeTree
   actions.dismissals.forEach(function(a) {
     var char = findCharByName(a.character);
     var didAny = false;
     if (typeof PostTransfer !== 'undefined' && GM.postSystem && GM.postSystem.posts && GM.postSystem.posts.length) {
-      try { PostTransfer.cascadeVacate(a.character); didAny = true; } catch(e){ if(window.TM&&TM.errors) TM.errors.capture(e,'endturn.cascadeVacate'); }
+      PostTransfer.cascadeVacate(a.character);
+      didAny = true;
     }
     // 同时扫 officeTree 把所有 holder===name 的 position 清空
     if (GM.officeTree) {
@@ -733,11 +769,9 @@ function applyEdictActions(actions) {
     addEB('人事', a.character + '被免职', { credibility: didAny ? 'high' : 'medium' });
     if (typeof AffinityMap !== 'undefined') AffinityMap.add(a.character, P.playerInfo.characterName || '玩家', -10, '被免职');
     // 免职即解兵权：被免者若正挂某军主帅，确定性摘帅留空缺（角色仍在世·按死活扫的 reconciler 抓不到这条，须显式摘）
-    try {
-      if (typeof TM !== 'undefined' && TM.AIChange && TM.AIChange.Army && typeof TM.AIChange.Army.vacateArmiesByCommander === 'function') {
-        TM.AIChange.Army.vacateArmiesByCommander(a.character, { moraleHit: 10, markLost: true, eb: '{army}主帅{name}奉诏去职、兵权交卸，军中暂缺主将，待下诏补任' });
-      }
-    } catch (_vcE) {}
+    if (typeof TM !== 'undefined' && TM.AIChange && TM.AIChange.Army && typeof TM.AIChange.Army.vacateArmiesByCommander === 'function') {
+      TM.AIChange.Army.vacateArmiesByCommander(a.character, { moraleHit: 10, markLost: true, eb: '{army}主帅{name}奉诏去职、兵权交卸，军中暂缺主将，待下诏补任' });
+    }
   });
   // 赦免/起复——清羁押/流放/致仕/逃亡·按需从 _origOfficialTitle 复官回座(治"下诏放人/官复原职没用")
   if (Array.isArray(actions.pardons)) actions.pardons.forEach(function(a) {
@@ -757,10 +791,10 @@ function applyEdictActions(actions) {
       var _orig = char._origOfficialTitle;
       var _hit = (typeof _findPositionInOfficeTree === 'function') ? _findPositionInOfficeTree(_orig) : null;
       if (_hit && _hit.pos && typeof _offSeatPersonInPosition === 'function') {
-        try { _offSeatPersonInPosition(_hit.pos, char.name, { replace: false }); } catch(_seatE){}
+        _offSeatPersonInPosition(_hit.pos, char.name, { replace: false });
       }
       if (typeof _offAddCharOfficeTitle === 'function') {
-        try { _offAddCharOfficeTitle(char, _orig, {}); } catch(_atE){ char.officialTitle = _orig; char.position = _orig; }
+        _offAddCharOfficeTitle(char, _orig, {});
       } else { char.officialTitle = _orig; char.position = _orig; }
       if (!char.officialTitle) { char.officialTitle = _orig; char.position = _orig; }
       char.title = char.officialTitle || _orig;
@@ -768,9 +802,9 @@ function applyEdictActions(actions) {
     }
     if (!char.careerHistory) char.careerHistory = [];
     char.careerHistory.push({ turn: GM.turn, event: a.restore ? ('奉诏起复' + (_restoredTitle ? '·复任' + _restoredTitle : '·官复原职')) : '奉诏赦免开释' });
-    if (typeof recordCharacterArc === 'function') { try { recordCharacterArc(a.character, 'recall', char._releaseReason); } catch(_arcE){} }
+    if (typeof recordCharacterArc === 'function') recordCharacterArc(a.character, 'recall', char._releaseReason);
     if (typeof addEB === 'function') addEB('人事', a.character + '·' + char._releaseReason + (_restoredTitle ? '（复任' + _restoredTitle + '）' : ''), { credibility: 'high' });
-    if (typeof AffinityMap !== 'undefined') { try { AffinityMap.add(a.character, P.playerInfo.characterName || '玩家', 12, a.restore ? '被起复复职·感恩' : '蒙赦释放·感恩'); } catch(_afE){} }
+    if (typeof AffinityMap !== 'undefined') AffinityMap.add(a.character, P.playerInfo.characterName || '玩家', 12, a.restore ? '被起复复职·感恩' : '蒙赦释放·感恩');
   });
   // 大赦天下·群体放归（第七轮G·flag massAmnestyEnabled 默认关·个体赦免不受此闸影响）
   //   在押人犯尽数放归田里(不复官·与个体"起复"有别)·谋逆/通敌/已定罪逆党十恶不赦·
@@ -787,7 +821,7 @@ function applyEdictActions(actions) {
       ch._releaseReason = '恩诏大赦·放归田里';
       if (!ch.careerHistory) ch.careerHistory = [];
       ch.careerHistory.push({ turn: GM.turn, event: '蒙恩诏大赦放归' });
-      if (typeof AffinityMap !== 'undefined') { try { AffinityMap.add(ch.name, P.playerInfo.characterName || '玩家', 8, '蒙大赦放归·感恩'); } catch(_amAf){} }
+      if (typeof AffinityMap !== 'undefined') AffinityMap.add(ch.name, P.playerInfo.characterName || '玩家', 8, '蒙大赦放归·感恩');
       _amReleased.push(ch.name);
     });
     if (typeof addEB === 'function') addEB('恩诏', '大赦天下：放归' + _amReleased.length + '人' + (_amHeld.length ? '·谋逆重犯' + _amHeld.length + '人不在赦列' : ''), { credibility: 'high' });
@@ -812,13 +846,11 @@ function applyEdictActions(actions) {
     addEB('人事', a.character + '被赐死');
         // P-QAM·诛逆确定性 floor：赐死的若是【系统已定罪的逆党】(char._conspiracyConvicted·镇压谋反时 apply 标记)，确定性给小额皇威——
         //   诛除已坐实奸党正法是立威之举·此为不含糊的质判定(已定罪 yes/no)·小额保底；其余 赐死(可能忠良/未定罪)不在此硬给·忠奸交 AI 经 record_sentiment_changes 判。系统每回合 ±5 净封顶兜住与 AI 的叠加。
-        try {
           if (char._conspiracyConvicted || a.treasonCited) {
             var _AEx = (typeof AuthorityEngines !== 'undefined' && AuthorityEngines) || (typeof window !== 'undefined' && window.AuthorityEngines) || null;
             var _zhuniWhy = (char._conspiracyConvicted ? '诛除已定罪逆党 ' : '诛除通敌奸佞 ') + a.character + '·正法立威';
             if (_AEx && typeof _AEx.adjustHuangwei === 'function') _AEx.adjustHuangwei('executeRebelMinister', 3, _zhuniWhy);
           }
-        } catch (_exHwE) {}
         // 赐死某人会让其亲近者对玩家产生怨恨
         if (typeof AffinityMap !== 'undefined') {
           var deadRels = AffinityMap.getRelations(a.character);
@@ -828,7 +860,6 @@ function applyEdictActions(actions) {
         //   非地方官部门(fiscal/military/judicial/central/imperial) 直降 subDepts[dept].true（aggregate 不覆盖这几口·持久）；
         //   地方官(provincial)或推不出 → 降全势力 div.corruption 源头（FE.adjustPlayerDivisionCorruption·cascade + 回合末 aggregate 都吃·持久）。
         //   量 = 保守保底 P_EXEC_CORR_DROP（可调·处决走诏书确定性通道·不走 AI reform_effects）。
-        try {
           var _title = String((char.officialTitle || char.position || '')).trim();
           var P_EXEC_CORR_DROP = 5; // 处决一名官员对其部门的震慑降浊度·保守保底·可调
           var _dept = '';
@@ -848,8 +879,18 @@ function applyEdictActions(actions) {
             var _ne = _FEe.adjustPlayerDivisionCorruption(_pFacE, -P_EXEC_CORR_DROP, 0, 100);
             if (_ne === 0) _FEe.adjustPlayerDivisionCorruption('', -P_EXEC_CORR_DROP, 0, 100);
           }
-        } catch (_execCorrE) {}
   });
+  return { ok: true, applied: true };
+  } catch (error) {
+    _edictRestoreState(_edictTxn.gmRef, _edictTxn.gm);
+    _edictRestoreState(_edictTxn.pRef, _edictTxn.p);
+    try {
+      if (typeof window !== 'undefined' && window.TM && TM.errors && typeof TM.errors.capture === 'function') {
+        TM.errors.capture(error, 'applyEdictActions.atomic');
+      }
+    } catch (_) {}
+    throw error;
+  }
 }
 
 // ============================================================

--- a/web/tm-endturn-followup.js
+++ b/web/tm-endturn-followup.js
@@ -24,6 +24,62 @@
 
   var ns = global.TM.Endturn.AI.followup;
 
+  function _cloneNpcApplyState(value) {
+    if (value == null || typeof value !== 'object') return value;
+    if (typeof deepClone === 'function') return deepClone(value);
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function _restoreNpcApplyState(target, snapshot) {
+    if (Array.isArray(target) && Array.isArray(snapshot)) {
+      while (target.length > snapshot.length) target.pop();
+      for (var i = 0; i < snapshot.length; i++) {
+        var srcItem = snapshot[i], dstItem = target[i];
+        if (srcItem && dstItem && typeof srcItem === 'object' && typeof dstItem === 'object'
+            && Array.isArray(srcItem) === Array.isArray(dstItem)) {
+          _restoreNpcApplyState(dstItem, srcItem);
+        } else {
+          target[i] = _cloneNpcApplyState(srcItem);
+        }
+      }
+      return target;
+    }
+    Object.keys(target || {}).forEach(function(key) {
+      if (!Object.prototype.hasOwnProperty.call(snapshot || {}, key)) delete target[key];
+    });
+    Object.keys(snapshot || {}).forEach(function(key) {
+      var src = snapshot[key], dst = target[key];
+      if (src && dst && typeof src === 'object' && typeof dst === 'object'
+          && Array.isArray(src) === Array.isArray(dst)) {
+        _restoreNpcApplyState(dst, src);
+      } else {
+        target[key] = _cloneNpcApplyState(src);
+      }
+    });
+    return target;
+  }
+
+  function _applyNpcDeepResultAtomic(applyFn, result) {
+    if (typeof applyFn !== 'function') return { ok: false, error: new Error('NPC deep-result applier missing') };
+    var gmRef = global.GM;
+    var pRef = global.P;
+    var gmSnapshot = _cloneNpcApplyState(gmRef);
+    var pSnapshot = _cloneNpcApplyState(pRef);
+    try {
+      applyFn(result);
+      return { ok: true };
+    } catch (error) {
+      _restoreNpcApplyState(gmRef, gmSnapshot);
+      _restoreNpcApplyState(pRef, pSnapshot);
+      try {
+        if (global.TM && TM.errors && typeof TM.errors.capture === 'function') TM.errors.capture(error, 'npc-deep-result.atomic');
+      } catch (_) {}
+      return { ok: false, error: error };
+    }
+  }
+
+  ns._applyNpcDeepResultAtomic = _applyNpcDeepResultAtomic;
+
   // ══ 立项拆分 alias（2026-07-06·第十九拆·alias 范式）══════════════════
   //  27 个顶层纯 helper + 6 个 ns 公开导出已迁 tm-endturn-followup-helpers.js
   //  （载于本文件之前·装载期填 bucket TM.__etFollowupParts·勿动序·契约见 lint-split-contracts）。
@@ -158,6 +214,17 @@
         _specialtySummary.sc17,
         _specialtySummary.sc18
       ].filter(Boolean).join('');
+    }
+    function _recordNpcDeepApplyFailure(id, outcome) {
+      var error = outcome && outcome.error;
+      if (!Array.isArray(GM._npcDeepApplyFailures)) GM._npcDeepApplyFailures = [];
+      GM._npcDeepApplyFailures.push({
+        id: id,
+        turn: GM.turn || 0,
+        message: String(error && (error.message || error) || 'unknown apply error')
+      });
+      if (GM._npcDeepApplyFailures.length > 10) GM._npcDeepApplyFailures = GM._npcDeepApplyFailures.slice(-10);
+      try { if (typeof recordSubcallError === 'function') recordSubcallError(id, 'apply', error || new Error('NPC deep result apply failed')); } catch (_) {}
     }
       // §5 sc15-sc27 后续子调用 + 收尾（NPC 深度·势力·财政·军事·审计·丰化·叙事）
       // ★ 并行优化（2026-04-30）：sc1 完成后扇出三路并行
@@ -426,9 +493,15 @@
               // ★2026-07-02 应用同源:走与 sc15 相同的 _applyNpcDeepResult——此前 sc15n 只存结果不应用·
               //   开着 sc15n 时 mood/忠诚/压力/关系网/暗流事件簿/阴谋台账全部静默停摆(半成品替代)。
               //   faction_undercurrents 亦由共享函数接管(历史归档+势力strength+事件簿·比原 append 版语义全)。
-              // 应用错误不外抛(2026-07-04 审查定罪)：外层 _runSubcall 重试会整段重跑·已落的 delta 再落一次=双记账。
-              // 应用中断=部分落地不回滚(可容)·但绝不因应用错误触发 AI 重调重应用。
-              try { _applyNpcDeepResult(p15n); } catch (_apE15n) { console.warn('[sc15n] 应用中断(不重试防双记):', _apE15n); }
+              // 已解析结果先固化，再以同步事务应用。失败只回滚本次应用且不向 _runSubcall 抛出，
+              // 因而不会重新调用 AI，也不会留下半套人物/关系/地区变更。
+              var _summary15nBefore = _specialtySummary.sc15;
+              var _apply15n = _applyNpcDeepResultAtomic(_applyNpcDeepResult, p15n);
+              if (!_apply15n.ok) {
+                _specialtySummary.sc15 = _summary15nBefore;
+                _recordNpcDeepApplyFailure('sc15n', _apply15n);
+                return;
+              }
               if (Array.isArray(p15n.npc_cognition)) {
                 if (!GM._npcCognition || typeof GM._npcCognition !== 'object') GM._npcCognition = {};
                 p15n.npc_cognition.forEach(function(nc) {
@@ -573,10 +646,14 @@
           var p15 = _p15Parse ? _p15Parse.parsed : null;
           if (p15) {
             // ★2026-07-02 应用逻辑抽出 _applyNpcDeepResult(见 Branch A 顶部)与 sc15n 共享·内容与原内联一致
-            // 应用错误不外抛(同 sc15n·重试整段重跑=已落 delta 双记账·2026-07-04 审查定罪)
-            try { _applyNpcDeepResult(p15); } catch (_apE15) { console.warn('[sc15] 应用中断(不重试防双记):', _apE15); }
-
             GM._turnAiResults.subcall15 = p15;
+            var _summary15Before = _specialtySummary.sc15;
+            var _apply15 = _applyNpcDeepResultAtomic(_applyNpcDeepResult, p15);
+            if (!_apply15.ok) {
+              _specialtySummary.sc15 = _summary15Before;
+              _recordNpcDeepApplyFailure('sc15', _apply15);
+              return;
+            }
             // Phase 4·sc15n API surface mirror (Slice 3 scaffold)·下游可读 subcall15n 而非分散 subcall15/subcall07
             // 3-tier 内容拆分·core (mood/relationship)·common (hidden_moves/undercurrents)·extended (schemes/rumors)
             try {

--- a/web/tm-endturn-followup.js
+++ b/web/tm-endturn-followup.js
@@ -217,13 +217,6 @@
     }
     function _recordNpcDeepApplyFailure(id, outcome) {
       var error = outcome && outcome.error;
-      if (!Array.isArray(GM._npcDeepApplyFailures)) GM._npcDeepApplyFailures = [];
-      GM._npcDeepApplyFailures.push({
-        id: id,
-        turn: GM.turn || 0,
-        message: String(error && (error.message || error) || 'unknown apply error')
-      });
-      if (GM._npcDeepApplyFailures.length > 10) GM._npcDeepApplyFailures = GM._npcDeepApplyFailures.slice(-10);
       try { if (typeof recordSubcallError === 'function') recordSubcallError(id, 'apply', error || new Error('NPC deep result apply failed')); } catch (_) {}
     }
       // §5 sc15-sc27 后续子调用 + 收尾（NPC 深度·势力·财政·军事·审计·丰化·叙事）

--- a/web/tm-endturn-pipeline-steps.js
+++ b/web/tm-endturn-pipeline-steps.js
@@ -420,22 +420,17 @@
       //   会战阶段:AI 推演已解算·涉玩家势力军的战斗被咽喉拦截入延后队列·此处亲征/委之·严格保位(先于诏令应用)·
       //   flag GM._yujiaQinzheng 默认 OFF → pending 恒空 → runPending no-op → 零行为变更·自带 try/catch 不外抛
       fn: async function(ctx) {
-        try {
-          if (typeof window !== 'undefined' && window.TMBattleTurn && typeof window.TMBattleTurn.runPending === 'function') {
-            await window.TMBattleTurn.runPending(typeof GM !== 'undefined' ? GM : null);
-          }
-        } catch (e) { try { console.warn('[pipeline.post-ai-edict·yujia-qinzheng]', e); } catch(_){} }
+        if (typeof window !== 'undefined' && window.TMBattleTurn && typeof window.TMBattleTurn.runPending === 'function') {
+          await window.TMBattleTurn.runPending(typeof GM !== 'undefined' ? GM : null);
+        }
         if (!ctx.input._agentEdictActionsApplied && typeof applyEdictActions === 'function') {
-          try {
-            var ea = ctx.input.edictActions;
-            if (ea && ((ea.appointments && ea.appointments.length) || (ea.dismissals && ea.dismissals.length) || (ea.deaths && ea.deaths.length) || (ea.armyBuilds && ea.armyBuilds.length) || (ea.rewards && ea.rewards.length) || (ea.payArrears && ea.payArrears.length))) {
-              applyEdictActions(ea);
-            }
-          } catch(e) { try { console.warn('[pipeline.post-ai-edict] applyEdictActions failed', e); } catch(_){} }
+          var ea = ctx.input.edictActions;
+          if (ea && ((ea.appointments && ea.appointments.length) || (ea.dismissals && ea.dismissals.length) || (ea.deaths && ea.deaths.length) || (ea.armyBuilds && ea.armyBuilds.length) || (ea.rewards && ea.rewards.length) || (ea.payArrears && ea.payArrears.length))) {
+            applyEdictActions(ea);
+          }
         }
         // G2·step 0a·Path C·扫 ctx.input.edicts 文本·识别 enke keyword → 路由到 _kjG2OnEnkeApproved (或 pending queue)
-        try {
-          if (!ctx.input._agentEdictKeywordActionsApplied) {
+        if (!ctx.input._agentEdictKeywordActionsApplied) {
           if (typeof _kjG2ScanCtxInputEdictsForEnke === 'function' && ctx.input && ctx.input.edicts) {
             var enkeActions = _kjG2ScanCtxInputEdictsForEnke(ctx.input.edicts);
             if (enkeActions && enkeActions.length && typeof _kjG2OnEnkeApprovedViaEdict === 'function') {
@@ -444,11 +439,9 @@
               }
             }
           }
-          }
-        } catch(e) { try { console.warn('[pipeline.post-ai-edict] G2 enke scan', e); } catch(_){} }
+        }
         // G3·RAA·C1·扫 ctx.input.edicts 识别 wuju keyword (跟 G2 同 paradigm)
-        try {
-          if (!ctx.input._agentEdictKeywordActionsApplied) {
+        if (!ctx.input._agentEdictKeywordActionsApplied) {
           if (typeof _kjG3ScanCtxInputEdictsForWuju === 'function' && ctx.input && ctx.input.edicts) {
             var wujuActions = _kjG3ScanCtxInputEdictsForWuju(ctx.input.edicts);
             if (wujuActions && wujuActions.length && typeof _kjG3OnWujuApprovedViaEdict === 'function') {
@@ -457,11 +450,9 @@
               }
             }
           }
-          }
-        } catch(e) { try { console.warn('[pipeline.post-ai-edict] G3 wuju scan', e); } catch(_){} }
+        }
         // G5·扫 tongzi keyword
-        try {
-          if (!ctx.input._agentEdictKeywordActionsApplied) {
+        if (!ctx.input._agentEdictKeywordActionsApplied) {
           if (typeof _kjG5ScanCtxInputEdictsForTongzi === 'function' && ctx.input && ctx.input.edicts) {
             var tongziActions = _kjG5ScanCtxInputEdictsForTongzi(ctx.input.edicts);
             if (tongziActions && tongziActions.length && typeof _kjG5OnTongziApprovedViaEdict === 'function') {
@@ -470,13 +461,11 @@
               }
             }
           }
-          }
-        } catch(e) { try { console.warn('[pipeline.post-ai-edict] G5 tongzi scan', e); } catch(_){} }
+        }
         // F6·扫时政记 (AI 推演输出)·覆盖"诏书未明写但 AI 在叙事中体现开恩科"的情况
         // 复用 3 个 ScanCtxInputEdictsForX·passing string (parser 已加 negative gate 防"罢/未/搁置"误识别)
-        try {
-          var _ar = ctx.results && ctx.results.aiResult;
-          if (_ar && !ctx.input._agentModeRan) {
+        var _ar = ctx.results && ctx.results.aiResult;
+        if (_ar && !ctx.input._agentModeRan) {
             var _shizhengTxt = [_ar.shizhengji || '', _ar.zhengwen || '', _ar.shilu || ''].join('\n');
             if (_shizhengTxt.trim()) {
               if (typeof _kjG2ScanCtxInputEdictsForEnke === 'function' && typeof _kjG2OnEnkeApprovedViaEdict === 'function') {
@@ -501,20 +490,17 @@
                 }
               }
             }
-          }
-        } catch(e) { try { console.warn('[pipeline.post-ai-edict] G2/G3/G5 shizhengji scan', e); } catch(_){} }
+        }
         if (!ctx.input._agentTyrantActivitiesApplied && typeof TyrantActivitySystem !== 'undefined' && TyrantActivitySystem && TyrantActivitySystem.applyEffects) {
-          try {
-            var ta = ctx.input.tyrantActivities || (typeof GM !== 'undefined' ? GM._turnTyrantActivities : null) || [];
-            if (ta.length > 0) {
-              ctx.results.tyrantResult = TyrantActivitySystem.applyEffects(ta);
-            }
-          } catch(e) { try { console.warn('[pipeline.post-ai-edict] tyrant applyEffects failed', e); } catch(_){} }
+          var ta = ctx.input.tyrantActivities || (typeof GM !== 'undefined' ? GM._turnTyrantActivities : null) || [];
+          if (ta.length > 0) {
+            ctx.results.tyrantResult = TyrantActivitySystem.applyEffects(ta);
+          }
         }
         ctx.input._postAiEdictRan = true;
         return ctx;
       },
-      onError: 'continue',
+      onError: 'abort',
       reads: ['ctx.input.edictActions', 'ctx.input.tyrantActivities', 'GM.officeTree', 'GM.armies', 'ctx.results.aiResult'],
       writes: ['GM.officeTree', 'GM._tyrantHistory', 'GM._tyrantDecadence', 'ctx.results.tyrantResult', 'ctx.input._postAiEdictRan', 'GM.armies (御驾亲征战果回填)']
     },

--- a/web/tm-game-loop.js
+++ b/web/tm-game-loop.js
@@ -547,6 +547,15 @@ function validateScenario(sc) {
     });
   }
 
+  // 经济比例必须在导入/开局边界拒绝，避免结算时生成负收入或超过 100% 的拆分。
+  var economyConfig = sc.economyConfig || {};
+  ['redistributionRate', 'privateIncomeRatio'].forEach(function(field) {
+    if (economyConfig[field] === undefined || economyConfig[field] === null || economyConfig[field] === '') return;
+    if (typeof economyConfig[field] !== 'number' || !Number.isFinite(economyConfig[field]) || economyConfig[field] < 0 || economyConfig[field] > 1) {
+      errors.push('经济配置 ' + field + ' 必须是 0 到 1 之间的数字');
+    }
+  });
+
   // 时间校验
   if (!sc.time && !P.time.year) warnings.push('未设定起始年份');
 

--- a/web/tm-map-system.js
+++ b/web/tm-map-system.js
@@ -120,7 +120,7 @@ function migrateLegacyRuntimeMap(legacyMap) {
   var migrated = cloneMapValue(legacyMap);
   normalizeGameMapRuntime(migrated);
   migrated.mapSchemaVersion = TM_RUNTIME_MAP_SCHEMA_VERSION;
-  if (typeof GM !== 'undefined' && GM) GM.mapData = migrated;
+  if (typeof GM !== 'undefined' && GM) GM.mapData = migrated; // arch-ok: runtime-map owner performs the one-time legacy map migration
   return migrated;
 }
 

--- a/web/tm-map-system.js
+++ b/web/tm-map-system.js
@@ -1127,7 +1127,7 @@ function computeIntersection(p1, p2, edge, bounds) {
 function renderHighlights(ctx) {
   var state = GM.mapData.state;
 
-  if (state.hoveredCityId) {
+  if (state.hoveredCityId != null) {
     var polygon = GM.mapData.polygons[state.hoveredCityId];
     if (polygon) {
       ctx.beginPath();
@@ -1149,7 +1149,7 @@ function renderHighlights(ctx) {
     }
   }
 
-  if (state.selectedCityId && state.selectedCityId !== state.hoveredCityId) {
+  if (state.selectedCityId != null && state.selectedCityId !== state.hoveredCityId) {
     var polygon = GM.mapData.polygons[state.selectedCityId];
     if (polygon) {
       ctx.beginPath();
@@ -1354,7 +1354,9 @@ function getCityAtPosition(x, y) {
   for (var cityId in GM.mapData.polygons) {
     var polygon = GM.mapData.polygons[cityId];
     if (isPointInPolygon(mapX, mapY, polygon)) {
-      return parseInt(cityId);
+      // 城市键允许数字、字符串和 UUID。对象键在运行时本来就是字符串，
+      // 强转数字会把 UUID 变成 NaN，也会让合法的 "0" 在调用方被当作不存在。
+      return cityId;
     }
   }
 
@@ -1390,7 +1392,7 @@ function initMapInteraction() {
     if (GM.mapData.state.hoveredCityId !== cityId) {
       GM.mapData.state.hoveredCityId = cityId;
       _scheduleRender();
-      canvas.style.cursor = cityId ? 'pointer' : 'default';
+      canvas.style.cursor = cityId != null ? 'pointer' : 'default';
     }
   });
 
@@ -1401,7 +1403,7 @@ function initMapInteraction() {
 
     var cityId = getCityAtPosition(x, y);
 
-    if (cityId) {
+    if (cityId != null) {
       GM.mapData.state.selectedCityId = cityId;
       renderMap();
       showCityInfo(cityId);
@@ -1472,45 +1474,73 @@ function showCityInfo(cityId) {
   var faction = findFacByName(city.owner);
   // faction may be null if owner not found — safe, not dereferenced below
 
-  var html = '<div style="position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:var(--bg);border:2px solid var(--gold);border-radius:0.5rem;padding:1.5rem;min-width:300px;z-index:10000;">';
-  html += '<h3 style="color:var(--gold);margin-bottom:1rem;">' + city.name + '</h3>';
-  html += '<div style="margin-bottom:0.5rem;"><strong>归属：</strong>' + city.owner + '</div>';
-    html += '<div style="margin-bottom:0.5rem;"><strong>人口：</strong>' + _mapSystemFiniteNumberOr(city.population, 0).toLocaleString() + '</div>';
-  html += '<div style="margin-bottom:0.5rem;"><strong>收入：</strong>' + (city.income||0).toLocaleString() + ' 金/月</div>';
+  var overlay = document.createElement('div');
+  overlay.id = 'city-info-overlay';
+  overlay.style.cssText = 'position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);z-index:10001;'; // 须压过 map-viewer-overlay(10000)·旧9999令城市详情被压在地图下(2026-07-04 审查定罪)
+
+  var panel = document.createElement('div');
+  panel.style.cssText = 'position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:var(--bg);border:2px solid var(--gold);border-radius:0.5rem;padding:1.5rem;min-width:300px;z-index:10000;';
+
+  var title = document.createElement('h3');
+  title.style.cssText = 'color:var(--gold);margin-bottom:1rem;';
+  title.textContent = String(city.name == null ? '' : city.name);
+  panel.appendChild(title);
+
+  function appendField(label, value) {
+    var row = document.createElement('div');
+    row.style.cssText = 'margin-bottom:0.5rem;';
+    var strong = document.createElement('strong');
+    strong.textContent = label + '：';
+    row.appendChild(strong);
+    row.appendChild(document.createTextNode(String(value == null ? '' : value)));
+    panel.appendChild(row);
+  }
+
+  appendField('归属', city.owner);
+  appendField('人口', _mapSystemFiniteNumberOr(city.population, 0).toLocaleString());
+  appendField('收入', _mapSystemFiniteNumberOr(city.income, 0).toLocaleString() + ' 金/月');
+
   var _cgv = Number(city.garrison || 0);
   if (_cgv > 0) {
-    html += '<div style="margin-bottom:0.5rem;"><strong>驻军：</strong>' + _cgv.toLocaleString() + '</div>';
+    appendField('驻军', _cgv.toLocaleString());
   } else {
     // 无逐块驻军实体：兜底显所属势力机动军力（游牧显「机动兵力」·余显「势力军力」），免得游牧/无常驻势力显 0
     var _cms = faction && Number(faction.militaryStrength || faction.military || 0);
     if (isFinite(_cms) && _cms > 0) {
       var _cnomad = /部落|游牧|游猎/.test(String((faction && faction.type) || '') + String((faction && faction.traits) ? faction.traits.join('') : ''));
-      html += '<div style="margin-bottom:0.5rem;"><strong>' + (_cnomad ? '机动兵力' : '势力军力') + '：</strong>' + _cms.toLocaleString() + '</div>';
+      appendField(_cnomad ? '机动兵力' : '势力军力', _cms.toLocaleString());
     } else {
-      html += '<div style="margin-bottom:0.5rem;"><strong>驻军：</strong>0</div>';
+      appendField('驻军', 0);
     }
   }
 
-  if ((city.neighbors||[]).length > 0) {
-    html += '<div style="margin-top:1rem;"><strong>相邻城市：</strong></div>';
-    html += '<div style="font-size:0.9rem;color:var(--txt-s);">';
-    (city.neighbors||[]).forEach(function(neighborId) {
-      var neighbor = GM.mapData.cities[neighborId];
-      if (neighbor) {
-        html += neighbor.name + ' (' + neighbor.owner + ')、';
-      }
-    });
-    html = html.slice(0, -1);
-    html += '</div>';
+  var neighborLabels = [];
+  (city.neighbors || []).forEach(function(neighborId) {
+    var neighbor = GM.mapData.cities[neighborId];
+    if (neighbor) neighborLabels.push(String(neighbor.name == null ? '' : neighbor.name) + ' (' + String(neighbor.owner == null ? '' : neighbor.owner) + ')');
+  });
+  if (neighborLabels.length > 0) {
+    var neighborTitle = document.createElement('div');
+    neighborTitle.style.cssText = 'margin-top:1rem;';
+    var neighborStrong = document.createElement('strong');
+    neighborStrong.textContent = '相邻城市：';
+    neighborTitle.appendChild(neighborStrong);
+    panel.appendChild(neighborTitle);
+
+    var neighborList = document.createElement('div');
+    neighborList.style.cssText = 'font-size:0.9rem;color:var(--txt-s);';
+    neighborList.textContent = neighborLabels.join('、');
+    panel.appendChild(neighborList);
   }
 
-  html += '<button class="bt" onclick="closeCityInfo()" style="width:100%;margin-top:1rem;">关闭</button>';
-  html += '</div>';
-
-  var overlay = document.createElement('div');
-  overlay.id = 'city-info-overlay';
-  overlay.style.cssText = 'position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);z-index:10001;'; // 须压过 map-viewer-overlay(10000)·旧9999令城市详情被压在地图下(2026-07-04 审查定罪)
-  overlay.innerHTML = html;
+  var closeButton = document.createElement('button');
+  closeButton.type = 'button';
+  closeButton.className = 'bt';
+  closeButton.style.cssText = 'width:100%;margin-top:1rem;';
+  closeButton.textContent = '关闭';
+  closeButton.addEventListener('click', closeCityInfo);
+  panel.appendChild(closeButton);
+  overlay.appendChild(panel);
 
   document.body.appendChild(overlay);
 }

--- a/web/tm-map-system.js
+++ b/web/tm-map-system.js
@@ -19,6 +19,9 @@ function _mapSystemFiniteNumberOr(value, fallback) {
 }
 
 function initMapSystem() {
+  // 旧档可能只有 GM.map，而兼容初始化会预先造出一个空 GM.mapData。
+  // 在补脚手架前先让权威选择器完成一次有版本标记的迁移。
+  getLiveMapData();
   if (!GM.mapData) {
     GM.mapData = {
       cities: {},
@@ -101,11 +104,41 @@ function ensureMapDataScaffold(mapData) {
   return mapData;
 }
 
+var TM_RUNTIME_MAP_SCHEMA_VERSION = 1;
+
+function hasRuntimeMapContent(mapData) {
+  if (!mapData || typeof mapData !== 'object') return false;
+  if (Array.isArray(mapData.regions) && mapData.regions.length > 0) return true;
+  if (Array.isArray(mapData.items) && mapData.items.length > 0) return true;
+  if (Array.isArray(mapData.roads) && mapData.roads.length > 0) return true;
+  return ['cities', 'polygons', 'edges'].some(function(field) {
+    return mapData[field] && typeof mapData[field] === 'object' && Object.keys(mapData[field]).length > 0;
+  });
+}
+
+function migrateLegacyRuntimeMap(legacyMap) {
+  var migrated = cloneMapValue(legacyMap);
+  normalizeGameMapRuntime(migrated);
+  migrated.mapSchemaVersion = TM_RUNTIME_MAP_SCHEMA_VERSION;
+  if (typeof GM !== 'undefined' && GM) GM.mapData = migrated;
+  return migrated;
+}
+
 function getLiveMapData() {
-  if (typeof GM !== 'undefined' && GM && GM.mapData && GM.mapData.regions) return GM.mapData;
-  if (typeof GM !== 'undefined' && GM && GM.map && GM.map.regions) return GM.map;
-  if (typeof P !== 'undefined' && P && P.map && P.map.regions) return P.map;
-  if (typeof P !== 'undefined' && P && P.mapData && P.mapData.regions) return P.mapData;
+  if (typeof GM !== 'undefined' && GM) {
+    if (hasRuntimeMapContent(GM.mapData)) {
+      if (!GM.mapData.mapSchemaVersion) GM.mapData.mapSchemaVersion = TM_RUNTIME_MAP_SCHEMA_VERSION;
+      return GM.mapData;
+    }
+    if (hasRuntimeMapContent(GM.map)) return migrateLegacyRuntimeMap(GM.map);
+    if (GM.mapData && typeof GM.mapData === 'object') return GM.mapData;
+  }
+  if (typeof P !== 'undefined' && P) {
+    if (hasRuntimeMapContent(P.mapData)) return P.mapData;
+    if (hasRuntimeMapContent(P.map)) return P.map;
+    if (P.mapData && typeof P.mapData === 'object') return P.mapData;
+    if (P.map && typeof P.map === 'object') return P.map;
+  }
   return null;
 }
 
@@ -201,6 +234,7 @@ function findScenarioFactionByMapValue(value, mapData) {
 function normalizeGameMapRuntime(mapData) {
   if (!mapData || typeof mapData !== 'object') return mapData;
   ensureMapDataScaffold(mapData);
+  mapData.mapSchemaVersion = TM_RUNTIME_MAP_SCHEMA_VERSION;
   mapData.width = mapData.width || mapData.config.width || 1200;
   mapData.height = mapData.height || mapData.config.height || 800;
   mapData.config.width = mapData.width;

--- a/web/tm-office-editor.js
+++ b/web/tm-office-editor.js
@@ -596,7 +596,7 @@ function _aiGenOptionsHTML(containerId, showMode) {
   return modeHtml +
     '<details style="margin-bottom:0.4rem;"><summary style="font-size:0.82rem;color:var(--txt-d);cursor:pointer;">\u2699\ufe0f \u9ad8\u7ea7\u9009\u9879</summary>'+
     '<div style="padding:0.4rem 0;">'+
-    '<div style="margin-bottom:0.3rem;"><label style="font-size:0.8rem;color:var(--txt-d);">\u5399\u4e8b\u98ce\u683c\u8986\u76d6 <span style="font-size:0.75rem;">(\u7a7a\u5219\u7528\u5168\u5c40\u8bbe\u7f6e: '+((typeof P!=='undefined'&&P.conf&&P.conf.style)||'\u6587\u5b66\u5316')+')</span></label>'+
+    '<div style="margin-bottom:0.3rem;"><label style="font-size:0.8rem;color:var(--txt-d);">\u5399\u4e8b\u98ce\u683c\u8986\u76d6 <span style="font-size:0.75rem;">(\u7a7a\u5219\u7528\u5168\u5c40\u8bbe\u7f6e: '+_officeEditorEsc((typeof P!=='undefined'&&P.conf&&P.conf.style)||'\u6587\u5b66\u5316')+')</span></label>'+
     '<input id="'+containerId+'-style" placeholder="\u5982\uff1a\u5c0f\u8bf4\u98ce\u683c/\u8bf4\u4e66\u4eba\u98ce\u683c/\u6b63\u53f2\u98ce\u683c" style="width:100%;font-size:0.82rem;"></div>'+
     '<div><label style="font-size:0.8rem;color:var(--txt-d);">\u53c2\u8003\u8d44\u6599\u8986\u76d6 <span style="font-size:0.75rem;">(\u7a7a\u5219\u7528\u5168\u5c40\u53c2\u8003\u6587\u672c)</span></label>'+
     '<textarea id="'+containerId+'-ref" rows="2" placeholder="\u53ef\u8d34\u5165\u53c2\u8003\u6587\u672c\u3001\u53f2\u4e66\u6bb5\u843d\u7b49\u2026" style="width:100%;font-size:0.82rem;"></textarea></div>'+
@@ -896,7 +896,7 @@ window.aiGenFullScenario = function() {
     '<select id="fg-words"><option value="brief">\u7b80\u7565\uff08\u5feb\u901f\uff09</option><option value="normal" selected>\u6807\u51c6\uff08\u63a8\u8350\uff09</option><option value="detailed">\u8be6\u7ec6\uff08\u5185\u5bb9\u4e30\u5bcc\uff09</option><option value="full">\u5b8c\u6574\uff08\u6700\u8be6\u5c3d\uff09</option></select></div></div>'+
     '<details style="margin:0.4rem 0;"><summary style="font-size:0.82rem;color:var(--txt-d);cursor:pointer;">\u2699\ufe0f \u9ad8\u7ea7\u9009\u9879</summary>'+
     '<div style="padding:0.4rem 0;">'+
-    '<div style="margin-bottom:0.3rem;"><label style="font-size:0.8rem;color:var(--txt-d);">\u5399\u4e8b\u98ce\u683c\u8986\u76d6 <span style="font-size:0.75rem;">(\u7a7a\u5219\u7528\u5168\u5c40: ' + globalStyle + ')</span></label>'+
+    '<div style="margin-bottom:0.3rem;"><label style="font-size:0.8rem;color:var(--txt-d);">\u5399\u4e8b\u98ce\u683c\u8986\u76d6 <span style="font-size:0.75rem;">(\u7a7a\u5219\u7528\u5168\u5c40: ' + _officeEditorEsc(globalStyle) + ')</span></label>'+
     '<input id="fg-style" placeholder="\u5982\uff1a\u5c0f\u8bf4\u98ce\u683c/\u8bf4\u4e66\u4eba\u98ce\u683c/\u6b63\u53f2\u98ce\u683c" style="width:100%;font-size:0.82rem;"></div>'+
     '<div><label style="font-size:0.8rem;color:var(--txt-d);">\u53c2\u8003\u8d44\u6599\u8986\u76d6 <span style="font-size:0.75rem;">(\u7a7a\u5219\u7528\u5168\u5c40\u53c2\u8003\u6587\u672c)</span></label>'+
     '<textarea id="fg-ref" rows="2" placeholder="\u53ef\u8d34\u5165\u53c2\u8003\u6587\u672c\u3001\u53f2\u4e66\u6bb5\u843d\u7b49\u2026" style="width:100%;font-size:0.82rem;"></textarea></div>'+
@@ -935,6 +935,12 @@ window.execFullGen = async function() {
 // Phase 6: editTech / editFac / editRul / editEvt
 // + render overrides with edit buttons
 // ========================================================
+function _officeEditorEsc(value) {
+  if (typeof escHtml === 'function') return escHtml(String(value == null ? '' : value));
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
 
 // ---- editTech(i) ----
 function editTech(i) {
@@ -942,11 +948,11 @@ function editTech(i) {
   if (!t) return;
   openGenericModal(
     '\u7F16\u8F91\u79D1\u6280',
-    '<div class="form-group"><label>\u540D\u79F0</label><input id="etk-name" value="' + (t.name||'') + '"></div>'+
-    '<div class="form-group"><label>\u63CF\u8FF0</label><textarea id="etk-desc" rows="2">' + (t.desc||'') + '</textarea></div>'+
+    '<div class="form-group"><label>\u540D\u79F0</label><input id="etk-name" value="' + _officeEditorEsc(t.name||'') + '"></div>'+
+    '<div class="form-group"><label>\u63CF\u8FF0</label><textarea id="etk-desc" rows="2">' + _officeEditorEsc(t.desc||'') + '</textarea></div>'+
     '<div class="form-group"><label>\u65F6\u4EE3</label><select id="etk-era"><option value="\u521D\u7EA7"' + (t.era==='\u521D\u7EA7'?' selected':'') + '>\u521D\u7EA7</option><option value="\u4E2D\u7EA7"' + (t.era==='\u4E2D\u7EA7'?' selected':'') + '>\u4E2D\u7EA7</option><option value="\u9AD8\u7EA7"' + (t.era==='\u9AD8\u7EA7'?' selected':'') + '>\u9AD8\u7EA7</option></select></div>'+
-    '<div class="form-group"><label>\u524D\u7F6E\u6761\u4EF6(\u9017\u53F7\u5206\u9694)</label><input id="etk-prereqs" value="' + (t.prereqs||[]).join(',') + '"></div>'+
-    '<div class="form-group"><label>\u6548\u679C(JSON)</label><input id="etk-effect" value="' + JSON.stringify(t.effect||{}) + '"></div>',
+    '<div class="form-group"><label>\u524D\u7F6E\u6761\u4EF6(\u9017\u53F7\u5206\u9694)</label><input id="etk-prereqs" value="' + _officeEditorEsc((t.prereqs||[]).join(',')) + '"></div>'+
+    '<div class="form-group"><label>\u6548\u679C(JSON)</label><input id="etk-effect" value="' + _officeEditorEsc(JSON.stringify(t.effect||{})) + '"></div>',
     function() {
       var tk = P.techTree[i];
       if (!tk) return;
@@ -973,10 +979,10 @@ function renderTechTab(em, sid) {
     list.map(function(t) {
       var i = P.techTree.indexOf(t);
       return '<div class="cd"><div style="display:flex;justify-content:space-between;align-items:center;">'+
-        '<span><strong>' + t.name + '</strong> <span class="tg">' + (t.era||'') + '</span></span>'+
+        '<span><strong>' + _officeEditorEsc(t.name) + '</strong> <span class="tg">' + _officeEditorEsc(t.era||'') + '</span></span>'+
         '<span><button class="bt bsm" onclick="editTech(' + i + ')">\u7F16\u8F91</button>'+
         '<button class="bd bsm" onclick="P.techTree.splice(' + i + ',1);renderEdTab(\u0027t-tech\u0027);">\u2715</button></span></div>'+
-        (t.desc ? '<div style="font-size:0.82rem;color:var(--txt-d);margin-top:0.3rem;">' + t.desc + '</div>' : '') +
+        (t.desc ? '<div style="font-size:0.82rem;color:var(--txt-d);margin-top:0.3rem;">' + _officeEditorEsc(t.desc) + '</div>' : '') +
         '</div>';
     }).join('') || '<div style="color:var(--txt-d);font-size:0.85rem;">\u6682\u65E0</div>';
 }
@@ -987,12 +993,12 @@ function editFac(i) {
   if (!f) return;
   openGenericModal(
     '\u7F16\u8F91\u6D3E\u7CFB',
-    '<div class="form-group"><label>\u540D\u79F0</label><input id="efc-name" value="' + (f.name||'') + '"></div>'+
-    '<div class="form-group"><label>\u9886\u8896</label><input id="efc-leader" value="' + (f.leader||'') + '"></div>'+
-    '<div class="form-group"><label>\u63CF\u8FF0</label><textarea id="efc-desc" rows="2">' + (f.desc||'') + '</textarea></div>'+
-    '<div class="form-group"><label>\u610F\u8BC6\u5F62\u6001</label><input id="efc-ideology" value="' + (f.ideology||'') + '"></div>'+
-    '<div class="form-group"><label>\u5730\u76D8</label><input id="efc-territory" value="' + (f.territory||'') + '"></div>'+
-    '<div class="form-group"><label>\u5B9E\u529B (0-100)</label><input type="range" id="efc-strength" min="0" max="100" value="' + (f.strength!=null?f.strength:50) + '" oninput="document.getElementById(\u0027efc-strength-v\u0027).textContent=this.value"> <span id="efc-strength-v">' + (f.strength!=null?f.strength:50) + '</span></div>',
+    '<div class="form-group"><label>\u540D\u79F0</label><input id="efc-name" value="' + _officeEditorEsc(f.name||'') + '"></div>'+
+    '<div class="form-group"><label>\u9886\u8896</label><input id="efc-leader" value="' + _officeEditorEsc(f.leader||'') + '"></div>'+
+    '<div class="form-group"><label>\u63CF\u8FF0</label><textarea id="efc-desc" rows="2">' + _officeEditorEsc(f.desc||'') + '</textarea></div>'+
+    '<div class="form-group"><label>\u610F\u8BC6\u5F62\u6001</label><input id="efc-ideology" value="' + _officeEditorEsc(f.ideology||'') + '"></div>'+
+    '<div class="form-group"><label>\u5730\u76D8</label><input id="efc-territory" value="' + _officeEditorEsc(f.territory||'') + '"></div>'+
+    '<div class="form-group"><label>\u5B9E\u529B (0-100)</label><input type="range" id="efc-strength" min="0" max="100" value="' + _officeEditorEsc(f.strength!=null?f.strength:50) + '" oninput="document.getElementById(\u0027efc-strength-v\u0027).textContent=this.value"> <span id="efc-strength-v">' + _officeEditorEsc(f.strength!=null?f.strength:50) + '</span></div>',
     function() {
       var fc = P.factions[i];
       if (!fc) return;
@@ -1018,10 +1024,10 @@ function renderFacTab(em, sid) {
     list.map(function(f) {
       var i = P.factions.indexOf(f);
       return '<div class="cd"><div style="display:flex;justify-content:space-between;align-items:center;">'+
-        '<strong>' + f.name + '</strong>'+
+        '<strong>' + _officeEditorEsc(f.name) + '</strong>'+
         '<span><button class="bt bsm" onclick="editFac(' + i + ')">\u7F16\u8F91</button>'+
         '<button class="bd bsm" onclick="P.factions.splice(' + i + ',1);renderEdTab(\u0027t-fac\u0027);">\u2715</button></span></div>'+
-        (f.desc ? '<div style="font-size:0.82rem;color:var(--txt-d);margin-top:0.2rem;">' + f.desc + '</div>' : '') +
+        (f.desc ? '<div style="font-size:0.82rem;color:var(--txt-d);margin-top:0.2rem;">' + _officeEditorEsc(f.desc) + '</div>' : '') +
         '</div>';
     }).join('') || '<div style="color:var(--txt-d);font-size:0.85rem;">\u6682\u65E0</div>';
 }
@@ -1032,14 +1038,14 @@ function editRul(i) {
   if (!r) return;
   openGenericModal(
     '\u7F16\u8F91\u89C4\u5219',
-    '<div class="form-group"><label>\u540D\u79F0</label><input id="erl-name" value="' + (r.name||'') + '"></div>'+
-    '<div class="form-group"><label>\u89E6\u53D1\u53D8\u91CF</label><input id="erl-var" value="' + (r.trigger&&r.trigger.variable||'') + '"></div>'+
+    '<div class="form-group"><label>\u540D\u79F0</label><input id="erl-name" value="' + _officeEditorEsc(r.name||'') + '"></div>'+
+    '<div class="form-group"><label>\u89E6\u53D1\u53D8\u91CF</label><input id="erl-var" value="' + _officeEditorEsc(r.trigger&&r.trigger.variable||'') + '"></div>'+
     '<div class="form-group"><label>\u89E6\u53D1\u6761\u4EF6</label>'+
     '<select id="erl-op"><option value="&lt;"' + ((r.trigger&&r.trigger.op)==='<'?' selected':'') + '>&lt;</option>'+
     '<option value="&gt;"' + ((r.trigger&&r.trigger.op)==='>'?' selected':'') + '>&gt;</option>'+
     '<option value="=="' + ((r.trigger&&r.trigger.op)==='=='?' selected':'') + '>&gt;=</option></select>'+
-    ' <input id="erl-val" type="number" value="' + (r.trigger&&r.trigger.value!=null?r.trigger.value:20) + '" style="width:60px;"></div>'+
-    '<div class="form-group"><label>\u53D9\u4E8B\u6548\u679C</label><textarea id="erl-narrative" rows="2">' + (r.effect&&r.effect.narrative||'') + '</textarea></div>'+
+    ' <input id="erl-val" type="number" value="' + _officeEditorEsc(r.trigger&&r.trigger.value!=null?r.trigger.value:20) + '" style="width:60px;"></div>'+
+    '<div class="form-group"><label>\u53D9\u4E8B\u6548\u679C</label><textarea id="erl-narrative" rows="2">' + _officeEditorEsc(r.effect&&r.effect.narrative||'') + '</textarea></div>'+
     '<div class="form-group"><label>\u542F\u7528</label><input type="checkbox" id="erl-enabled"' + (r.enabled?' checked':'') + '></div>',
     function() {
       var rl = P.rules[i];
@@ -1066,10 +1072,10 @@ function renderRulTab(em, sid) {
     list.map(function(r) {
       var i = P.rules.indexOf(r);
       return '<div class="cd"><div style="display:flex;justify-content:space-between;align-items:center;">'+
-        '<strong>' + r.name + '</strong>'+
+        '<strong>' + _officeEditorEsc(r.name) + '</strong>'+
         '<span><button class="bt bsm" onclick="editRul(' + i + ')">\u7F16\u8F91</button>'+
         '<button class="bd bsm" onclick="P.rules.splice(' + i + ',1);renderEdTab(\u0027t-rul\u0027);">\u2715</button></span></div>'+
-        '<div style="font-size:0.78rem;color:var(--txt-d);">' + (r.trigger&&r.trigger.variable?r.trigger.variable+' '+r.trigger.op+' '+r.trigger.value:'') + '</div>'+
+        '<div style="font-size:0.78rem;color:var(--txt-d);">' + _officeEditorEsc(r.trigger&&r.trigger.variable?r.trigger.variable+' '+r.trigger.op+' '+r.trigger.value:'') + '</div>'+
         '</div>';
     }).join('') || '<div style="color:var(--txt-d);font-size:0.85rem;">\u6682\u65E0</div>';
 }
@@ -1080,12 +1086,12 @@ function editEvt(i) {
   if (!ev) return;
   openGenericModal(
     '\u7F16\u8F91\u4E8B\u4EF6',
-    '<div class="form-group"><label>\u540D\u79F0</label><input id="evt-name" value="' + (ev.name||'') + '"></div>'+
-    '<div class="form-group"><label>\u89E6\u53D1\u56DE\u5408</label><input type="number" id="evt-turn" value="' + (ev.triggerTurn||0) + '"></div>'+
+    '<div class="form-group"><label>\u540D\u79F0</label><input id="evt-name" value="' + _officeEditorEsc(ev.name||'') + '"></div>'+
+    '<div class="form-group"><label>\u89E6\u53D1\u56DE\u5408</label><input type="number" id="evt-turn" value="' + _officeEditorEsc(ev.triggerTurn||0) + '"></div>'+
     '<div class="form-group"><label>\u7C7B\u578B</label>'+
     '<select id="evt-type"><option value="scripted"' + (ev.type==='scripted'?' selected':'') + '>scripted</option>'+
     '<option value="random"' + (ev.type==='random'?' selected':'') + '>random</option></select></div>'+
-    '<div class="form-group"><label>\u53D9\u4E8B</label><textarea id="evt-narrative" rows="3">' + (ev.narrative||'') + '</textarea></div>'+
+    '<div class="form-group"><label>\u53D9\u4E8B</label><textarea id="evt-narrative" rows="3">' + _officeEditorEsc(ev.narrative||'') + '</textarea></div>'+
     '<div class="form-group"><label><input type="checkbox" id="evt-onetime"' + (ev.oneTime?' checked':'') + '> \u4EC5\u89E6\u53D1\u4E00\u6B21</label></div>',
     function() {
       var ev2 = P.events[i];
@@ -1109,10 +1115,10 @@ function renderEvtTab(em, sid) {
     list.map(function(ev) {
       var i = P.events.indexOf(ev);
       return '<div class="cd"><div style="display:flex;justify-content:space-between;align-items:center;">'+
-        '<strong>' + ev.name + '</strong>'+
+        '<strong>' + _officeEditorEsc(ev.name) + '</strong>'+
         '<span><button class="bt bsm" onclick="editEvt(' + i + ')">\u7F16\u8F91</button>'+
         '<button class="bd bsm" onclick="P.events.splice(' + i + ',1);renderEdTab(\u0027t-evt\u0027);">\u2715</button></span></div>'+
-        '<div style="font-size:0.78rem;color:var(--txt-d);">\u7B2C ' + (ev.triggerTurn||0) + ' \u56DE\u5408 | ' + (ev.type||'scripted') + (ev.oneTime?' | \u5355\u6B21':'') + '</div>'+
+        '<div style="font-size:0.78rem;color:var(--txt-d);">\u7B2C ' + _officeEditorEsc(ev.triggerTurn||0) + ' \u56DE\u5408 | ' + _officeEditorEsc(ev.type||'scripted') + (ev.oneTime?' | \u5355\u6B21':'') + '</div>'+
         '</div>';
     }).join('') || '<div style="color:var(--txt-d);font-size:0.85rem;">\u6682\u65E0</div>';
 }
@@ -1136,7 +1142,7 @@ function renderEvtTab(em, sid) {
       '<div style="font-size:0.8rem;color:var(--txt-d);margin-bottom:0.5rem;">全局参考资料，供 AI 生成和史实模式使用。</div>'+
       '<div class="fd full">'+
       '<label>参考资料（可粘贴史书段落、论文等）</label>'+
-      '<textarea id="wld-ref-text" rows="6" style="width:100%;" placeholder="在此粘贴参考文本…">' + (refVal.replace(/</g,'&lt;').replace(/>/g,'&gt;')) + '</textarea>'+
+      '<textarea id="wld-ref-text" rows="6" style="width:100%;" placeholder="在此粘贴参考文本…">' + _officeEditorEsc(refVal) + '</textarea>'+
       '</div>'+
       '<div style="display:flex;gap:0.4rem;margin-top:0.4rem;">'+
       '<button class="bt bp" onclick="_wldSaveRef()">✅ 保存参考资料</button>'+
@@ -1190,11 +1196,11 @@ function renderCivicTab(em) {
     if (c.sid !== sid) return '';
     return '<div class="card" style="margin-bottom:6px;">'+
       '<div style="display:flex;justify-content:space-between;align-items:center;">'+
-      '<strong>' + (c.name || '') + '</strong>'+
+      '<strong>' + _officeEditorEsc(c.name || '') + '</strong>'+
       '<span><button class="bt bsm" onclick="editCivic(' + i + ')">' + '\u7F16\u8F91</button>'+
       '<button class="bd bsm" onclick="P.civicTree.splice(' + i + ',1);renderEdTab(\'t-civic\');">\u2715</button></span>'+
       '</div>'+
-      '<div style="font-size:12px;color:var(--txt-d);margin-top:2px;">' + (c.desc || '') + '</div>'+
+      '<div style="font-size:12px;color:var(--txt-d);margin-top:2px;">' + _officeEditorEsc(c.desc || '') + '</div>'+
       '</div>';
   }).join('');
   em.innerHTML = '<h4 style="color:var(--gold);">\u5E02\u653F\u6811</h4>'+
@@ -1641,11 +1647,11 @@ function renderOfficeTab(em) {
       }
       nodesDivs +=
         '<div style="font-size:12px;color:#9ac870;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">'
-        + (nd.name || '?') + _svgSuccLabel + '</div>';
+         + _officeEditorEsc(nd.name || '?') + _svgSuccLabel + '</div>';
       if (nd.rank || nd.holder) {
         nodesDivs += '<div style="font-size:11px;color:#5a7a42;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">';
-        if (nd.rank)   nodesDivs += nd.rank;
-        if (nd.holder) nodesDivs += (nd.rank ? ' \u2013 ' : '') + nd.holder;
+        if (nd.rank)   nodesDivs += _officeEditorEsc(nd.rank);
+        if (nd.holder) nodesDivs += (nd.rank ? ' \u2013 ' : '') + _officeEditorEsc(nd.holder);
         nodesDivs += '</div>';
       }
       nodesDivs += '</div>';
@@ -1698,7 +1704,7 @@ function renderOfficeTab(em) {
         + 'font-size:12px;color:' + nameClr + ';flex-shrink:0">' + icon + '</div>';
       nodesDivs +=
         '<span style="flex:1;font-size:12px;font-weight:bold;color:' + nameClr + ';'
-        + 'overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + (nd.name || '?') + '</span>';
+        + 'overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + _officeEditorEsc(nd.name || '?') + '</span>';
       nodesDivs += colBtn;
       if (!isEmperor) {
         nodesDivs +=
@@ -1721,7 +1727,7 @@ function renderOfficeTab(em) {
       nodesDivs +=
         '<div style="display:flex;align-items:center;gap:4px;padding:2px 5px;font-size:10px;color:#6a5020">';
       nodesDivs += (descText4
-        ? '<span style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + descText4 + '</span>'
+        ? '<span style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + _officeEditorEsc(descText4) + '</span>'
         : '<span style="flex:1"></span>');
       if (statsText4)
         nodesDivs += '<span>' + statsText4 + '</span>';
@@ -1835,19 +1841,19 @@ function _renderOfficeDept(dept, path, depth) {
       fns.map(function(fn, fi) {
         return '<span style="background:var(--bg-4,#2a2a2a);color:var(--txt-d);font-size:12px;'
           + 'padding:1px 6px;border-radius:10px;cursor:pointer" '
-          + 'onclick="_officeFnDel(' + pathStr + ',' + fi + ')" title="点击删除">× ' + fn + '</span>';
+          + 'onclick="_officeFnDel(' + pathStr + ',' + fi + ')" title="点击删除">× ' + _officeEditorEsc(fn) + '</span>';
       }).join('') + '</div>'
     : '';
   var posHTML = ps.map(function(p, pi) {
     return '<div style="display:flex;align-items:center;gap:6px;padding:3px 8px;border-top:1px solid var(--bg-4,#333)">'
       + '<span style="flex:1;font-size:12px;color:var(--txt-s)">'
-      + (p.name||'')
-      + (p.rank ? ' <span style="color:var(--txt-d);font-size:12px">('+p.rank+')</span>' : '')
+      + _officeEditorEsc(p.name||'')
+      + (p.rank ? ' <span style="color:var(--txt-d);font-size:12px">('+_officeEditorEsc(p.rank)+')</span>' : '')
       + (function(){var _sl={appointment:'\u6D41',hereditary:'\u88AD',examination:'\u79D1',military:'\u519B',recommendation:'\u8350'};return p.succession&&_sl[p.succession]?' <span style="font-size:10px;background:var(--bg-4);padding:0 3px;border-radius:2px;color:var(--txt-d)">'+_sl[p.succession]+'</span>':'';})()
-      + (p.holder ? ' <span style="color:var(--gold);font-size:12px">&mdash;'+p.holder+'</span>' : '')
+      + (p.holder ? ' <span style="color:var(--gold);font-size:12px">&mdash;'+_officeEditorEsc(p.holder)+'</span>' : '')
       + '</span>'
       + '<span style="font-size:12px;color:var(--txt-d);flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">'
-      + (p.desc||'') + '</span>'
+      + _officeEditorEsc(p.desc||'') + '</span>'
       + '<button class="bd bsm" onclick="_officeEditPos(' + pathStr + ',' + pi + ')">✎</button>'
       + '<button class="bd bsm" onclick="_officeDelPos(' + pathStr + ',' + pi + ')">✕</button>'
       + '</div>';
@@ -1857,9 +1863,9 @@ function _renderOfficeDept(dept, path, depth) {
   }).join('');
   return '<div style="' + borderStyle + 'overflow:hidden">'
     + '<div style="display:flex;align-items:center;gap:6px;padding:6px 8px;background:' + bgColor + '">'
-    + '<strong style="flex:0 0 auto;color:var(--gold)">' + (depth===0?'▶':'▸') + ' ' + (dept.name||'') + '</strong>'
+    + '<strong style="flex:0 0 auto;color:var(--gold)">' + (depth===0?'▶':'▸') + ' ' + _officeEditorEsc(dept.name||'') + '</strong>'
     + (dept.desc
-        ? '<span style="font-size:12px;color:var(--txt-d);flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + dept.desc + '</span>'
+        ? '<span style="font-size:12px;color:var(--txt-d);flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + _officeEditorEsc(dept.desc) + '</span>'
         : '<span style="flex:1"></span>')
     + '<button class="bt bsm" onclick="_officeEditDept(' + pathStr + ')">✎ 编辑</button>'
     + '<button class="bt bsm" onclick="_officeAddFn(' + pathStr + ')">＋ 职能</button>'
@@ -1888,10 +1894,10 @@ function _officeEditDept(path) {
   if (!dept) return;
   var fns = dept.functions || [];
   openGenericModal('编辑部门',
-    '<div class="form-group"><label>部门名</label><input id="gmf-name" value="' + (dept.name||'') + '"></div>'+
-    '<div class="form-group"><label>简介</label><input id="gmf-desc" value="' + (dept.desc||'') + '"></div>'+
+    '<div class="form-group"><label>部门名</label><input id="gmf-name" value="' + _officeEditorEsc(dept.name||'') + '"></div>'+
+    '<div class="form-group"><label>简介</label><input id="gmf-desc" value="' + _officeEditorEsc(dept.desc||'') + '"></div>'+
     '<div class="form-group"><label>现有职能（共 ' + fns.length + ' 项，在部门卡头点『＋职能』添加）</label>'+
-    '<div style="font-size:12px;color:var(--txt-d)">' + (fns.length ? fns.join('、') : '暂无') + '</div></div>',
+    '<div style="font-size:12px;color:var(--txt-d)">' + _officeEditorEsc(fns.length ? fns.join('、') : '暂无') + '</div></div>',
     function() {
       dept.name = gv('gmf-name') || dept.name;
       dept.desc = gv('gmf-desc');
@@ -1958,10 +1964,10 @@ function _officeEditPos(path, pi) {
   if (!dept || !dept.positions[pi]) return;
   var p = dept.positions[pi];
   openGenericModal('编辑官职',
-    '<div class="form-group"><label>官职名</label><input id="gmf-name" value="' + (p.name||'') + '"></div>'+
-    '<div class="form-group"><label>任职者</label><input id="gmf-holder" value="' + (p.holder||'') + '"></div>'+
-    '<div class="form-group"><label>品级</label><input id="gmf-rank" value="' + (p.rank||'') + '"></div>'+
-    '<div class="form-group"><label>职能描述</label><textarea id="gmf-desc">' + (p.desc||'') + '</textarea></div>',
+    '<div class="form-group"><label>官职名</label><input id="gmf-name" value="' + _officeEditorEsc(p.name||'') + '"></div>'+
+    '<div class="form-group"><label>任职者</label><input id="gmf-holder" value="' + _officeEditorEsc(p.holder||'') + '"></div>'+
+    '<div class="form-group"><label>品级</label><input id="gmf-rank" value="' + _officeEditorEsc(p.rank||'') + '"></div>'+
+    '<div class="form-group"><label>职能描述</label><textarea id="gmf-desc">' + _officeEditorEsc(p.desc||'') + '</textarea></div>',
     function() {
       p.name = gv('gmf-name') || p.name;
       p.holder = gv('gmf-holder');

--- a/web/tm-post-turn-jobs.js
+++ b/web/tm-post-turn-jobs.js
@@ -417,6 +417,57 @@ function _ensurePostTurnJobQueue() {
 
 // Phase 4 P3·post-turn DAG·_enqueuePostTurnJob 支持 dependsOn:['sc28', 'sc25c'] 正式 API
 // 与 _awaitPostTurnJobsById 互补·dependsOn 在入队时声明·调度时自动 await 前置
+function _runPostTurnJobAttempt(job) {
+  if (!job) return Promise.resolve({ ok: false, error: new Error('post-turn job missing') });
+  if (job.status === 'running' && job.promise) return job.promise;
+  if (job.status === 'done' && job.promise) return job.promise;
+  if (job.status === 'failed' && job.promise) return job.promise;
+  job.status = 'running';
+  job.failureObserved = false;
+  job.attempts = (job.attempts || 0) + 1;
+  job.promise = Promise.resolve().then(job.run).then(function(value) {
+    job.status = 'done';
+    job.value = value;
+    job.lastError = null;
+    return { ok: true, value: value, attempt: job.attempts };
+  }, function(error) {
+    job.lastError = error;
+    job.status = job.attempts < job.maxAttempts ? 'retryable' : 'failed';
+    try {
+      if (typeof recordMemoryDiagnostic === 'function') recordMemoryDiagnostic('post_turn_job', {
+        id: job.id,
+        status: job.status,
+        attempt: job.attempts,
+        maxAttempts: job.maxAttempts,
+        error: String(error && error.message || error)
+      });
+    } catch(_) {}
+    _dbg('[PostTurn]' + job.id + ' failed attempt ' + job.attempts + '/' + job.maxAttempts + ':', error);
+    return { ok: false, error: error, attempt: job.attempts, retryable: job.status === 'retryable' };
+  });
+  return job.promise;
+}
+
+function _postTurnJobPromiseForWait(job) {
+  if (!job) return Promise.resolve({ ok: false, error: new Error('post-turn job missing') });
+  // 第一次等待负责把失败明确交给调用者；只有该失败已经被观察过，下一次保存/过回合才重建 Promise。
+  if (job.status === 'retryable' && job.failureObserved) return _runPostTurnJobAttempt(job);
+  if (!job.promise) return _runPostTurnJobAttempt(job);
+  return job.promise;
+}
+
+function _collectPostTurnFailures(waiting, results) {
+  var failed = [];
+  (results || []).forEach(function(result, index) {
+    if (result && result.ok === false) {
+      var job = waiting[index];
+      if (job) job.failureObserved = true;
+      failed.push({ id: job && job.id, error: result.error, retryable: !!result.retryable, attempt: result.attempt });
+    }
+  });
+  return failed;
+}
+
 function _enqueuePostTurnJob(id, fn, opts) {
   var q = _ensurePostTurnJobQueue();
   if (!q || typeof fn !== 'function') return null;
@@ -429,15 +480,24 @@ function _enqueuePostTurnJob(id, fn, opts) {
     if (!_tmWorldLeaseCurrent(lease)) return { stale: true };
     return fn(lease);
   };
-  var p = Promise.resolve().then(wrappedFn).then(function(value) {
-    return { ok: true, value: value };
-  }, function(e) {
-    try { if (typeof recordMemoryDiagnostic === 'function') recordMemoryDiagnostic('post_turn_job', { id: id, status: 'fail', error: String(e && e.message || e) }); } catch(_) {}
-    _dbg('[PostTurn]' + id + ' failed:', e);
-    return { ok: false, error: e };
-  });
-  q.pending.push({ id: id, promise: p, dependsOn: dependsOn, lease: lease });
-  return p;
+  var configuredAttempts = Number(opts && opts.maxAttempts);
+  var maxAttempts = Number.isFinite(configuredAttempts) && configuredAttempts > 0
+    ? Math.floor(configuredAttempts)
+    : ((_isCriticalPostTurnJob({ id: id }) || _isSaveRequiredPostTurnJob({ id: id })) ? 3 : 2);
+  var job = {
+    id: id,
+    run: wrappedFn,
+    promise: null,
+    dependsOn: dependsOn,
+    lease: lease,
+    status: 'pending',
+    attempts: 0,
+    maxAttempts: maxAttempts,
+    failureObserved: false,
+    lastError: null
+  };
+  q.pending.push(job);
+  return _runPostTurnJobAttempt(job);
 }
 
 async function _awaitPostTurnJobsById(ids) {
@@ -447,11 +507,8 @@ async function _awaitPostTurnJobsById(ids) {
     return job && ids.indexOf(job.id) >= 0;
   });
   if (!waiting.length) return;
-  var results = await Promise.all(waiting.map(function(job) { return job.promise; }));
-  var failed = [];
-  results.forEach(function(result, index) {
-    if (result && result.ok === false) failed.push({ id: waiting[index].id, error: result.error });
-  });
+  var results = await Promise.all(waiting.map(_postTurnJobPromiseForWait));
+  var failed = _collectPostTurnFailures(waiting, results);
   if (failed.length) {
     var error = new Error('关键后台任务失败：' + failed.map(function(item) { return item.id; }).join(', '));
     error.postTurnFailures = failed;
@@ -521,11 +578,8 @@ async function _awaitPostTurnJobs(opts) {
   var waiting = criticalOnly ? pending.filter(_isCriticalPostTurnJob) : pending.slice();
   var remaining = criticalOnly ? pending.filter(function(job) { return !_isCriticalPostTurnJob(job); }) : [];
   _dbg('[PostTurn] wait', waiting.length, criticalOnly ? 'critical jobs' : 'jobs', 'detach', remaining.length);
-  var results = waiting.length ? await Promise.all(waiting.map(function(job) { return job.promise; })) : [];
-  var failed = [];
-  results.forEach(function(result, index) {
-    if (result && result.ok === false) failed.push({ id: waiting[index].id, error: result.error });
-  });
+  var results = waiting.length ? await Promise.all(waiting.map(_postTurnJobPromiseForWait)) : [];
+  var failed = _collectPostTurnFailures(waiting, results);
   if (failed.length) {
     try {
       if (typeof recordMemoryDiagnostic === 'function') recordMemoryDiagnostic('post_turn_await', {
@@ -567,11 +621,8 @@ async function _awaitPostTurnJobsForSave(ids) {
   }
   if (!wanted.length) return;
   _dbg('[PostTurn] wait before save:', wanted.map(function(job) { return job.id || '?'; }).join(','));
-  var results = await Promise.all(wanted.map(function(job) { return job.promise; }));
-  var failed = [];
-  results.forEach(function(result, index) {
-    if (result && result.ok === false) failed.push({ id: wanted[index].id, error: result.error });
-  });
+  var results = await Promise.all(wanted.map(_postTurnJobPromiseForWait));
+  var failed = _collectPostTurnFailures(wanted, results);
   if (failed.length) {
     var error = new Error('保存前关键后台任务失败：' + failed.map(function(item) { return item.id; }).join(', '));
     error.postTurnFailures = failed;

--- a/web/tm-sidebar-ui.js
+++ b/web/tm-sidebar-ui.js
@@ -34,15 +34,31 @@ function tmSidebarFullTextAttr(value, always) {
   return v ? ' title="' + escHtml(v) + '"' : '';
 }
 
+function tmSidebarFinite(value, fallback) {
+  var n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function tmSidebarPercent(value, fallback) {
+  return Math.max(0, Math.min(100, tmSidebarFinite(value, fallback)));
+}
+
+function tmSidebarColor(value, fallback) {
+  var color = String(value == null ? '' : value).trim();
+  return /^(?:#[0-9a-f]{3,8}|rgba?\([0-9.,%\s]+\)|hsla?\([0-9.,%\s]+\))$/i.test(color)
+    ? color
+    : fallback;
+}
+
 function renderGameTech(){
   var el=_$("g-tech");if(!el||!GM.techTree)return;
   el.innerHTML=GM.techTree.map(function(t,i){
     var canUnlock=true;
-    var costDesc=(t.costs||[]).map(function(c){var v=GM.vars[c.variable];var ok=v&&v.value>=c.amount;if(!ok)canUnlock=false;return "<span style=\"color:"+(ok?"var(--green)":"var(--red)")+";\">"+c.variable+":"+c.amount+(v?" ("+v.value+")":"")+"</span>";}).join(" ");
+    var costDesc=(t.costs||[]).map(function(c){var v=GM.vars[c.variable];var amount=tmSidebarFinite(c.amount,0);var ok=v&&v.value>=amount;if(!ok)canUnlock=false;return "<span style=\"color:"+(ok?"var(--green)":"var(--red)")+";\">"+escHtml(c.variable)+":"+amount+(v?" ("+tmSidebarFinite(v.value,0)+")":"")+"</span>";}).join(" ");
     if(t.prereqs)t.prereqs.forEach(function(pre){var pt=findTechByName(pre);if(!pt||!pt.unlocked)canUnlock=false;});
     var prereqDesc='';
     if(t.prereqs&&t.prereqs.length>0&&!t.unlocked){prereqDesc='<div style="font-size:0.71rem;color:var(--txt-d);">\u524D\u7F6E: '+t.prereqs.map(function(p){var pt=findTechByName(p);return '<span style="color:'+(pt&&pt.unlocked?'var(--green)':'var(--red)')+';">'+escHtml(p)+'</span>';}).join(', ')+'</div>';}
-    return "<div class=\"cd\" style=\"border-left:3px solid "+(t.unlocked?"var(--green)":"var(--bdr)")+";\"><div style=\"display:flex;justify-content:space-between;\"><strong>"+t.name+(t.era?' <span style=\"font-size:0.71rem;color:var(--txt-d);\">['+t.era+']</span>':'')+"</strong>"+(t.unlocked?"<span class=\"tg\" style=\"background:rgba(39,174,96,0.2);color:var(--green);\">\u2705</span>":canUnlock?"<button class=\"bt bp bsm\" onclick=\"unlockTech("+i+")\">\u89E3\u9501</button>":"")+"</div><div style=\"font-size:0.78rem;color:var(--txt-s);\">"+(t.desc||t.description||'')+"</div>"+prereqDesc+(!t.unlocked&&costDesc?"<div style=\"font-size:0.72rem;margin-top:0.2rem;\">\u6D88\u8017: "+costDesc+"</div>":"")+"</div>";
+    return "<div class=\"cd\" style=\"border-left:3px solid "+(t.unlocked?"var(--green)":"var(--bdr)")+";\"><div style=\"display:flex;justify-content:space-between;\"><strong>"+escHtml(t.name)+(t.era?' <span style=\"font-size:0.71rem;color:var(--txt-d);\">['+escHtml(t.era)+']</span>':'')+"</strong>"+(t.unlocked?"<span class=\"tg\" style=\"background:rgba(39,174,96,0.2);color:var(--green);\">\u2705</span>":canUnlock?"<button class=\"bt bp bsm\" onclick=\"unlockTech("+i+")\">\u89E3\u9501</button>":"")+"</div><div style=\"font-size:0.78rem;color:var(--txt-s);\">"+escHtml(t.desc||t.description||'')+"</div>"+prereqDesc+(!t.unlocked&&costDesc?"<div style=\"font-size:0.72rem;margin-top:0.2rem;\">\u6D88\u8017: "+costDesc+"</div>":"")+"</div>";
   }).join("")||"<div style=\"color:var(--txt-d);\">\u65E0</div>";
 }
 function unlockTech(i){
@@ -66,12 +82,12 @@ function renderGameCivic(){
         if(!pt||!pt.adopted)canAdopt=false;
       });
     }
-    var costDesc=(c.costs||[]).map(function(ct){var v=GM.vars[ct.variable];var ok=v&&v.value>=ct.amount;if(!ok)canAdopt=false;return "<span style=\"color:"+(ok?"var(--green)":"var(--red)")+";\">"+ct.variable+":"+ct.amount+"</span>";}).join(" ");
+    var costDesc=(c.costs||[]).map(function(ct){var v=GM.vars[ct.variable];var amount=tmSidebarFinite(ct.amount,0);var ok=v&&v.value>=amount;if(!ok)canAdopt=false;return "<span style=\"color:"+(ok?"var(--green)":"var(--red)")+";\">"+escHtml(ct.variable)+":"+amount+"</span>";}).join(" ");
     var prereqDesc='';
     if(c.prereqs&&c.prereqs.length>0&&!c.adopted){
       prereqDesc='<div style="font-size:0.71rem;color:var(--txt-d);">\u524D\u7F6E: '+c.prereqs.map(function(p){var pt=GM.civicTree.find(function(x){return x.name===p;});return '<span style="color:'+(pt&&pt.adopted?'var(--green)':'var(--red)')+';">'+escHtml(p)+'</span>';}).join(', ')+'</div>';
     }
-    return "<div class=\"cd\" style=\"border-left:3px solid "+(c.adopted?"var(--green)":"var(--bdr)")+";\"><div style=\"display:flex;justify-content:space-between;\"><strong>"+c.name+"</strong>"+(c.adopted?"<span class=\"tg\" style=\"background:rgba(39,174,96,0.2);color:var(--green);\">\u2705</span>":canAdopt?"<button class=\"bt bp bsm\" onclick=\"adoptCivic("+i+")\">\u63A8\u884C</button>":"")+"</div><div style=\"font-size:0.78rem;color:var(--txt-s);\">"+(c.desc||c.description||'')+"</div>"+prereqDesc+(!c.adopted&&costDesc?"<div style=\"font-size:0.72rem;margin-top:0.2rem;\">\u6D88\u8017: "+costDesc+"</div>":"")+"</div>";
+    return "<div class=\"cd\" style=\"border-left:3px solid "+(c.adopted?"var(--green)":"var(--bdr)")+";\"><div style=\"display:flex;justify-content:space-between;\"><strong>"+escHtml(c.name)+"</strong>"+(c.adopted?"<span class=\"tg\" style=\"background:rgba(39,174,96,0.2);color:var(--green);\">\u2705</span>":canAdopt?"<button class=\"bt bp bsm\" onclick=\"adoptCivic("+i+")\">\u63A8\u884C</button>":"")+"</div><div style=\"font-size:0.78rem;color:var(--txt-s);\">"+escHtml(c.desc||c.description||'')+"</div>"+prereqDesc+(!c.adopted&&costDesc?"<div style=\"font-size:0.72rem;margin-top:0.2rem;\">\u6D88\u8017: "+costDesc+"</div>":"")+"</div>";
   }).join("")||"<div style=\"color:var(--txt-d);\">\u65E0</div>";
 }
 function adoptCivic(i){
@@ -379,8 +395,8 @@ function renderSidePanels(){
     var fp=document.createElement("div");fp.style.marginBottom="0.8rem";
     fp.innerHTML="<div class=\"pt\">\u2694 \u52BF\u529B\u683C\u5C40 <span style=\"font-size:0.7rem;color:var(--txt-d);font-weight:400;\">"+GM.facs.length+"\u4E2A</span></div>"+GM.facs.map(function(f){
       var attClr=f.attitude==='\u53CB\u597D'||f.attitude==='\u8054\u76DF'?'var(--green)':f.attitude==='\u654C\u5BF9'||f.attitude==='\u4EA4\u6218'||f.attitude==='\u654C\u89C6'?'var(--red)':f.attitude==='\u9644\u5C5E'||f.attitude==='\u5B97\u4E3B'||f.attitude==='\u671D\u8D21'?'var(--blue)':'var(--txt-d)';
-      var str=f.strength||50;
-      var milStr=f.militaryStrength?' \u5175'+f.militaryStrength:'';
+      var str=tmSidebarPercent(f.strength,50);
+      var milStr=f.militaryStrength?' \u5175'+tmSidebarFinite(f.militaryStrength,0):'';
       // 类型标签
       var typeTag=f.type?'<span style="font-size:0.62rem;color:var(--ink-300);margin-left:2px;">'+escHtml(f.type)+'</span>':'';
       // 封臣/宗主标签
@@ -388,7 +404,7 @@ function renderSidePanels(){
       if(f.liege)_vassalTag=' <span style="font-size:0.62rem;color:var(--blue);border:1px solid var(--blue);border-radius:3px;padding:0 3px;">\u81E3\u2192'+escHtml(String(f.liege))+'</span>';
       else if(f.vassals&&f.vassals.length>0)_vassalTag=' <span style="font-size:0.62rem;color:var(--gold);border:1px solid var(--gold);border-radius:3px;padding:0 3px;">\u5B97\u4E3B('+f.vassals.length+')</span>';
       // 颜色条
-      var facColor = f.color || attClr;
+      var facColor = tmSidebarColor(f.color, attClr);
       // 首领信息
       var leaderLine = '';
       if (f.leader) {
@@ -405,7 +421,7 @@ function renderSidePanels(){
       if (extras.length > 0) extraLine = '<div style="font-size:0.64rem;color:var(--ink-300);margin-top:1px;">' + extras.join(' \u00B7 ') + '</div>';
       return '<div style="margin-bottom:0.45rem;border-left:2px solid '+facColor+';padding-left:0.4rem;">'
         +'<div style="display:flex;justify-content:space-between;font-size:0.78rem;">'
-        +'<span>'+(f.name||'')+typeTag+_vassalTag+(f.attitude?' <span style="font-size:0.66rem;color:'+attClr+';">'+f.attitude+'</span>':'')+'</span>'
+        +'<span>'+escHtml(f.name||'')+typeTag+_vassalTag+(f.attitude?' <span style="font-size:0.66rem;color:'+attClr+';">'+escHtml(f.attitude)+'</span>':'')+'</span>'
         +'<span style="color:'+attClr+';">'+str+milStr+'</span></div>'
         +'<div class="rb"><div class="rf" style="width:'+str+'%;background:'+facColor+';"></div></div>'
         +leaderLine+extraLine+'</div>';
@@ -415,7 +431,7 @@ function renderSidePanels(){
       var _frHtml='<div style="margin-top:0.3rem;font-size:0.7rem;color:var(--txt-d);border-top:1px solid var(--bg-4);padding-top:0.3rem;">';
       GM.factionRelations.forEach(function(r){
         var rClr=(r.value||0)>30?'var(--green)':(r.value||0)<-30?'var(--red)':'var(--txt-d)';
-        _frHtml+='<div>'+r.from+'\u2192'+r.to+' <span style="color:'+rClr+';">'+r.type+'('+r.value+')</span></div>';
+        _frHtml+='<div>'+escHtml(r.from)+'\u2192'+escHtml(r.to)+' <span style="color:'+rClr+';">'+escHtml(r.type)+'('+tmSidebarFinite(r.value,0)+')</span></div>';
       });
       _frHtml+='</div>';
       fp.innerHTML+=_frHtml;
@@ -430,20 +446,21 @@ function renderSidePanels(){
       var mp=document.createElement("div");mp.style.marginBottom="0.8rem";mp.style.cursor="pointer";
       mp.onclick=function(){openMilitaryDetailPanel();};
       mp.title='\u70B9\u51FB\u67E5\u770B\u5404\u519B\u5B8C\u6574\u8BE6\u60C5';
-      var totalSol=activeA.reduce(function(s,a){return s+(a.soldiers||0);},0);
+      var totalSol=activeA.reduce(function(s,a){return s+Math.max(0,tmSidebarFinite(a.soldiers,0));},0);
       mp.innerHTML="<div class=\"pt\">\u2694\uFE0F \u519B\u4E8B\u529B\u91CF <span style=\"font-size:0.7rem;color:var(--txt-d);\">\u603B\u5175\u529B"+totalSol+"\u00B7"+activeA.length+"\u652F</span></div>"+activeA.map(function(a){
-        var sol=a.soldiers||0;
+        var sol=Math.max(0,tmSidebarFinite(a.soldiers,0));
         var pct=totalSol>0?Math.round(sol/totalSol*100):0;
-        var morClr=(a.morale||0)>70?'var(--green)':(a.morale||0)>40?'var(--gold)':'var(--red)';
-        var info=a.name+(a.armyType?' <span style=\"font-size:0.66rem;color:var(--txt-d);\">'+a.armyType+'</span>':'');
-        var detail=sol+'\u5175 \u58EB\u6C14'+(a.morale||50)+' \u8BAD\u7EC3'+(a.training||50);
+        var morale=tmSidebarPercent(a.morale,50);
+        var morClr=morale>70?'var(--green)':morale>40?'var(--gold)':'var(--red)';
+        var info=escHtml(a.name)+(a.armyType?' <span style=\"font-size:0.66rem;color:var(--txt-d);\">'+escHtml(a.armyType)+'</span>':'');
+        var detail=sol+'\u5175 \u58EB\u6C14'+morale+' \u8BAD\u7EC3'+tmSidebarPercent(a.training,50);
         var _cn=a.commander||'';
         var _cc=(_cn&&typeof findCharByName==='function')?findCharByName(_cn):null;
         var _cDead=!!_cn&&(_cc?(_cc.alive===false||_cc.dead===true):true);
         if(!_cn)detail+=' <span style="color:var(--red,#c0563a);">\u5E05:\u7A7A\u7F3A</span>';
-        else if(_cDead)detail+=' <span style="color:var(--red,#c0563a);">\u5E05:'+_cn+'(\u6B81)</span>';
-        else detail+=' \u5E05:'+_cn;
-        if(a.garrison)detail+=' \u9A7B:'+String(a.garrison);
+        else if(_cDead)detail+=' <span style="color:var(--red,#c0563a);">\u5E05:'+escHtml(_cn)+'(\u6B81)</span>';
+        else detail+=' \u5E05:'+escHtml(_cn);
+        if(a.garrison)detail+=' \u9A7B:'+escHtml(String(a.garrison));
         return "<div style=\"margin-bottom:0.4rem;\"><div style=\"display:flex;justify-content:space-between;font-size:0.78rem;\"><span>"+info+"</span><span style=\"color:"+morClr+";\">"+sol+"</span></div><div class=\"rb\"><div class=\"rf\" style=\"width:"+pct+"%;background:"+morClr+";\"></div></div><div style=\"font-size:0.7rem;color:var(--txt-d);\">"+ detail+"</div></div>";
       }).join("");
       gl.appendChild(mp);
@@ -459,8 +476,9 @@ function renderSidePanels(){
       // \u26052026-07-06 \u76EE\u6807\u8F74\u4FEE\u590D\uFF1A\u63A5\u4E0A\u5F15\u64CE\u5DF2\u7B97\u597D\u7684\u8FDB\u5EA6(checkGoals \u6BCF\u56DE\u5408\u5199 g.progress)\u2014\u2014\u65E7\u7248\u53EA\u663E\u540D\u00B7\u76EE\u6807\u770B\u7740\u6C38\u4E0D\u52A8
       var pct = g.completed ? 100 : (typeof g.progress === 'number' ? g.progress : (typeof _calcGoalProgress === 'function' ? (function(){ try { return _calcGoalProgress(g); } catch(_e) { return 0; } })() : 0));
       var done = !!g.completed;
-      var tip = String(g.description || g.desc || '').replace(/"/g, '&quot;');
-      return "<div style=\"padding:0.2rem 0;font-size:0.75rem;display:flex;gap:0.3rem;align-items:center;\" title=\""+tip+"\"><span style=\"color:"+(done?'var(--gold)':(typeColors[g.type]||'var(--txt-s)'))+";\">"+(done?'\u2713':(typeIcons[g.type]||'\u25CB'))+"</span><span style=\"flex:1;\">"+(g.name||'')+"</span><span style=\"color:"+(done?'var(--gold)':'var(--txt-s)')+";font-size:0.68rem;\">"+(done?'\u6210':pct+'%')+"</span></div>";
+      pct = tmSidebarPercent(pct, 0);
+      var tip = escHtml(g.description || g.desc || '');
+      return "<div style=\"padding:0.2rem 0;font-size:0.75rem;display:flex;gap:0.3rem;align-items:center;\" title=\""+tip+"\"><span style=\"color:"+(done?'var(--gold)':(typeColors[g.type]||'var(--txt-s)'))+";\">"+(done?'\u2713':(typeIcons[g.type]||'\u25CB'))+"</span><span style=\"flex:1;\">"+escHtml(g.name||'')+"</span><span style=\"color:"+(done?'var(--gold)':'var(--txt-s)')+";font-size:0.68rem;\">"+(done?'\u6210':pct+'%')+"</span></div>";
     }).join("");
     gl.appendChild(gp);
   }
@@ -493,7 +511,7 @@ function renderSidePanels(){
         var ts=c.titles.map(function(t){
           var hTag=t.hereditary?'\u4E16\u88AD':'\u6D41\u5B98';
           var supTag=(t._suppressed&&t._suppressed.length>0)?' \u26D4':'';
-          return t.name+'<span style="font-size:0.62rem;color:var(--txt-d);">('+hTag+supTag+')</span>';
+          return escHtml(t.name)+'<span style="font-size:0.62rem;color:var(--txt-d);">('+hTag+supTag+')</span>';
         }).join(' ');
         _tHtml+="<div style=\"font-size:0.75rem;padding:2px 0;\"><span style=\"color:var(--gold-l);\">"+escHtml(c.name)+"</span> "+ts+"</div>";
       });
@@ -548,10 +566,10 @@ function renderSidePanels(){
       var ap=document.createElement("div");ap.style.marginBottom="0.8rem";
       var _aHtml="<div class=\"pt\">\uD83C\uDFEF \u884C\u653F\u533A\u5212 <span style=\"font-size:0.7rem;color:var(--txt-d);\">\u5171"+_totalDivs+"\u5355\u4F4D \u5B98"+_govCount+"</span></div>";
       _topDivs.forEach(function(d){
-        var pStr=d.prosperity?' \u7E41'+d.prosperity:'';
+        var pStr=d.prosperity?' \u7E41'+tmSidebarFinite(d.prosperity,0):'';
         var gStr=d.governor?' \u5B98:'+escHtml(d.governor):'';
         var chCount=d.children?d.children.length:0;
-        _aHtml+="<div style=\"font-size:0.72rem;padding:2px 0;\">"+escHtml(d.name)+"<span style=\"color:var(--txt-d);font-size:0.66rem;\"> "+(d.terrain||'')+(d.level?'('+d.level+')':'')+(chCount>0?' \u4E0B\u8F96'+chCount:'')+pStr+gStr+"</span></div>";
+        _aHtml+="<div style=\"font-size:0.72rem;padding:2px 0;\">"+escHtml(d.name)+"<span style=\"color:var(--txt-d);font-size:0.66rem;\"> "+escHtml(d.terrain||'')+(d.level?'('+escHtml(d.level)+')':'')+(chCount>0?' \u4E0B\u8F96'+chCount:'')+pStr+gStr+"</span></div>";
       });
       ap.innerHTML=_aHtml;
       gl.appendChild(ap);
@@ -562,7 +580,7 @@ function renderSidePanels(){
   if(GM.classes&&GM.classes.length>0){
     var cp=document.createElement("div");cp.style.marginBottom="0.8rem";cp.style.cursor="pointer";
     cp.onclick=function(){openClassDetailPanel();};
-    cp.innerHTML="<div class=\"pt\">\uD83D\uDC51 \u9636\u5C42</div>"+GM.classes.map(function(c){var _ci=c.influence||c.classInfluence||0;return "<div style=\"margin-bottom:0.3rem;\"><div style=\"display:flex;justify-content:space-between;font-size:0.78rem;\"><span>"+escHtml(c.name)+(c.satisfaction?' <span style=\"font-size:0.7rem;color:var(--txt-d);\">'+Math.round(c.satisfaction)+'</span>':'')+"</span><span style=\"color:var(--gold);\">"+_ci+"</span></div><div class=\"rb\"><div class=\"rf\" style=\"width:"+_ci+"%;background:var(--blue);\"></div></div></div>";}).join("");
+    cp.innerHTML="<div class=\"pt\">\uD83D\uDC51 \u9636\u5C42</div>"+GM.classes.map(function(c){var _ci=tmSidebarPercent(c.influence!=null?c.influence:c.classInfluence,0);var _sat=c.satisfaction!=null?tmSidebarPercent(c.satisfaction,50):null;return "<div style=\"margin-bottom:0.3rem;\"><div style=\"display:flex;justify-content:space-between;font-size:0.78rem;\"><span>"+escHtml(c.name)+(_sat!=null?' <span style=\"font-size:0.7rem;color:var(--txt-d);\">'+Math.round(_sat)+'</span>':'')+"</span><span style=\"color:var(--gold);\">"+_ci+"</span></div><div class=\"rb\"><div class=\"rf\" style=\"width:"+_ci+"%;background:var(--blue);\"></div></div></div>";}).join("");
     gl.appendChild(cp);
   }
 
@@ -570,7 +588,7 @@ function renderSidePanels(){
   if(GM.parties&&GM.parties.length>0){
     var pp=document.createElement("div");pp.style.marginBottom="0.8rem";pp.style.cursor="pointer";
     pp.onclick=function(){openPartyDetailPanel();};
-    pp.innerHTML="<div class=\"pt\">\uD83C\uDFDB \u515A\u6D3E</div>"+GM.parties.map(function(p){var _inf=p.influence||p.strength||0;var _stClr=p.status==='\u6D3B\u8DC3'?'var(--green)':p.status==='\u5F0F\u5FAE'?'var(--gold)':p.status==='\u88AB\u538B\u5236'?'var(--red)':'var(--txt-d)';return "<div style=\"margin-bottom:0.3rem;\"><div style=\"display:flex;justify-content:space-between;font-size:0.78rem;\"><span>"+escHtml(p.name)+(p.status?' <span style=\"font-size:0.7rem;color:'+_stClr+';\">'+escHtml(p.status)+'</span>':'')+"</span><span>"+_inf+"</span></div><div class=\"rb\"><div class=\"rf\" style=\"width:"+_inf+"%;background:var(--purple);\"></div></div></div>";}).join("");
+    pp.innerHTML="<div class=\"pt\">\uD83C\uDFDB \u515A\u6D3E</div>"+GM.parties.map(function(p){var _inf=tmSidebarPercent(p.influence!=null?p.influence:p.strength,0);var _stClr=p.status==='\u6D3B\u8DC3'?'var(--green)':p.status==='\u5F0F\u5FAE'?'var(--gold)':p.status==='\u88AB\u538B\u5236'?'var(--red)':'var(--txt-d)';return "<div style=\"margin-bottom:0.3rem;\"><div style=\"display:flex;justify-content:space-between;font-size:0.78rem;\"><span>"+escHtml(p.name)+(p.status?' <span style=\"font-size:0.7rem;color:'+_stClr+';\">'+escHtml(p.status)+'</span>':'')+"</span><span>"+_inf+"</span></div><div class=\"rb\"><div class=\"rf\" style=\"width:"+_inf+"%;background:var(--purple);\"></div></div></div>";}).join("");
     gl.appendChild(pp);
   }
 
@@ -584,8 +602,8 @@ function renderSidePanels(){
       var _acqStyle = it.acquired ? '' : 'opacity:0.5;';
       var _acqTag = it.acquired ? '' : '<span style="font-size:0.62rem;color:var(--ink-300);margin-left:3px;">\u672A\u83B7</span>';
       _iHtml+="<div style=\"padding:0.2rem 0;font-size:0.75rem;border-bottom:1px solid var(--bg-4);"+_acqStyle+"\">";
-      _iHtml+="<div style=\"display:flex;justify-content:space-between;\"><span>"+(typeIcons[it.type]||'\u2022')+' '+(it.name||'')+_acqTag+"</span>";
-      if(it.rarity&&it.rarity!=='\u666E\u901A')_iHtml+="<span style=\"font-size:0.66rem;color:"+(rarClr[it.rarity]||'var(--txt-d)')+";\">"+it.rarity+"</span>";
+      _iHtml+="<div style=\"display:flex;justify-content:space-between;\"><span>"+(typeIcons[it.type]||'\u2022')+' '+escHtml(it.name||'')+_acqTag+"</span>";
+      if(it.rarity&&it.rarity!=='\u666E\u901A')_iHtml+="<span style=\"font-size:0.66rem;color:"+(rarClr[it.rarity]||'var(--txt-d)')+";\">"+escHtml(it.rarity)+"</span>";
       _iHtml+="</div>";
       if(it.effect)_iHtml+="<div style=\"font-size:0.7rem;color:var(--gold-d);\">"+escHtml(String(it.effect))+"</div>";
       if(it.owner)_iHtml+="<div style=\"font-size:0.66rem;color:var(--ink-300);\">\u6301\u6709\uFF1A"+escHtml(it.owner)+"</div>";
@@ -614,18 +632,18 @@ function renderSidePanels(){
         var childCount=sp.children?sp.children.length:0;
         var loyClr=(sp.loyalty||50)>70?'var(--green)':(sp.loyalty||50)<30?'var(--red)':'var(--txt-s)';
         _hHtml+="<div style=\"font-size:0.72rem;padding:2px 0;display:flex;justify-content:space-between;\">";
-        _hHtml+="<span>"+rkIcon+" "+escHtml(sp.name)+" <span style=\"color:var(--gold-d);font-size:0.66rem;\">"+escHtml(rkName)+"</span></span>";
-        var favStr = sp.favor !== undefined ? ' \u5BA0' + sp.favor : '';
-        _hHtml+="<span style=\"font-size:0.66rem;\"><span style=\"color:"+loyClr+"\">\u5FE0"+(sp.loyalty||50)+"</span>"+favStr+(childCount>0?" \u5B50"+childCount:"")+"</span>";
+        _hHtml+="<span>"+escHtml(rkIcon)+" "+escHtml(sp.name)+" <span style=\"color:var(--gold-d);font-size:0.66rem;\">"+escHtml(rkName)+"</span></span>";
+        var favStr = sp.favor !== undefined ? ' \u5BA0' + tmSidebarFinite(sp.favor,0) : '';
+        _hHtml+="<span style=\"font-size:0.66rem;\"><span style=\"color:"+loyClr+"\">\u5FE0"+tmSidebarPercent(sp.loyalty,50)+"</span>"+favStr+(childCount>0?" \u5B50"+childCount:"")+"</span>";
         _hHtml+="</div>";
       });
       // 继承人
       if(GM.harem.heirs&&GM.harem.heirs.length>0){
-        _hHtml+="<div style=\"font-size:0.7rem;color:var(--gold);margin-top:3px;border-top:1px solid var(--bg-4);padding-top:3px;\">\u7EE7\u627F\u4EBA: "+GM.harem.heirs.join('\u3001')+"</div>";
+        _hHtml+="<div style=\"font-size:0.7rem;color:var(--gold);margin-top:3px;border-top:1px solid var(--bg-4);padding-top:3px;\">\u7EE7\u627F\u4EBA: "+GM.harem.heirs.map(escHtml).join('\u3001')+"</div>";
       }
       // 孕期
       if(GM.harem.pregnancies&&GM.harem.pregnancies.length>0){
-        _hHtml+="<div style=\"font-size:0.7rem;color:var(--purple,#9b59b6);\">\u6709\u5B55: "+GM.harem.pregnancies.map(function(p){return p.mother;}).join('\u3001')+"</div>";
+        _hHtml+="<div style=\"font-size:0.7rem;color:var(--purple,#9b59b6);\">\u6709\u5B55: "+GM.harem.pregnancies.map(function(p){return escHtml(p.mother);}).join('\u3001')+"</div>";
       }
       hp.innerHTML=_hHtml;
       gl.appendChild(hp);
@@ -647,7 +665,7 @@ function renderSidePanels(){
     var _catEntries=Object.keys(_catCount);
     if(_catEntries.length>0){
       _bHtml+="<div style=\"display:flex;flex-wrap:wrap;gap:4px;font-size:0.7rem;\">";
-      _catEntries.forEach(function(c){_bHtml+="<span style=\"background:var(--bg-3);padding:1px 5px;border-radius:3px;\">"+(_catNames[c]||c)+":"+_catCount[c]+"</span>";});
+      _catEntries.forEach(function(c){_bHtml+="<span style=\"background:var(--bg-3);padding:1px 5px;border-radius:3px;\">"+escHtml(_catNames[c]||c)+":"+_catCount[c]+"</span>";});
       _bHtml+="</div>";
     }
     if(_inQueue>0)_bHtml+="<div style=\"font-size:0.7rem;color:var(--gold);margin-top:3px;\">\u5EFA\u9020\u4E2D: "+_inQueue+"\u9879</div>";
@@ -667,7 +685,7 @@ function renderSidePanels(){
         _eHtml+="<div style=\"font-size:0.72rem;padding:2px 0;\"><span style=\"color:"+impClr+";\">"+(e.importance==='\u5173\u952E'?'\u2605':e.importance==='\u91CD\u8981'?'\u25C6':'\u25CB')+"</span> "+escHtml(e.name||'')+(e.type?' <span style=\"font-size:0.66rem;color:var(--txt-d);\">'+escHtml(e.type)+'</span>':'')+"</div>";
       });
       if(_trigEvts.length>0){
-        _eHtml+="<div style=\"font-size:0.7rem;color:var(--green);margin-top:3px;border-top:1px solid var(--bg-4);padding-top:2px;\">\u5DF2\u53D1\u751F: "+_trigEvts.map(function(e){return e.name;}).join('\u3001')+"</div>";
+        _eHtml+="<div style=\"font-size:0.7rem;color:var(--green);margin-top:3px;border-top:1px solid var(--bg-4);padding-top:2px;\">\u5DF2\u53D1\u751F: "+_trigEvts.map(function(e){return escHtml(e.name);}).join('\u3001')+"</div>";
       }
       ep2.innerHTML=_eHtml;
       gl.appendChild(ep2);
@@ -680,7 +698,7 @@ function renderSidePanels(){
     function cnt(tree){tree.forEach(function(d){td++;to+=(d.positions||[]).filter(function(p){return p.holder;}).length;if(d.subs)cnt(d.subs);});}
     cnt(GM.officeTree);
     var oc=document.createElement("div");oc.style.marginBottom="0.8rem";
-    oc.innerHTML="<div class=\"pt\">\uD83D\uDCB0 \u5B98\u5236\u6D88\u8017</div><div style=\"font-size:0.71rem;color:var(--txt-d);\">\u90E8\u95E8:"+td+" \u5B98\u5458:"+to+"</div>"+P.officeConfig.costVariables.map(function(cv){var cost=(cv.perDept||0)*td+(cv.perOfficial||0)*to;var v=GM.vars[cv.variable];var ok=v&&v.value>=cost;return "<div style=\"display:flex;justify-content:space-between;font-size:0.75rem;\"><span>"+cv.variable+"</span><span style=\"color:"+(ok?"var(--txt-s)":"var(--red)")+";\">-"+cost+"/\u56DE</span></div>";}).join("");
+    oc.innerHTML="<div class=\"pt\">\uD83D\uDCB0 \u5B98\u5236\u6D88\u8017</div><div style=\"font-size:0.71rem;color:var(--txt-d);\">\u90E8\u95E8:"+td+" \u5B98\u5458:"+to+"</div>"+P.officeConfig.costVariables.map(function(cv){var cost=tmSidebarFinite(cv.perDept,0)*td+tmSidebarFinite(cv.perOfficial,0)*to;var v=GM.vars[cv.variable];var ok=v&&v.value>=cost;return "<div style=\"display:flex;justify-content:space-between;font-size:0.75rem;\"><span>"+escHtml(cv.variable)+"</span><span style=\"color:"+(ok?"var(--txt-s)":"var(--red)")+";\">-"+cost+"/\u56DE</span></div>";}).join("");
     gl.appendChild(oc);
   }
 
@@ -695,7 +713,7 @@ function renderSidePanels(){
     var _typeLabels = { main_hall:'外朝', imperial_residence:'帝居', consort_residence:'后妃居所', dowager:'太后宫', crown_prince:'太子宫', ceremonial:'礼制', garden:'园林', office:'内廷', offering:'祭祀' };
     var _statItems = [];
     Object.keys(_typeStats).forEach(function(t) {
-      _statItems.push((_typeLabels[t] || t) + _typeStats[t]);
+      _statItems.push(escHtml(_typeLabels[t] || t) + _typeStats[t]);
     });
     // 本回合居住的妃嫔数
     var _occupiedCount = 0;

--- a/web/tm-storage.js
+++ b/web/tm-storage.js
@@ -52,8 +52,9 @@ var TM_SaveDB = (function() {
   'use strict';
 
   var DB_NAME = 'tianming_db'; // 统一数据库名
-  var DB_VERSION = 2; // v2: saves + projects 双store
+  var DB_VERSION = 3; // v3: 存档 payload 与列表 metadata 分离
   var SAVE_STORE = 'saves';
+  var SAVE_META_STORE = 'saveMetadata';
   var PROJECT_STORE = 'projects';
   var _db = null;
   var _available = false;
@@ -74,12 +75,32 @@ var TM_SaveDB = (function() {
       var req = indexedDB.open(DB_NAME, DB_VERSION);
       req.onupgradeneeded = function(e) {
         var db = e.target.result;
+        var saveStore;
         if (!db.objectStoreNames.contains(SAVE_STORE)) {
-          var s = db.createObjectStore(SAVE_STORE, { keyPath: 'id' });
-          s.createIndex('timestamp', 'timestamp', { unique: false });
+          saveStore = db.createObjectStore(SAVE_STORE, { keyPath: 'id' });
+          saveStore.createIndex('timestamp', 'timestamp', { unique: false });
+        } else {
+          saveStore = e.target.transaction.objectStore(SAVE_STORE);
+        }
+        var metadataStore;
+        if (!db.objectStoreNames.contains(SAVE_META_STORE)) {
+          metadataStore = db.createObjectStore(SAVE_META_STORE, { keyPath: 'id' });
+          metadataStore.createIndex('timestamp', 'timestamp', { unique: false });
+        } else {
+          metadataStore = e.target.transaction.objectStore(SAVE_META_STORE);
         }
         if (!db.objectStoreNames.contains(PROJECT_STORE)) {
           db.createObjectStore(PROJECT_STORE, { keyPath: 'id' });
+        }
+        // v2→v3 只在升级事务中遍历一次旧 payload，之后列表永远只读轻量 metadata。
+        if (e.oldVersion > 0 && e.oldVersion < 3 && saveStore && metadataStore) {
+          var cursorReq = saveStore.openCursor();
+          cursorReq.onsuccess = function() {
+            var cursor = cursorReq.result;
+            if (!cursor) return;
+            metadataStore.put(_toSaveMetadata(cursor.value));
+            cursor.continue();
+          };
         }
       };
       req.onsuccess = function(e) {
@@ -112,9 +133,26 @@ var TM_SaveDB = (function() {
     catch (_) { return false; }
   }
 
+  function _toSaveMetadata(record) {
+    record = record || {};
+    return {
+      id: record.id,
+      name: record.name,
+      type: record.type,
+      timestamp: record.timestamp,
+      turn: record.turn,
+      scenarioName: record.scenarioName,
+      eraName: record.eraName,
+      date: record.date || '',
+      dynastyPhase: record.dynastyPhase || '',
+      snapshotId: record.snapshotId || '',
+      commitState: record.commitState || ''
+    };
+  }
+
   function _dropOldestAutoSave(writeGuard) {
     if (!_writeGuardAllows(writeGuard)) return Promise.resolve(false);
-    return _listAll(SAVE_STORE).then(function(records) {
+    return _listSaveMetadata().then(function(records) {
       // 列表读取本身是异步的；失效请求不得为了一个已取消的写入删除仍可恢复的旧 autosave。
       if (!_writeGuardAllows(writeGuard)) return false;
       var autos = (records || []).filter(function(r){ return r.type === 'auto'; })
@@ -122,7 +160,61 @@ var TM_SaveDB = (function() {
       if (autos.length === 0) return false; // 没 auto 可清
       var victim = autos[0];
       console.warn('[SaveDB] quota 满·清最老自动存档:', victim.id, 'ts=' + new Date(victim.timestamp||0).toLocaleString());
-      return _del(SAVE_STORE, victim.id).then(function(){ return true; });
+      return _deleteSaveRecord(victim.id, writeGuard).then(function(){ return true; });
+    });
+  }
+
+  function _putSaveRecord(record, _retryCount, writeGuard) {
+    if (!_writeGuardAllows(writeGuard)) return Promise.resolve(false);
+    var metadata = _toSaveMetadata(record);
+    if (!_available || !_db) {
+      var payloadKey = 'tm_idb_' + SAVE_STORE + '_' + record.id;
+      var metadataKey = 'tm_idb_' + SAVE_META_STORE + '_' + record.id;
+      var previousPayload = localStorage.getItem(payloadKey);
+      var previousMetadata = localStorage.getItem(metadataKey);
+      try {
+        localStorage.setItem(payloadKey, JSON.stringify(record));
+        localStorage.setItem(metadataKey, JSON.stringify(metadata));
+        return Promise.resolve(true);
+      } catch (e) {
+        try {
+          if (previousPayload == null) localStorage.removeItem(payloadKey);
+          else localStorage.setItem(payloadKey, previousPayload);
+          if (previousMetadata == null) localStorage.removeItem(metadataKey);
+          else localStorage.setItem(metadataKey, previousMetadata);
+        } catch (_) {}
+        return Promise.reject(e);
+      }
+    }
+    return new Promise(function(resolve, reject) {
+      try {
+        var tx = _db.transaction([SAVE_STORE, SAVE_META_STORE], 'readwrite');
+        var settled = false;
+        tx.objectStore(SAVE_STORE).put(record);
+        tx.objectStore(SAVE_META_STORE).put(metadata);
+        tx.oncomplete = function() { if (!settled) { settled = true; resolve(true); } };
+        function handleWriteFailure(e) {
+          if (settled) return;
+          settled = true;
+          var err = e.target && e.target.error;
+          var isQuota = err && err.name === 'QuotaExceededError';
+          if (isQuota && !_retryCount) {
+            if (!_writeGuardAllows(writeGuard)) { resolve(false); return; }
+            _dropOldestAutoSave(writeGuard).then(function(dropped) {
+              if (!_writeGuardAllows(writeGuard)) { resolve(false); return; }
+              if (dropped) _putSaveRecord(record, 1, writeGuard).then(resolve, reject);
+              else {
+                if (typeof window.toast === 'function') window.toast('❌ 存档空间满·请手动删除旧存档后重试');
+                resolve(false);
+              }
+            }).catch(reject);
+          } else {
+            reject(err || new Error('IndexedDB 存档写入失败'));
+          }
+        }
+        tx.onerror = handleWriteFailure;
+        tx.onabort = handleWriteFailure;
+      } catch (e) { reject(e); }
     });
   }
 
@@ -191,6 +283,12 @@ var TM_SaveDB = (function() {
           var previous = localStorage.getItem(key);
           localStorage.setItem(key, JSON.stringify(record));
           written.push({ key: key, previous: previous });
+          if (storeName === SAVE_STORE) {
+            var metadataKey = 'tm_idb_' + SAVE_META_STORE + '_' + record.id;
+            var previousMetadata = localStorage.getItem(metadataKey);
+            localStorage.setItem(metadataKey, JSON.stringify(_toSaveMetadata(record)));
+            written.push({ key: metadataKey, previous: previousMetadata });
+          }
         });
         return Promise.resolve(records.length);
       } catch (e) {
@@ -205,9 +303,14 @@ var TM_SaveDB = (function() {
     }
     return new Promise(function(resolve, reject) {
       try {
-        var tx = _db.transaction(storeName, 'readwrite');
+        var txStores = storeName === SAVE_STORE ? [SAVE_STORE, SAVE_META_STORE] : storeName;
+        var tx = _db.transaction(txStores, 'readwrite');
         var store = tx.objectStore(storeName);
-        records.forEach(function(record) { store.put(record); });
+        var metadataStore = storeName === SAVE_STORE ? tx.objectStore(SAVE_META_STORE) : null;
+        records.forEach(function(record) {
+          store.put(record);
+          if (metadataStore) metadataStore.put(_toSaveMetadata(record));
+        });
         tx.oncomplete = function() { resolve(records.length); };
         tx.onerror = function(e) { reject(e.target && e.target.error || new Error('IndexedDB 批量写入失败')); };
         tx.onabort = function(e) { reject(e.target && e.target.error || new Error('IndexedDB 批量写入已中止')); };
@@ -251,6 +354,37 @@ var TM_SaveDB = (function() {
     });
   }
 
+  function _deleteSaveRecord(id, writeGuard) {
+    if (!_writeGuardAllows(writeGuard)) return Promise.resolve(false);
+    if (!_available || !_db) {
+      var payloadKey = 'tm_idb_' + SAVE_STORE + '_' + id;
+      var metadataKey = 'tm_idb_' + SAVE_META_STORE + '_' + id;
+      var previousPayload = localStorage.getItem(payloadKey);
+      var previousMetadata = localStorage.getItem(metadataKey);
+      try {
+        localStorage.removeItem(payloadKey);
+        localStorage.removeItem(metadataKey);
+        return Promise.resolve(true);
+      } catch (e) {
+        try {
+          if (previousPayload != null) localStorage.setItem(payloadKey, previousPayload);
+          if (previousMetadata != null) localStorage.setItem(metadataKey, previousMetadata);
+        } catch (_) {}
+        return Promise.reject(e);
+      }
+    }
+    return new Promise(function(resolve, reject) {
+      try {
+        var tx = _db.transaction([SAVE_STORE, SAVE_META_STORE], 'readwrite');
+        tx.objectStore(SAVE_STORE).delete(id);
+        tx.objectStore(SAVE_META_STORE).delete(id);
+        tx.oncomplete = function() { resolve(true); };
+        tx.onerror = function(e) { reject(e.target && e.target.error || new Error('IndexedDB 存档删除失败')); };
+        tx.onabort = function(e) { reject(e.target && e.target.error || tx.error || new Error('IndexedDB 存档删除事务已中止')); };
+      } catch (e) { reject(e); }
+    });
+  }
+
   // ── 通用列出 ──
   function _listAll(storeName) {
     if (!_available || !_db) {
@@ -275,6 +409,29 @@ var TM_SaveDB = (function() {
         req.onerror = function(e) { reject(e.target && e.target.error || new Error('IndexedDB 列表读取失败')); };
         tx.onabort = function(e) { reject(e.target && e.target.error || tx.error || new Error('IndexedDB 列表事务已中止')); };
       } catch(e) { reject(e); }
+    });
+  }
+
+  function _listSaveMetadata() {
+    if (_available && _db) return _listAll(SAVE_META_STORE);
+    return _listAll(SAVE_META_STORE).then(function(metadataRecords) {
+      // 旧 localStorage fallback 没有独立 metadata；只为缺失项做一次惰性回填。
+      var byId = Object.create(null);
+      (metadataRecords || []).forEach(function(record) { if (record && record.id != null) byId[String(record.id)] = true; });
+      var payloadPrefix = 'tm_idb_' + SAVE_STORE + '_';
+      for (var i = 0; i < localStorage.length; i++) {
+        var key = localStorage.key(i);
+        if (!key || key.indexOf(payloadPrefix) !== 0) continue;
+        var id = key.slice(payloadPrefix.length);
+        if (byId[id]) continue;
+        var raw = localStorage.getItem(key);
+        if (!raw) continue;
+        var metadata = _toSaveMetadata(JSON.parse(raw));
+        localStorage.setItem('tm_idb_' + SAVE_META_STORE + '_' + id, JSON.stringify(metadata));
+        metadataRecords.push(metadata);
+        byId[id] = true;
+      }
+      return metadataRecords;
     });
   }
 
@@ -336,7 +493,7 @@ var TM_SaveDB = (function() {
         }
         // 压缩/开库可能跨越读档或下一回合；真正开启写事务前再验一次租约。
         if (!_writeStillAllowed()) return false;
-        return _put(SAVE_STORE, record, 0, _writeStillAllowed);
+        return _putSaveRecord(record, 0, _writeStillAllowed);
       });
     });
   }
@@ -369,7 +526,7 @@ var TM_SaveDB = (function() {
   /** 列出所有游戏存档（不含gameState大数据，仅元信息） */
   function list() {
     return _ensureOpen().then(function() {
-      return _listAll(SAVE_STORE);
+      return _listSaveMetadata();
     }).then(function(records) {
       return records.map(function(r) {
         return { id:r.id, name:r.name, type:r.type, timestamp:r.timestamp, turn:r.turn, scenarioName:r.scenarioName, eraName:r.eraName, date:r.date||'', dynastyPhase:r.dynastyPhase||'', snapshotId:r.snapshotId||'', commitState:r.commitState||'' };
@@ -378,7 +535,7 @@ var TM_SaveDB = (function() {
   }
 
   /** 删除游戏存档 */
-  function deleteSave(id) { return _ensureOpen().then(function() { return _del(SAVE_STORE, id); }); }
+  function deleteSave(id) { return _ensureOpen().then(function() { return _deleteSaveRecord(id); }); }
 
   // ============================================================
   //  公开API：剧本项目


### PR DESCRIPTION
## 修复内容

- 消除旧城市详情及相关剧本/工坊数据的 HTML 注入点，收紧账户公开 DTO、在线请求路由和 IPC 请求体边界。
- 将回合末尾确定性结算、诏令执行与 NPC 深度结果纳入原子事务，关键错误会传播到回合事务并整体回滚。
- 为关键 post-turn 任务增加可重试状态机，保留失败输入且不复用已失败 Promise。
- 修正零贡赋 fallback、财政比例/零值、运行地图选择、字符串/UUID/0 城市 ID 等边界。
- 禁止 AI 通用 set 整体替换结构化状态；拆分浏览器存档 metadata/payload，列表不再读取完整存档。
- 补齐对应回归测试，并按完整资产树刷新 1.3.4.11 热更基线。

## 本地门禁

- `npm ci --ignore-scripts`
- `node web/scripts/sync-official-scenarios.js` + `git diff --exit-code`
- `node web/scripts/ci-smokes.js`：842 项；840 PASS，2 项为隔离工作树缺大资产的既有白名单豁免，命令退出码 0
- `node web/scripts/lint-arch-all.js`：8/8 PASS
- `node web/scripts/verify-official-scenario-parity.js`：27 assertions PASS
- `node scripts/verify-release-contract.js`：165 assertions PASS
- `node web/scripts/verify-hot-builder-gates.js`：27 assertions PASS
- 完整资产基线：1081 files，version 1.3.4.11，PASS

本 PR 不执行打包、发版或 Pages 部署。