### PR TITLE
fix: close fifth-round audit consistency gaps

### DIFF
--- a/main-impl.js
+++ b/main-impl.js
@@ -18,6 +18,7 @@ const AdmZip = require('adm-zip');
 const yauzl = require('yauzl');
 const { pipeline } = require('stream');
 const { autoUpdater } = require('electron-updater');
+const { createTurnDataCommitter } = require('./main-turn-data-commit.js');
 
 // ============================================================
 //  基本配置
@@ -3167,66 +3168,28 @@ ipcMain.handle('open-scenarios-dir', () => {
 //  每回合数据 (turn-data) IPC
 // ============================================================
 
-// 写入一回合的数据  { saveName, turn, data }
-// data 结构：{ context, playerInput, aiResults, varChanges, scenario (仅首回合) }
-ipcMain.handle('write-turn-data', async (event, { saveName, turn, data }) => {
+const turnDataCommitter = createTurnDataCommitter({
+  fs, path, crypto, turnDataDir: TURN_DATA_DIR, turnDataRoot, turnSeg,
+  ensureWritableDir, writeJson, writeJsonAtomic, writeFileAtomic
+});
+
+async function runTurnDataCommit(action, payload) {
   try {
     ensureSaveDir();
-    const saveRoot = turnDataRoot(saveName, true);
-    const turnDir = path.join(saveRoot, turnSeg(turn));
-    const staging = turnDir + '.tmp-' + process.pid + '-' + crypto.randomUUID();
-    fs.mkdirSync(staging, { recursive: true });
-
-    try {
-      // 1. 主上下文文件（兼容旧格式：如果data没有子结构，直接写入）
-      writeJson(path.join(staging, 'context.json'), data.context || data);
-
-      // 2. 玩家操作记录
-      if (data.playerInput) writeJson(path.join(staging, 'player-input.json'), data.playerInput);
-
-      // 3. AI推演全部结果（各Sub-call的原始返回值）
-      if (data.aiResults) writeJson(path.join(staging, 'ai-results.json'), data.aiResults);
-
-      // 4. 变量资源变化文件
-      if (data.varChanges) writeJson(path.join(staging, 'var-changes.json'), data.varChanges);
-
-      // 整回合目录一次提交；失败时旧目录保持不变。
-      const backup = turnDir + '.bak-' + process.pid + '-' + crypto.randomUUID();
-      let movedOld = false;
-      try {
-        if (fs.existsSync(turnDir)) { fs.renameSync(turnDir, backup); movedOld = true; }
-        fs.renameSync(staging, turnDir);
-        if (movedOld) fs.rmSync(backup, { recursive: true, force: true });
-      } catch (commitErr) {
-        try { if (movedOld && !fs.existsSync(turnDir) && fs.existsSync(backup)) fs.renameSync(backup, turnDir); } catch (_) {}
-        throw commitErr;
-      }
-    } catch (stageErr) {
-      try { fs.rmSync(staging, { recursive: true, force: true }); } catch (_) {}
-      throw stageErr;
-    }
-
-    // 5. 剧本快照（仅首回合或指定时保存）
-    if (data.scenario) {
-      const scenarioFile = path.join(saveRoot, 'scenario.json');
-      if (!fs.existsSync(scenarioFile)) {
-        writeJsonAtomic(scenarioFile, data.scenario);
-      }
-    }
-
-    // 6. 严格史实模式的参考文件
-    if (data.refText) {
-      const refFile = path.join(saveRoot, 'reference.txt');
-      if (!fs.existsSync(refFile)) {
-        writeFileAtomic(refFile, data.refText, 'utf-8');
-      }
-    }
-
-    return { success: true, path: turnDir };
+    return await Promise.resolve(turnDataCommitter[action](payload || {}));
   } catch (e) {
-    return { success: false, error: e.message };
+    return { success: false, error: e && e.message || String(e) };
   }
-});
+}
+
+// 新回合先写 .staging；只有 canonical 存档事务成功后才 publish 到正式回合目录。
+ipcMain.handle('stage-turn-data', (event, payload) => runTurnDataCommit('stage', payload));
+ipcMain.handle('publish-turn-data', (event, payload) => runTurnDataCommit('publish', payload));
+ipcMain.handle('recover-turn-data', (event, payload) => runTurnDataCommit('recover', payload));
+ipcMain.handle('discard-turn-data', (event, payload) => runTurnDataCommit('discard', payload));
+
+// 兼容旧 renderer：单次调用内部仍走 stage -> publish，不再维护第二套落盘实现。
+ipcMain.handle('write-turn-data', (event, payload) => runTurnDataCommit('writeLegacy', payload));
 
 // 读取某存档某回合数据（返回该回合目录下所有文件）
 ipcMain.handle('read-turn-data', async (event, { saveName, turn }) => {

--- a/main-turn-data-commit.js
+++ b/main-turn-data-commit.js
@@ -1,0 +1,162 @@
+'use strict';
+
+// Desktop turn bundles use a two-phase protocol:
+//   renderer finalizes records -> stage files -> canonical saves commit -> publish directory.
+// A committed save keeps the transaction descriptor, so an interrupted publish is idempotently
+// recoverable on the next load without exposing an uncommitted turn directory.
+function createTurnDataCommitter(deps) {
+  const fs = deps.fs;
+  const path = deps.path;
+  const crypto = deps.crypto;
+  const turnDataDir = deps.turnDataDir;
+  const turnDataRoot = deps.turnDataRoot;
+  const turnSeg = deps.turnSeg;
+  const ensureWritableDir = deps.ensureWritableDir;
+  const writeJson = deps.writeJson;
+  const writeJsonAtomic = deps.writeJsonAtomic;
+  const writeFileAtomic = deps.writeFileAtomic;
+  const stagingRoot = path.join(turnDataDir, '.staging');
+
+  function assertInside(root, target) {
+    const rootResolved = path.resolve(root);
+    const targetResolved = path.resolve(target);
+    const prefix = rootResolved.endsWith(path.sep) ? rootResolved : rootResolved + path.sep;
+    if (targetResolved !== rootResolved && !targetResolved.startsWith(prefix)) {
+      throw new Error('回合分卷路径越界');
+    }
+    return targetResolved;
+  }
+
+  function transactionId(value) {
+    const id = String(value == null ? '' : value).trim();
+    if (!/^[A-Za-z0-9._-]{8,160}$/.test(id)) throw new Error('非法回合事务 ID');
+    return id;
+  }
+
+  function descriptor(input) {
+    input = input || {};
+    const saveName = String(input.saveName == null ? '' : input.saveName);
+    if (!saveName) throw new Error('缺少存档名称');
+    const saveRoot = assertInside(turnDataDir, turnDataRoot(saveName, true));
+    const saveKey = path.basename(saveRoot);
+    const txId = transactionId(input.transactionId);
+    const turn = turnSeg(input.turn);
+    const stageDir = assertInside(stagingRoot, path.join(stagingRoot, saveKey, txId));
+    return { saveName, saveRoot, saveKey, transactionId: txId, turn, stageDir };
+  }
+
+  function readJsonIfPresent(file) {
+    if (!fs.existsSync(file)) return null;
+    return JSON.parse(fs.readFileSync(file, 'utf-8'));
+  }
+
+  function removeStage(stageDir) {
+    const checked = assertInside(stagingRoot, stageDir);
+    if (fs.existsSync(checked)) fs.rmSync(checked, { recursive: true, force: true });
+    const parent = path.dirname(checked);
+    try { if (fs.existsSync(parent) && fs.readdirSync(parent).length === 0) fs.rmdirSync(parent); } catch (_) {}
+  }
+
+  function writeTurnFiles(turnDir, data, manifest) {
+    ensureWritableDir(turnDir);
+    writeJson(path.join(turnDir, 'context.json'), data.context || data);
+    if (data.playerInput) writeJson(path.join(turnDir, 'player-input.json'), data.playerInput);
+    if (data.aiResults) writeJson(path.join(turnDir, 'ai-results.json'), data.aiResults);
+    if (data.varChanges) writeJson(path.join(turnDir, 'var-changes.json'), data.varChanges);
+    writeJsonAtomic(path.join(turnDir, 'transaction.json'), manifest);
+  }
+
+  function stage(input) {
+    const ref = descriptor(input);
+    const data = input && input.data;
+    if (!data || typeof data !== 'object') throw new Error('回合分卷数据为空');
+    removeStage(ref.stageDir);
+    ensureWritableDir(ref.stageDir);
+    const manifest = {
+      version: 1,
+      status: 'prepared',
+      saveKey: ref.saveKey,
+      campaignId: String(input.campaignId || ''),
+      turn: Number(ref.turn),
+      transactionId: ref.transactionId,
+      stateChecksum: String(input.stateChecksum || ''),
+      createdAt: new Date().toISOString()
+    };
+    try {
+      writeTurnFiles(path.join(ref.stageDir, 'turn'), data, manifest);
+      if (data.scenario) writeJsonAtomic(path.join(ref.stageDir, 'scenario.json'), data.scenario);
+      if (data.refText) writeFileAtomic(path.join(ref.stageDir, 'reference.txt'), String(data.refText), 'utf-8');
+      writeJsonAtomic(path.join(ref.stageDir, 'manifest.json'), manifest);
+      return Object.assign({ success: true }, manifest);
+    } catch (error) {
+      try { removeStage(ref.stageDir); } catch (_) {}
+      throw error;
+    }
+  }
+
+  function replaceTurnDirectory(stagedTurn, finalTurn) {
+    const backup = finalTurn + '.bak-' + process.pid + '-' + crypto.randomUUID();
+    let movedOld = false;
+    try {
+      ensureWritableDir(path.dirname(finalTurn));
+      if (fs.existsSync(finalTurn)) { fs.renameSync(finalTurn, backup); movedOld = true; }
+      fs.renameSync(stagedTurn, finalTurn);
+      if (movedOld) fs.rmSync(backup, { recursive: true, force: true });
+    } catch (error) {
+      try { if (movedOld && !fs.existsSync(finalTurn) && fs.existsSync(backup)) fs.renameSync(backup, finalTurn); } catch (_) {}
+      throw error;
+    }
+  }
+
+  function publish(input) {
+    const ref = descriptor(input);
+    const manifestFile = path.join(ref.stageDir, 'manifest.json');
+    const manifest = readJsonIfPresent(manifestFile);
+    const finalTurn = assertInside(ref.saveRoot, path.join(ref.saveRoot, ref.turn));
+    const finalManifestFile = path.join(finalTurn, 'transaction.json');
+    const existing = readJsonIfPresent(finalManifestFile);
+    function matchesDescriptor(candidate) {
+      if (!candidate || candidate.transactionId !== ref.transactionId || String(candidate.turn) !== ref.turn) return false;
+      if (input.campaignId != null && String(candidate.campaignId || '') !== String(input.campaignId || '')) return false;
+      if (input.stateChecksum != null && String(candidate.stateChecksum || '') !== String(input.stateChecksum || '')) return false;
+      return true;
+    }
+    if (!manifest && matchesDescriptor(existing)) {
+      return { success: true, recovered: true, path: finalTurn, transactionId: ref.transactionId };
+    }
+    if (!matchesDescriptor(manifest)) {
+      throw new Error('回合分卷暂存记录不存在或不匹配');
+    }
+    const stagedTurn = path.join(ref.stageDir, 'turn');
+    if (!matchesDescriptor(existing)) {
+      if (!fs.existsSync(stagedTurn)) throw new Error('回合分卷暂存内容缺失');
+      replaceTurnDirectory(stagedTurn, finalTurn);
+    }
+    const stagedScenario = path.join(ref.stageDir, 'scenario.json');
+    const stagedReference = path.join(ref.stageDir, 'reference.txt');
+    const scenarioFile = path.join(ref.saveRoot, 'scenario.json');
+    const referenceFile = path.join(ref.saveRoot, 'reference.txt');
+    if (fs.existsSync(stagedScenario) && !fs.existsSync(scenarioFile)) writeJsonAtomic(scenarioFile, readJsonIfPresent(stagedScenario));
+    if (fs.existsSync(stagedReference) && !fs.existsSync(referenceFile)) writeFileAtomic(referenceFile, fs.readFileSync(stagedReference, 'utf-8'), 'utf-8');
+    writeJsonAtomic(finalManifestFile, Object.assign({}, manifest, { status: 'committed', publishedAt: new Date().toISOString() }));
+    removeStage(ref.stageDir);
+    return { success: true, path: finalTurn, transactionId: ref.transactionId };
+  }
+
+  function discard(input) {
+    const ref = descriptor(input);
+    removeStage(ref.stageDir);
+    return { success: true, transactionId: ref.transactionId };
+  }
+
+  function writeLegacy(input) {
+    input = input || {};
+    const txId = 'legacy-' + Date.now() + '-' + crypto.randomUUID();
+    const staged = stage(Object.assign({}, input, { transactionId: txId }));
+    return publish({ saveName: input.saveName, turn: input.turn, transactionId: staged.transactionId });
+  }
+
+  return { stage, publish, recover: publish, discard, writeLegacy };
+}
+
+module.exports = { createTurnDataCommitter };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "files": [
       "main.js",
       "main-impl.js",
+      "main-turn-data-commit.js",
       "preload.js",
       "preload-impl.js",
       "resources/hot-update-public-key.pem",

--- a/preload-impl.js
+++ b/preload-impl.js
@@ -265,6 +265,18 @@ contextBridge.exposeInMainWorld('tianming', {
     ipcRenderer.invoke('open-scenarios-dir'),
 
   // === 每回合数据 ===
+  stageTurnData: (payload) =>
+    ipcRenderer.invoke('stage-turn-data', payload),
+
+  publishTurnData: (payload) =>
+    ipcRenderer.invoke('publish-turn-data', payload),
+
+  recoverTurnData: (payload) =>
+    ipcRenderer.invoke('recover-turn-data', payload),
+
+  discardTurnData: (payload) =>
+    ipcRenderer.invoke('discard-turn-data', payload),
+
   writeTurnData: (saveName, turn, data) =>
     ipcRenderer.invoke('write-turn-data', { saveName, turn, data }),
 

--- a/scripts/verify-release-contract.js
+++ b/scripts/verify-release-contract.js
@@ -68,6 +68,8 @@ function main() {
   const publicKeyRel = 'resources/hot-update-public-key.pem';
   const publicKeyPath = path.join(ROOT, publicKeyRel);
   ok(files.has(publicKeyRel) && fs.existsSync(publicKeyPath), 'installer 固定携带热更新发布者公钥');
+  ok(files.has('main-turn-data-commit.js') && fs.existsSync(path.join(ROOT, 'main-turn-data-commit.js')),
+    'installer 携带回合分卷两阶段提交模块');
   const publicKey = crypto.createPublicKey(fs.readFileSync(publicKeyPath));
   ok(publicKey.asymmetricKeyType === 'ed25519', '热更新固定公钥类型为 Ed25519');
   ok(['win', 'mac', 'linux'].every(platform => String(pkg.scripts['build:' + platform] || '').includes('scripts/build-electron.js --platform ' + platform)

--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-19T09:07:28.247Z",
+  "generatedAt": "2026-08-19T12:13:12.764Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -21,8 +21,8 @@
     },
     {
       "path": "ARCHITECTURE.md",
-      "sha256": "0acbcda11886f8f8c861c02be866db8b6a40fe5a04f6215f455f55f330742ab5",
-      "size": 18452
+      "sha256": "b521d9b860728b1e1a9e8505f46778ebfff322ba8fb38e8c3fb29ea83b001ba9",
+      "size": 18680
     },
     {
       "path": "assets/assets-isolated/audio/bgm/README.md",
@@ -3761,8 +3761,8 @@
     },
     {
       "path": "tm-court-meter.js",
-      "sha256": "06240a9c3a762c9452de47f4d5f3c4e4f9ab339004a2fddbebefafcc0f2df5db",
-      "size": 15243
+      "sha256": "00eb51a2b5bf6f2a05c3d405b93a1da782506d806c6976fa479a05e91f373f8b",
+      "size": 13425
     },
     {
       "path": "tm-custom-build-agent.js",
@@ -3921,8 +3921,8 @@
     },
     {
       "path": "tm-endturn-core.js",
-      "sha256": "4848475fe95f4f246a9226f4fec52b94641f2816308a9fa179a2ef0a76303e71",
-      "size": 87971
+      "sha256": "d82cd50f2d4c5914d0c4ea684d79ef2b3858edd57c16b90dabddf73b535ee51d",
+      "size": 90012
     },
     {
       "path": "tm-endturn-edict.js",
@@ -3961,8 +3961,8 @@
     },
     {
       "path": "tm-endturn-pipeline-steps.js",
-      "sha256": "c0b031d94edf08f59897c3cc499452252734225c3571c00a171e7372fe669ccc",
-      "size": 58524
+      "sha256": "86a405cbfbc2c7ab9db7d9f9373adb1eb6d2425278b621032a250b299caa5eb1",
+      "size": 55825
     },
     {
       "path": "tm-endturn-pipeline-types.js",
@@ -4006,8 +4006,8 @@
     },
     {
       "path": "tm-endturn-render.js",
-      "sha256": "a5eb58e0d9d2a23fa9ce02d928b62d41bbbfa198f1cf149fc6a3c30e6755f204",
-      "size": 29111
+      "sha256": "36a08311472f0d4d5ddcf20e9643f6d8f532904e3143f3c7a9a5d1d2b07ba4bb",
+      "size": 32769
     },
     {
       "path": "tm-endturn-shiji-compose.js",
@@ -4231,8 +4231,8 @@
     },
     {
       "path": "tm-game-ui-shell.js",
-      "sha256": "e8c22096ab34db8fb8ec4fe10f20af7d7757b8a8c5e5ed402bb7af9001036025",
-      "size": 51879
+      "sha256": "bdd7beedc0ded24547a4377569c0b4f6f1e40bc693792ea3dacaed64772ec9d7",
+      "size": 51951
     },
     {
       "path": "tm-globalrules.js",
@@ -4591,8 +4591,8 @@
     },
     {
       "path": "tm-map-system.js",
-      "sha256": "8545c876666670699672a93b317bc917b0716076064ed49ae6b6fb79522e844b",
-      "size": 91150
+      "sha256": "1b77b32bd35e298bf10bdb340f949ec0dfd5219e6d223d8e26230a10e3263134",
+      "size": 91213
     },
     {
       "path": "tm-mapeditor-fit.js",
@@ -5096,8 +5096,8 @@
     },
     {
       "path": "tm-save-lifecycle.js",
-      "sha256": "90ac15a624ce45d45da315fd25fe39083472229b78753626136fcd73c63db21c",
-      "size": 106156
+      "sha256": "49cabbe8bddf3fb3af018e7426c7dbbb3f6d158c80310b6d4d591d12119dbf04",
+      "size": 107162
     },
     {
       "path": "tm-save-manager.js",
@@ -5156,8 +5156,8 @@
     },
     {
       "path": "tm-storage.js",
-      "sha256": "0ca26e610ff77b7d2d8a6715d2584efac30a8dabd9082e7095469d82a881b154",
-      "size": 35466
+      "sha256": "9c7cc1b75da43ad9c81c515f455f67c79b17b63ac75d5526b4a8bd6112049ac7",
+      "size": 42608
     },
     {
       "path": "tm-talent-backlash.js",
@@ -5286,8 +5286,8 @@
     },
     {
       "path": "tm-wendui.js",
-      "sha256": "0dd64c3ce88b432bf18f9933b0c8fd43e2e9399e4a0e31a3f9a76add313ada6e",
-      "size": 183719
+      "sha256": "f590ef2f60cdd04d85f2e28fd94fce43e3e7d232d0912767feee4983bc4340ea",
+      "size": 183870
     },
     {
       "path": "tm-wentian-agent.js",

--- a/web/ARCHITECTURE.md
+++ b/web/ARCHITECTURE.md
@@ -213,9 +213,11 @@ endTurn()                          ← tm-endturn-core.js（入口 + 前置 acto
      │     户籍 HujiEngine；环境 EnvCapacityEngine；科举 advanceKejuByDays；
      │     权威 AuthorityEngines；腐败 CorruptionEngine
      │
-     └─ step 'render-and-finalize'  ← tm-endturn-render.js
-           yearlyChronicles.push 摘要 / memorialsLog 归档 / showPostTurnCourtBanner /
-           renderShiji / renderChronicle；GM.turn++；GM.date=getTSText()；autoSave(slot0)
+     ├─ step 'render-and-finalize'  ← tm-endturn-pipeline-steps.js
+     │     准备记录参数；执行 after hooks / 科举 / 路程 / NPC 状态收官；失败即 abort
+     └─ step 'prepare-commit-barrier' ← tm-endturn-core.js + tm-endturn-render.js
+           finalize records → stage turn-data → autosave+slot_0 单事务 → commit →
+           publish turn-data → 清玩家草稿 → 纯 UI render（仅此处可降级）
 ```
 
 **调试技巧**：
@@ -309,7 +311,7 @@ tm-var-drawers / -ext / -final · 变量抽屉的 3 代版本
 
 **已落地（原路线图项）**
 - ✅ 合并 `tm-guoku-p2/p4/p5/p6` → 现仅存 `tm-guoku-engine.js`（`tm-corruption`/`tm-neitang` 的 p2/p4 后补也已并）
-- ✅ endTurn 拆为显式管道：6 step（`prep/plan-prefetch/ai/post-ai-edict/systems/render-and-finalize`，见 §6），每 step 独立 onError
+- ✅ endTurn 拆为显式管道：7 step（`prep/plan-prefetch/ai/post-ai-edict/systems/render-and-finalize/prepare-commit-barrier`，见 §6），每 step 独立 onError
 - ✅ JSDoc/类型：`@ts-check` 已覆盖 `tm-*.js` 的 **78%**（239/306）
 - ✅ 导航债清零：1500+ 行根文件 TOC 覆盖 **62/62 = 100%**（2026-06-13 一刀补齐；`debt-report.js` 已认 `§字母`/`Module:` 等约定）。各大文件顶部均有「章节导航」块，靠 grep 小节标题跳转、不写行号
 

--- a/web/docs/2026-05-08-handoff-pipeline-and-topbar.md
+++ b/web/docs/2026-05-08-handoff-pipeline-and-topbar.md
@@ -51,7 +51,8 @@ endTurn → _endTurnInternal → _endTurnCore
   │ 3. ai                [onError: abort]      │ ← _endTurn_aiInfer + await prefetch
   │ 4. post-ai-edict     [onError: abort]      │ ← applyEdictActions + tyrant.applyEffects（状态写入原子化）
   │ 5. systems           [onError: abort]      │ ← _endTurn_updateSystems (含 GM.turn++) + edictEfficacy enqueue
-  │ 6. render-and-finalize [onError: abort]    │ ← 状态收官失败回滚；仅显式包裹的纯 UI 渲染可降级
+  │ 6. render-and-finalize [onError: abort]    │ ← 参数准备 + 状态收官，失败回滚
+  │ 7. prepare-commit-barrier [onError: abort] │ ← records/save/commit；commit 后纯 UI 可降级
   └────────────────────────────────────────────┘
   ┌─ post-pipeline tail ───────────────────────┐
   │ aiMemory compress / monthly chronicle       │

--- a/web/docs/endturn-data-flow.md
+++ b/web/docs/endturn-data-flow.md
@@ -108,15 +108,15 @@
 - **同步/异步**：纯同步
 - **错误处理**：无（trivial 装配函数）
 
-### tm-endturn-render.js (2099 LOC)
-- **入口函数**：`_endTurn_render(shizhengji, zhengwen, ..., 17 个参数)`
-- **职责一句话**：渲染史记面板 + Delta 面板 + 角色高亮 + 触发自动存档
-- **被谁调**：core.js L230 直接调；deferredPhase5 不调（phase4 渲染已经过了）
+### tm-endturn-render.js
+- **入口函数**：`_endTurn_finalizeRecords(...)` / `_endTurn_saveSnapshot(ctx)` / `_endTurn_render(presentation)`
+- **职责一句话**：事务内最终化史记、起居注、指标和分卷暂存；原子保存 canonical 双槽；commit 后只渲染 UI
+- **被谁调**：`tm-endturn-core.js` 的共享 commit barrier；normal/deferred 两条路径复用同一入口
 - **GM 读字段**：`GM.chars` / `GM.vars` / `GM.guoku` / `GM.neitang` / `GM.population` / `GM._prevGuoku` / `GM._prevNeitang` / `GM._prevPopulation` / `GM._prevVars` / `GM._turnBattleResults` / `GM._turnTyrantActivities` / `GM._tyrantHistory` / `GM._yearlyDigest` / `GM._reconcilePatchLog` / `GM._fengwenRecord` / `GM._edictEfficacyReport` / `GM._fiscalDeficitStreak` / `GM._metricHistory` / `GM._turnAiResults`
 - **GM 写字段**：`GM.shijiHistory.push` / `GM.eraName` / `GM._pendingToasts` / `GM._tyrantDecadence` / `GM._lastFixedExpense` / `GM._reconcileLog`
 - **关键临时字段**：消费所有 `_prev*` snapshots 算 delta；消费 `_turnAiResults`/`_turnTyrantActivities`/`_turnBattleResults` 渲染
-- **同步/异步**：函数本身同步；存档分支内部 2 处 await
-- **错误处理**：19 处 try/catch
+- **同步/异步**：记录最终化同步；存档和桌面分卷 stage/publish 为显式 await
+- **错误处理**：记录或存档异常向事务边界传播；只有 commit 后纯展示异常允许降级
 
 ### tm-endturn-province.js (2236 LOC)
 - **入口函数**：`initProvinceEconomy()` / `updateProvinceEconomy()` / `appointGovernor()` + 省级面板 UI
@@ -215,7 +215,7 @@
 
 ## 4. 管道步骤切分建议
 
-按数据依赖最小割推荐切成 **6 个粗粒度 step**（不是当前 15+ sub-phase）：
+按数据依赖最小割切成 **7 个粗粒度 step**（不是当前 15+ sub-phase）：
 
 1. **prep**（同步）：`_endTurn_init` + `_endTurn_collectInput` + memorial decisions + 三系统更新 (1.7) + ghost sweep + npc auto-appoint
    - 输出：`{npcContext, input{edicts,xinglu,memRes,oldVars,edictActions,tyrantActivities}, snapshots:{prevGuoku,prevNeitang,prevPopulation}, edictTrackerNew}`
@@ -223,7 +223,8 @@
 3. **ai**（顺序流水线）：prompt.build → subcalls.runMain (sc0/sc05/sc1) → apply.writeBack → followup.run（含三路并行 + 后台化分支）
 4. **post-ai-edict**（同步）：`applyEdictActions` (phase 2.5) + `TyrantActivitySystem.applyEffects` (2.6) + `aiEdictEfficacyAudit`（已后台化）
 5. **systems**（同步串联）：`_endTurn_updateSystems` 50+ engine.tick·**已经是 in-process pipeline**·作为单 step 不再拆
-6. **render-and-finalize**（同步 + 朝会分支）：`_endTurn_render` + after hooks + 科举/角色路程/勤政 streak·若 `_pendingShijiModal.courtDone===false` 则将 phase5 打包成 `deferredPhase5` 等待朝会回调。该 step 的状态收官采用 `onError: abort`；只有 `_endTurn_render` 及其纯展示 fallback 在局部捕获后允许降级。
+6. **render-and-finalize**（同步 + 朝会分支）：只准备 finalization 参数，并执行 after hooks、科举、角色路程和勤政等剩余状态结算；若 `_pendingShijiModal.courtDone===false` 则等待朝会回调。全部状态异常 `onError: abort`。
+7. **prepare-commit-barrier**：声明最终存档要求；随后 core 依次执行 `_endTurn_finalizeRecords` → 分卷 stage → `saveManyAtomic(autosave, slot_0)` → commit → 分卷 publish → 清草稿 → `_endTurn_render`。只有最后的纯 UI 阶段允许降级。
 
 每 step 内部并行/顺序与当前一致；step 之间 boundary 严格走 ctx 显式字段。
 

--- a/web/docs/module-boundaries.md
+++ b/web/docs/module-boundaries.md
@@ -142,12 +142,12 @@ tm-endturn-core (调 / 间接·tm-player-core (endTurn 按钮)
 
 | 项 | 内容 |
 |---|---|
-| owns | _endTurn_render 主入口·渲染前清洗（_unescNarr/死亡过滤/年号）·全部副作用（worldChangeDigest·风闻转录·shijiHistory 落账·起居注·清输入·快照·自动存档·回合收尾） |
+| owns | `_endTurn_finalizeRecords` 事务内记录落账·`_endTurn_saveSnapshot` canonical 双槽原子保存与桌面分卷暂存·`_endTurn_render` commit 后纯展示 |
 | does not own | 弹窗 HTML 组装 (→ tm-endturn-shiji-compose·2026-07-06 迁)·AI 推演 (→ tm-endturn-ai-infer)·业务结算 (→ tm-endturn-systems)·battle 数据 (→ tm-military) |
-| public API | `_endTurn_render` (内部由 ai-infer 末尾调用) |
+| public API | `_endTurn_finalizeRecords` / `_endTurn_saveSnapshot` / `_endTurn_render`（由 core commit barrier 调用） |
 | depends on | tm-endturn-shiji-compose (`_composeShijiHtml`·**必须先加载**)·tm-endturn-helpers / tm-utils |
-| used by | tm-endturn-ai-infer (Region 5 末尾·由 core 末尾) |
-| 新功能加哪 | 回合收尾副作用 → 加这里；结果展示 → tm-endturn-shiji-compose |
+| used by | tm-endturn-core（normal/deferred 共用提交屏障） |
+| 新功能加哪 | 状态记录落账 → finalizer；结果 HTML 组装 → tm-endturn-shiji-compose；DOM 动画 → renderer |
 | smoke | `render-smoke` (7 targets·13 pass) |
 
 ---

--- a/web/scripts/smoke-endturn-battle-detail-fallback.js
+++ b/web/scripts/smoke-endturn-battle-detail-fallback.js
@@ -66,7 +66,7 @@ const sandbox = {
       { name: '孙承宗', faction: '明军', alive: true },
       { name: '侯养性', faction: '后金', alive: true }
     ],
-    facs: [],
+    facs: [{ name: '覆灭势力', strength: 0, militaryStrength: 0 }],
     vars: {},
     rels: {},
     evtLog: [],
@@ -133,9 +133,10 @@ vm.runInContext(fs.readFileSync(path.join(ROOT, 'tm-endturn-render.js'), 'utf8')
   filename: 'tm-endturn-render.js'
 });
 
+assert(typeof sandbox._endTurn_finalizeRecords === 'function', '_endTurn_finalizeRecords should be callable');
 assert(typeof sandbox._endTurn_render === 'function', '_endTurn_render should be callable');
 
-sandbox._endTurn_render(
+const presentation = sandbox._endTurn_finalizeRecords(
   '辽东战事略胜，诸军收兵。',
   '曹文诏、孙承宗督军转进，侯养性部溃退。',
   '',
@@ -155,6 +156,7 @@ sandbox._endTurn_render(
   '',
   null
 );
+sandbox._endTurn_render(presentation);
 
 const html = (sandbox.GM.shijiHistory[0] && sandbox.GM.shijiHistory[0].html) || sandbox._lastTurnResultHtml || '';
 const match = html.match(/<details[\s\S]*?<summary[\s\S]*?3\s*军卷入[\s\S]*?<\/table><\/details>/);
@@ -169,5 +171,7 @@ assert(/主将无恙/.test(details), 'commanderFate.outcome should localize surv
 assert(/溃退/.test(details) && /主将被俘/.test(details), 'stateAfter and captured outcome should localize enemy fate');
 assert(/120/.test(details) && /540/.test(details), 'loss should render as casualties fallback');
 assert(!/<td[^>]*>\s*\?\s*<\/td>/.test(details), 'battle details should not render bare question-mark cells');
+assert(sandbox.GM._factionHistory[0].turn === 39 && sandbox.GM._factionHistory[0].factions['覆灭势力'].strength === 0,
+  'faction history preserves zero strength and labels the completed turn');
 
 console.log('[smoke-endturn-battle-detail-fallback] PASS battle detail fallbacks render named army/fate rows');

--- a/web/scripts/smoke-endturn-render-loading-guard.js
+++ b/web/scripts/smoke-endturn-render-loading-guard.js
@@ -1,40 +1,29 @@
 #!/usr/bin/env node
-// smoke-endturn-render-loading-guard.js
-// Guards against the end-turn loading overlay being left open if Shiji render fails.
+// Guards the post-commit-only UI render boundary and its loading-overlay fallback.
 'use strict';
 
 const fs = require('fs');
 const path = require('path');
 
 const ROOT = path.resolve(__dirname, '..');
-const src = fs.readFileSync(path.join(ROOT, 'tm-endturn-pipeline-steps.js'), 'utf8');
-
+const core = fs.readFileSync(path.join(ROOT, 'tm-endturn-core.js'), 'utf8');
+const pipeline = fs.readFileSync(path.join(ROOT, 'tm-endturn-pipeline-steps.js'), 'utf8');
+const render = fs.readFileSync(path.join(ROOT, 'tm-endturn-render.js'), 'utf8');
 let passed = 0;
-function assert(cond, label) {
-  if (!cond) throw new Error('[assert] ' + label);
-  passed++;
-}
+function assert(cond, label) { if (!cond) throw new Error('[assert] ' + label); passed++; }
 
-const renderIdx = src.indexOf('_endTurn_render.apply(null, _renderArgs);');
-assert(renderIdx >= 0, 'render call exists');
+const commitIdx = core.indexOf('if (!_tmCommitEndTurnTransaction(txn))');
+const renderIdx = core.indexOf('_endTurn_render(ctx.meta.turnPresentation)', commitIdx);
+assert(commitIdx >= 0 && renderIdx > commitIdx, 'pure UI render starts only after the world transaction commits');
+const postCommit = core.slice(commitIdx, renderIdx + 900);
+assert(postCommit.indexOf('ctx.results.renderError = renderError') >= 0, 'post-commit render failure is retained for diagnostics');
+assert(postCommit.indexOf('_endTurn_showRenderFallback(renderError)') >= 0, 'post-commit render failure opens the safe fallback');
+assert(pipeline.indexOf('_endTurn_render.apply(null, _renderArgs)') < 0, 'pipeline no longer renders before state finalization and save');
+assert(pipeline.indexOf('ctx.meta.turnRenderArgs = _renderArgs') >= 0, 'pipeline stages immutable render inputs for the commit barrier');
 
-const renderBlockStart = src.lastIndexOf("if (typeof _endTurn_render === 'function')", renderIdx);
-const renderBlock = src.slice(renderBlockStart, renderIdx + 1800);
-assert(renderBlockStart >= 0, 'render block found');
-
-const stepStart = src.lastIndexOf("name: 'render-and-finalize'", renderIdx);
-const preRenderBlock = src.slice(stepStart, renderIdx);
-assert(stepStart >= 0, 'render-finalize step found');
-assert(preRenderBlock.indexOf('_normalizeTurnChangesForRender') >= 0,
-  'turnChanges are normalized before the result render');
-assert(preRenderBlock.indexOf('ctx.results.changeReportError') >= 0,
-  'legacy change report generation is guarded before the result render');
-
-assert(renderBlock.indexOf('try {') >= 0, 'render call is wrapped in try/catch');
-assert(renderBlock.indexOf("typeof hideLoading === 'function'") >= 0, 'render failure hides loading overlay');
-assert(renderBlock.indexOf('pipeline.render-finalize] render failed') >= 0, 'render failure has diagnostic label');
-assert(renderBlock.indexOf('ctx.results.renderError') >= 0, 'render failure is recorded in ctx');
-assert(renderBlock.indexOf('showTurnResult(') >= 0 || renderBlock.indexOf('toast(') >= 0,
-  'render failure gives player-visible feedback');
+const fallbackIdx = render.indexOf('function _endTurn_showRenderFallback(error)');
+const fallback = render.slice(fallbackIdx, fallbackIdx + 1300);
+assert(fallbackIdx >= 0 && fallback.indexOf("typeof hideLoading === 'function'") >= 0, 'fallback always releases the loading overlay');
+assert(fallback.indexOf('showTurnResult(') >= 0 && fallback.indexOf('本回合已安全保存') >= 0, 'fallback accurately reports a committed world');
 
 console.log('[smoke-endturn-render-loading-guard] pass assertions=' + passed);

--- a/web/scripts/smoke-endturn-transaction-failures.js
+++ b/web/scripts/smoke-endturn-transaction-failures.js
@@ -44,7 +44,7 @@ ctx.window = ctx;
 vm.createContext(ctx);
 vm.runInContext(sourceBetween(coreSource, 'async function _tmRunCriticalEndTurnSystem', 'async function _runPreSubmitPartyClassCalibration'), ctx);
 vm.runInContext(sourceBetween(coreSource, 'async function _runPreSubmitPartyClassCalibration()', 'async function _endTurnInternal'), ctx);
-vm.runInContext(sourceBetween(coreSource, 'function _tmCaptureEndTurnObject', 'async function _tmFinalizeEndTurnTransaction'), ctx);
+vm.runInContext(sourceBetween(coreSource, 'function _tmCaptureEndTurnObject', "if (typeof window !== 'undefined') {\n  window._tmMaybeStageTurnResult"), ctx);
 vm.runInContext(systemsSource, ctx);
 vm.runInContext(pipelineStepsSource, ctx);
 
@@ -63,6 +63,10 @@ function resetWorld(extra) {
   delete ctx.IntegrationBridge;
   delete ctx.TMArmory;
   delete ctx._endTurn_render;
+  delete ctx._endTurn_finalizeRecords;
+  delete ctx._endTurn_publishStagedTurnData;
+  delete ctx._endTurn_clearCommittedInputs;
+  delete ctx._endTurn_showRenderFallback;
   delete ctx._settleCourtMeter;
   delete ctx.advanceCharTravelByDays;
   delete ctx.advanceKejuByDays;
@@ -223,12 +227,71 @@ async function main() {
     };
   }, 'npc-guoku-partial-failure', 'NPC treasury finalization');
 
-  resetWorld();
+  resetWorld({ shijiHistory: [], qijuHistory: [] });
+  let recordBefore = comparableWorld(ctx.GM);
+  txn = ctx._tmCaptureEndTurnTransaction();
+  ctx._endTurn_finalizeRecords = function() {
+    ctx.GM.shijiHistory.push({ turn: 4 });
+    throw new Error('chronicle-after-shiji');
+  };
+  let recordCtx = buildStepCtx();
+  recordCtx.meta.turnRenderArgs = [];
+  ok(await expectFailure(ctx._tmFinalizeEndTurnTransaction(recordCtx, txn), 'chronicle-after-shiji'),
+    'record finalization failure propagates before save/commit');
+  ctx._tmRollbackEndTurnTransaction(txn, new Error('chronicle-after-shiji'));
+  ok(comparableWorld(ctx.GM) === recordBefore, 'partial Shiji record is rolled back');
+
+  resetWorld({ shijiHistory: [], qijuHistory: [] });
+  txn = ctx._tmCaptureEndTurnTransaction();
+  ctx._endTurn_finalizeRecords = function() {
+    ctx.GM.qijuHistory.push({ turn: 4 });
+    throw new Error('memorial-after-qiju');
+  };
+  recordCtx = buildStepCtx();
+  recordCtx.meta.turnRenderArgs = [];
+  ok(await expectFailure(ctx._tmFinalizeEndTurnTransaction(recordCtx, txn), 'memorial-after-qiju'),
+    'Qiju/memorial record failure propagates before save/commit');
+  ctx._tmRollbackEndTurnTransaction(txn, new Error('memorial-after-qiju'));
+  ok(ctx.GM.qijuHistory.length === 0, 'partial Qiju record is rolled back');
+
+  resetWorld({ shijiHistory: [] });
+  txn = ctx._tmCaptureEndTurnTransaction();
+  ctx._endTurn_finalizeRecords = function() { ctx.GM.marker = 20; return { shijiHtml: 'ok' }; };
+  ctx._endTurn_saveSnapshot = async function() { return true; };
   ctx._endTurn_render = function() { throw new Error('ui-render-only-failure'); };
   const uiCtx = buildStepCtx();
-  await finalizeStep.fn(uiCtx);
-  ok(uiCtx.results.renderError && uiCtx.results.renderError.message === 'ui-render-only-failure',
-    'pure UI rendering failure remains explicitly degradable');
+  uiCtx.meta.turnRenderArgs = [];
+  ok(await ctx._tmFinalizeEndTurnTransaction(uiCtx, txn) === true && txn.committed === true,
+    'pure UI failure after commit cannot roll the world back');
+  ok(uiCtx.results.renderError && uiCtx.results.renderError.message === 'ui-render-only-failure' && ctx.GM.marker === 20,
+    'post-commit UI failure remains explicitly degradable and diagnostic');
+
+  resetWorld();
+  txn = ctx._tmCaptureEndTurnTransaction();
+  let clearDraftCalls = 0;
+  ctx._endTurn_finalizeRecords = function() { return { shijiHtml: 'pending' }; };
+  ctx._endTurn_saveSnapshot = async function() { return false; };
+  ctx._endTurn_clearCommittedInputs = function() { clearDraftCalls++; };
+  const failedSaveCtx = buildStepCtx();
+  failedSaveCtx.meta.turnRenderArgs = [];
+  ok(await expectFailure(ctx._tmFinalizeEndTurnTransaction(failedSaveCtx, txn), '回合最终存档失败'),
+    'canonical save failure aborts before commit');
+  ok(clearDraftCalls === 0 && txn.committed === false, 'player input drafts remain untouched when final save fails');
+
+  resetWorld({ _pendingTurnDataPublish: { transactionId: 'turn-publish-retry' } });
+  txn = ctx._tmCaptureEndTurnTransaction();
+  clearDraftCalls = 0;
+  ctx._endTurn_finalizeRecords = function() { return { shijiHtml: 'committed' }; };
+  ctx._endTurn_saveSnapshot = async function() { return true; };
+  ctx._endTurn_publishStagedTurnData = async function() { throw new Error('publish-after-commit'); };
+  ctx._endTurn_clearCommittedInputs = function() { clearDraftCalls++; };
+  ctx._endTurn_render = function() {};
+  const publishCtx = buildStepCtx();
+  publishCtx.meta.turnRenderArgs = [];
+  ok(await ctx._tmFinalizeEndTurnTransaction(publishCtx, txn) === true && txn.committed === true,
+    'turn-data publish failure cannot roll back an already committed world');
+  ok(clearDraftCalls === 1 && ctx.GM._pendingTurnDataPublish.transactionId === 'turn-publish-retry' && publishCtx.results.turnDataPublishError,
+    'publish failure keeps its recovery marker while post-commit input cleanup proceeds');
 
   resetWorld({ _pendingShijiModal: { courtDone: false, aiReady: false, payload: null } });
   ctx.P.keju = { currentExam: true };

--- a/web/scripts/smoke-formal-edict-endturn-bridge.js
+++ b/web/scripts/smoke-formal-edict-endturn-bridge.js
@@ -15,6 +15,7 @@ const phase8 = bridge + '\n' + drafts;
 const office = read('tm-office-panel.js');
 const prep = read('tm-endturn-prep.js');
 const render = read('tm-endturn-render.js');
+const core = read('tm-endturn-core.js');
 
 assert(/function syncFormalEdictDraftsToLegacyInputs\(\)/.test(phase8), 'phase8 bridge sync function is missing');
 assert(/function getFormalEdictDraftSnapshot\(\)/.test(phase8), 'phase8 edict snapshot function is missing');
@@ -45,6 +46,11 @@ assert(collectIndex >= 0 && collectSyncIndex > collectIndex && collectSyncIndex 
 
 const clearInputIndex = render.indexOf('["edict-pol","edict-mil","edict-dip","edict-eco","edict-oth","xinglu","xinglu-pub","xinglu-prv"]');
 const clearPhase8Index = render.indexOf('clearEdictDrafts', clearInputIndex);
-assert(clearInputIndex >= 0 && clearPhase8Index > clearInputIndex, 'end-turn render must clear phase8 edict drafts after clearing legacy inputs');
+assert(clearInputIndex >= 0 && clearPhase8Index > clearInputIndex, 'post-commit cleanup clears phase8 drafts after legacy inputs');
+assert(/function _endTurn_stripCommittedDraftsFromSnapshot[\s\S]*?delete snapGM\._savedEdictDrafts[\s\S]*?edictDrafts = \{\}/.test(render),
+  'canonical final save omits already-submitted legacy and formal edict drafts without mutating live inputs');
+const commitIndex = core.indexOf('if (!_tmCommitEndTurnTransaction(txn))');
+const clearCommittedIndex = core.indexOf('_endTurn_clearCommittedInputs()', commitIndex);
+assert(commitIndex >= 0 && clearCommittedIndex > commitIndex, 'live player drafts are cleared only after transaction commit');
 
 console.log('[smoke-formal-edict-endturn-bridge] pass');

--- a/web/scripts/smoke-memory-trace-persist.js
+++ b/web/scripts/smoke-memory-trace-persist.js
@@ -59,9 +59,9 @@ assert(!persistedJson.includes('SECRET_INJECTION_TEXTSECRET_INJECTION_TEXTSECRET
 
 const finalizeIdx = renderSrc.indexOf('TM.MemoryTrace.finalizeTurnTrace');
 const aiResultsIdx = renderSrc.indexOf('var aiResults=GM._turnAiResults||{};');
-assert(finalizeIdx >= 0, 'render should finalize MemoryTrace before desktop writeTurnData');
+assert(finalizeIdx >= 0, 'record finalization should finalize MemoryTrace before staging desktop turn data');
 assert(aiResultsIdx >= 0, 'render should still write aiResults from GM._turnAiResults');
-assert(finalizeIdx < aiResultsIdx, 'MemoryTrace should be finalized before aiResults is captured for writeTurnData');
+assert(finalizeIdx < aiResultsIdx, 'MemoryTrace should be finalized before aiResults is captured for staged turn data');
 assert(renderSrc.includes("recordMemoryDiagnostic('trace'"), 'render should publish a lightweight MemoryTrace diagnostic summary');
 
 console.log('smoke-memory-trace-persist ok');

--- a/web/scripts/smoke-postturn-court-render-fallback.js
+++ b/web/scripts/smoke-postturn-court-render-fallback.js
@@ -1,30 +1,28 @@
 #!/usr/bin/env node
-// smoke-postturn-court-render-fallback.js
-// Guards the deferred post-turn court path against render-time loading deadlocks.
-
+// Guards deferred court-close ordering: critical finalization before post-commit UI.
 'use strict';
 
 const fs = require('fs');
 const path = require('path');
-
 const ROOT = path.resolve(__dirname, '..');
-const src = fs.readFileSync(path.join(ROOT, 'tm-court-meter.js'), 'utf8');
-
+const court = fs.readFileSync(path.join(ROOT, 'tm-court-meter.js'), 'utf8');
+const pipeline = fs.readFileSync(path.join(ROOT, 'tm-endturn-pipeline-steps.js'), 'utf8');
 let passed = 0;
-function assert(cond, label) {
-  if (!cond) throw new Error('[assert] ' + label);
-  passed++;
-}
+function assert(cond, label) { if (!cond) throw new Error('[assert] ' + label); passed++; }
 
-assert(src.indexOf('function _postTurnCourtShowRenderFallback(error)') >= 0, 'post-turn court render fallback helper exists');
-assert(src.indexOf("hideLoading();") >= 0, 'fallback hides loading overlay');
-assert(src.indexOf("showTurnResult(html, idx);") >= 0, 'fallback opens a result modal');
-assert(src.indexOf("btn.textContent = '⏳ 静待时变'") >= 0, 'fallback restores end-turn button text');
+const closeStart = court.indexOf('async function _onPostTurnCourtEnd()');
+const closeBody = court.slice(closeStart);
+assert(closeStart >= 0, 'post-turn court close handler exists');
+assert(closeBody.indexOf('_endTurn_render.apply') < 0, 'court handler never renders an uncommitted result');
+assert(closeBody.indexOf('await _deferredPhase5();') >= 0, 'court close awaits the shared critical finalizer');
+assert(closeBody.indexOf('_finishPostTurnCourtState();') > closeBody.indexOf('await _deferredPhase5();'), 'court state is released only after finalization succeeds');
 
-const renderCallIdx = src.indexOf('_endTurn_render.apply(null, _payload);');
-const fallbackCallIdx = src.indexOf('_postTurnCourtShowRenderFallback(_e);');
-assert(renderCallIdx >= 0, 'post-turn court close still invokes _endTurn_render');
-assert(fallbackCallIdx > renderCallIdx, 'render catch calls fallback after failed render');
-assert(fallbackCallIdx - renderCallIdx < 700, 'fallback is tied to the render catch block');
+const deferredStart = pipeline.indexOf('GM._pendingShijiModal.deferredPhase5 = async function()');
+const deferredBody = pipeline.slice(deferredStart, deferredStart + 1400);
+assert(deferredStart >= 0, 'pipeline registers deferred finalization closure');
+assert(deferredBody.indexOf('await _runPostRenderTurnOpeners(ctx)') >= 0, 'deferred state writers finish before commit barrier');
+assert(deferredBody.indexOf('ctx.meta.deferEndTurnSave = false') >= 0, 'deferred closure explicitly arms the final save');
+assert(deferredBody.indexOf('await _tmFinalizeEndTurnTransaction(ctx, ctx.meta.transaction)') >= 0,
+  'deferred closure uses the same record/save/commit/post-commit UI transaction entry');
 
 console.log('[smoke-postturn-court-render-fallback] pass assertions=' + passed);

--- a/web/scripts/smoke-runtime-save-consistency.js
+++ b/web/scripts/smoke-runtime-save-consistency.js
@@ -63,34 +63,35 @@ ok(/_preState = _buildSaveState\(\{ format: 'idb', gm: _preSaveGM, p: _preSaveP 
 ok(/global\._buildSaveState\(\{ format: 'idb', detach: true, gm: GM, p: P \|\| \{\} \}\)/.test(resume), '残局发布以 detached 模式复用统一 builder');
 ok(!/gameState\s*=\s*deepClone\(GM\)|GM\s*:\s*deepClone\(GM\)/.test(lifecycle + '\n' + core + '\n' + manager), '生产存档写口无裸 deepClone(GM)');
 ok(!/SaveManager\.autoSave\(\)/.test(render), '端回合不再重复调用 SaveManager.autoSave 覆盖 slot_0');
-ok(/TM_SaveDB\.save\('autosave',[\s\S]*?if\s*\(ok\s*!==\s*true\)\s*throw[\s\S]*?Promise\.all\(\[_autoWrite, _slotWrite\]\)[\s\S]*?_clearPreEndturnMarkerAfterSave\(_endturnSavePreId\)/.test(render), 'autosave resolve(false) 保留 pre_endturn 恢复标记');
-ok(/TM_SaveDB\.save\('slot_0',[\s\S]*?if\s*\(ok\s*!==\s*true\)\s*throw[\s\S]*?Promise\.all\(\[_autoWrite, _slotWrite\]\)[\s\S]*?_updateSaveIndex/.test(render), 'slot_0 resolve(false) 不伪造案卷索引');
+ok(/TM_SaveDB\.saveManyAtomic\(\[[\s\S]*?id: 'autosave'[\s\S]*?id: 'slot_0'[\s\S]*?_writeOk !== true[\s\S]*?_clearPreEndturnMarkerAfterSave/.test(render),
+  'canonical batch failure preserves the pre_endturn recovery marker');
+ok(/_writeOk !== true[\s\S]*?throw new Error\('canonical 回合存档未原子落库'\)[\s\S]*?_updateSaveIndex/.test(render),
+  'slot index is published only after the canonical batch commits');
 {
-  const autosaveAt = render.indexOf("TM_SaveDB.save('autosave'");
-  const slotAt = render.indexOf("TM_SaveDB.save('slot_0'");
-  const writesDoneAt = render.indexOf('var _writeResults = await Promise.all', slotAt);
-  const markerAt = render.indexOf("localStorage.setItem('tm_autosave_mark'", autosaveAt);
-  ok(markerAt > writesDoneAt && writesDoneAt > slotAt && /turn:\s*_autoMeta\.turn/.test(render.slice(markerAt, markerAt + 300)), 'tm_autosave_mark 仅在两个槽位成功后写入并锚定快照 turn');
+  const batchAt = render.indexOf('TM_SaveDB.saveManyAtomic([');
+  const writesDoneAt = render.indexOf("if (_writeOk !== true", batchAt);
+  const markerAt = render.indexOf("localStorage.setItem('tm_autosave_mark'", batchAt);
+  ok(markerAt > writesDoneAt && writesDoneAt > batchAt && /turn:\s*_autoMeta\.turn/.test(render.slice(markerAt, markerAt + 300)), 'tm_autosave_mark 仅在原子双槽提交后写入并锚定快照 turn');
 }
 ok(/_autoSaveResult\s*=\s*await window\.tianming\.autoSave\(saveData\);[\s\S]*?if\s*\(!_tmDesktopAutoSaveResultOk\(_autoSaveResult\)\)\s*throw[\s\S]*?_autoSaveLastDoneMs=Date\.now\(\)/.test(lifecycle), '60s Electron autoSave 仅在业务成功后推进成功时钟');
 ok(/_autoSaveLastSavedTurn=\(saveData\._saveMeta[\s\S]*?saveData\._saveMeta\.turn/.test(lifecycle), 'Electron 闲置跳存基线锚定已写快照 turn');
 ok(!/window\.tianming\.autoSave\(/.test(render), '端回合删除重复 Electron autoSave·崩溃恢复档只留 60s 写口');
 ok(/var _endturnSaveGM = GM;[\s\S]*?var _endturnSaveP = P;[\s\S]*?_endturnSaveLoadGen[\s\S]*?_endturnSavePreId/.test(render), '端回合 detached save 捕获 GM/P/loadGen/pre snapshotId');
 ok(/await _awaitPostTurnJobsForSave[\s\S]*?if \(!_endturnSaveStillCurrent\(\)\) return false;[\s\S]*?_buildSaveState\(\{format:'idb',gm:_endturnSaveGM,p:_endturnSaveP\}\)/.test(render), '后台等待后先验租约·builder 在 detached snapshot 上准备');
-ok(/TM_SaveDB\.save\('autosave', _autoState, _autoMeta, _autoWriteOptions\)/.test(render)
-  && /TM_SaveDB\.save\('slot_0', _autoState, _autoMeta, _autoWriteOptions\)/.test(render), 'autosave/slot_0 写事务共用代际租约');
+ok(/TM_SaveDB\.saveManyAtomic\([\s\S]*?_autoWriteOptions\)/.test(render)
+  && /function saveManyAtomic\(entries, options\)/.test(storage), 'autosave/slot_0 共用代际租约与单一批量事务');
 {
   const renderFn = sliceFn(render, 'function _endTurn_render(');
   const barrierStepAt = pipeline.indexOf("name: 'prepare-commit-barrier'");
   const normalIndicatorAt = pipeline.indexOf('_kjUpdateIndicators(ctx)');
   const deferredOpenersAt = pipeline.indexOf('await _runPostRenderTurnOpeners(ctx)');
-  const deferredSaveAt = pipeline.indexOf('_endTurn_saveSnapshot()', deferredOpenersAt);
+  const deferredSaveAt = pipeline.indexOf('await _tmFinalizeEndTurnTransaction(ctx, ctx.meta.transaction)', deferredOpenersAt);
   ok(!/_endTurn_saveSnapshot\s*\(/.test(renderFn), '_endTurn_render 只渲染·不再在 Phase5 前启动存档');
   ok(barrierStepAt > normalIndicatorAt && normalIndicatorAt >= 0 && /finalSaveRequired\s*=\s*true/.test(pipeline.slice(barrierStepAt)), 'normal 路径在 Phase5/J1 后只声明提交屏障');
-  ok(deferredSaveAt > deferredOpenersAt && /await ctx\.meta\.endTurnSavePromise\s*!==\s*true/.test(pipeline.slice(deferredOpenersAt, deferredSaveAt + 500)), 'deferred 路径在 Phase5/openers 后等待存档成功');
+  ok(deferredSaveAt > deferredOpenersAt && /ctx\.meta\.deferEndTurnSave\s*=\s*false/.test(pipeline.slice(deferredOpenersAt, deferredSaveAt + 300)), 'deferred 路径在 Phase5/openers 后复用共享提交屏障');
   ok(/ctx\.meta\.deferEndTurnSave\s*=\s*true/.test(pipeline) && /if \(ctx\.meta\.deferEndTurnSave\) return true;/.test(core), 'deferred 路径显式阻止 core 提前落库');
   ok(/!ctx\.meta\.endTurnSavePromise && typeof _endTurn_saveSnapshot/.test(core)
-    && /!ctx\.meta\.endTurnSavePromise && typeof _endTurn_saveSnapshot/.test(pipeline), 'normal/deferred 两条路径各自复用同一幂等存档 promise');
+    && (core.match(/_endTurn_saveSnapshot\(ctx\)/g) || []).length === 1, 'normal/deferred 两条路径复用同一幂等存档 promise');
   ok(/var saved = await ctx\.meta\.endTurnSavePromise;[\s\S]*?saved !== true[\s\S]*?_tmCommitEndTurnTransaction/.test(core), 'normal 提交屏障严格等待最终存档后才 commit');
 }
 ok(/function save\(id, gameState, meta, options\)[\s\S]*?_writeStillAllowed\(\)[\s\S]*?SaveCompression\.compress[\s\S]*?if \(!_writeStillAllowed\(\)\) return false;[\s\S]*?return _put/.test(storage), 'SaveDB 在压缩前及真正 put 前复验 writeGuard');
@@ -100,7 +101,19 @@ ok(/auto-save-session-rotate/.test(mainImpl) && /autoSaveSessionMatches\(request
   && /writeFile[\s\S]*?autoSaveSessionMatches\(requestToken\)[\s\S]*?rename/.test(mainImpl), 'Electron canonical auto-save 在 write/rename 间按 session token 复验');
 ok(/rotateAutoSaveSession/.test(preloadImpl) && /_tmRotateDesktopAutoSaveSession\('full-load'/.test(lifecycle)
   && /_tmRotateDesktopAutoSaveSession\('new-game'/.test(startPatch), 'preload + 读档 + 新局共同切换 auto-save session');
-ok(/writeTurnData\([\s\S]*?\.then\(function\(result\)[\s\S]*?result\.success === true[\s\S]*?throw new Error\('回合分卷写入失败'/.test(render), 'writeTurnData resolve({success:false}) 显式报错');
+ok(/stageTurnData\([\s\S]*?result\.success === true[\s\S]*?回合分卷暂存失败/.test(render)
+  && /_tmCommitEndTurnTransaction[\s\S]*?await _endTurn_publishStagedTurnData/.test(core), '回合分卷先暂存并仅在世界 commit 后发布');
+ok(/function _recoverPendingTurnDataPublish\(\)[\s\S]*?recoverTurnData\(marker\)[\s\S]*?transactionId !== marker\.transactionId[\s\S]*?delete GM\._pendingTurnDataPublish/.test(lifecycle),
+  '读档按世界身份和 transactionId 租约幂等补发未发布分卷');
+{
+  const finalizerFn = sliceFn(render, 'function _endTurn_finalizeRecords(');
+  const uiRenderFn = sliceFn(render, 'function _endTurn_render(');
+  ok(/_syncFiscalScalars\(GM\)[\s\S]*?_wdPrepareAudienceRenderState\(\)[\s\S]*?updateMapColors\(\{ refresh: false \}\)/.test(finalizerFn),
+    '财政、问对和地图派生状态在事务内最终化');
+  ok(/renderWenduiChars\(false, \{ skipStatePreparation: true \}\)/.test(uiRenderFn)
+    && /renderGameState\(\{ skipStateSync: true \}\)/.test(uiRenderFn)
+    && !/updateMapColors\(/.test(uiRenderFn), 'commit 后 UI 渲染跳过所有已知状态准备入口');
+}
 
 console.log('=== 2. pre_endturn two-phase + strict validator ===');
 ok(/commitState:\s*'pending'/.test(core) && /_livePreMark\.commitState = 'committed'/.test(core), 'marker pending -> committed 两阶段');
@@ -174,13 +187,47 @@ async function runDynamicLeaseSmokes() {
       _awaitPostTurnJobsForSave: async () => { order.push('jobs'); }, _prepareGMForSave: () => { order.push('prepare'); },
       _buildSaveState: opts => { order.push('snapshot:' + opts.gm.phase5Value); return { GM: { phase5Value: opts.gm.phase5Value }, P: opts.p }; },
       findScenarioById: () => ({ name: '测试剧本' }), getTSText: () => '某日',
-      TM_SaveDB: { save: async (id, state) => { writes.push([id, state.GM.phase5Value]); return true; } }
+      TM_SaveDB: {
+        saveManyAtomic: async entries => {
+          entries.forEach(entry => writes.push([entry.id, entry.gameState.GM.phase5Value]));
+          return true;
+        }
+      }
     };
     ctx.window.window = ctx.window;
     vm.createContext(ctx); vm.runInContext(render, ctx);
     order.push('phase5');
-    const saved = await ctx._endTurn_saveSnapshot();
+    const saved = await ctx._endTurn_saveSnapshot({ meta: {} });
     ok(saved === true && order.indexOf('phase5') < order.indexOf('snapshot:after') && writes.length === 2 && writes.every(w => w[1] === 'after'), '真实 save helper 只快照 Phase5 后状态并同时写 autosave/slot_0');
+  }
+  {
+    let staged = 0, discarded = 0;
+    const ctx = {
+      GM: { turn: 50, sid: 's1', saveName: 'desktop-save', _campaignId: 'campaign-a', eraName: '某年号' }, P: {},
+      window: {
+        _tmLoadGen: 2,
+        _tmActivePreEndturnSnapshotId: 'pre-50',
+        TM: { errors: { capture() {}, captureSilent() {} } },
+        tianming: {
+          isDesktop: true,
+          async stageTurnData() { staged++; return { success: true }; },
+          async discardTurnData() { discarded++; return { success: true }; }
+        }
+      },
+      TM: { errors: { capture() {}, captureSilent() {} } }, console, Promise, Date, JSON, Math, Error, setTimeout,
+      deepClone: value => JSON.parse(JSON.stringify(value)),
+      localStorage: { getItem: () => null, setItem() {}, removeItem() {} },
+      _awaitPostTurnJobsForSave: async () => {}, _prepareGMForSave() {},
+      _buildSaveState: opts => ({ GM: JSON.parse(JSON.stringify(opts.gm)), P: opts.p }),
+      findScenarioById: () => ({ name: '测试剧本' }), getTSText: () => '某日',
+      TM_SaveDB: { async saveManyAtomic() { throw new Error('slot_0 injected failure'); } }
+    };
+    ctx.window.window = ctx.window;
+    vm.createContext(ctx); vm.runInContext(render, ctx);
+    const saveCtx = { meta: { transactionId: 'turn-11111111-2222-4333-8444-555555555555', turnPresentation: { turnData: { context: { turn: 49 } } } } };
+    const saved = await ctx._endTurn_saveSnapshot(saveCtx);
+    ok(saved === false && staged === 1 && discarded === 1 && !ctx.GM._pendingTurnDataPublish,
+      'canonical batch failure discards desktop staging and leaves no formal publish marker');
   }
   {
     let src = storage;

--- a/web/scripts/smoke-storage-atomic-batch.js
+++ b/web/scripts/smoke-storage-atomic-batch.js
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.resolve(__dirname, '..');
+const fullSource = fs.readFileSync(path.join(ROOT, 'tm-storage.js'), 'utf8');
+const bootAt = fullSource.lastIndexOf('\nTM_SaveDB.open().then');
+const source = bootAt > 0 ? fullSource.slice(0, bootAt) : fullSource;
+let assertions = 0;
+function check(value, message) {
+  if (!value) throw new Error('[smoke-storage-atomic-batch] ' + message);
+  assertions++;
+}
+function clone(value) { return value == null ? value : JSON.parse(JSON.stringify(value)); }
+
+function makeLocalStorage(initial, failKey) {
+  const rows = new Map(Object.entries(initial || {}).map(([k, v]) => [k, String(v)]));
+  let failed = false;
+  return {
+    rows,
+    get length() { return rows.size; },
+    key(i) { return Array.from(rows.keys())[i] || null; },
+    getItem(k) { return rows.has(String(k)) ? rows.get(String(k)) : null; },
+    setItem(k, v) {
+      if (!failed && failKey && String(k) === failKey) { failed = true; throw new Error('injected-local-write-failure'); }
+      rows.set(String(k), String(v));
+    },
+    removeItem(k) { rows.delete(String(k)); }
+  };
+}
+
+function makeIndexedDB(initial, failPutAt) {
+  const stores = new Map([
+    ['saves', new Map(Object.entries(initial && initial.saves || {}).map(([k, v]) => [k, clone(v)]))],
+    ['saveMetadata', new Map(Object.entries(initial && initial.saveMetadata || {}).map(([k, v]) => [k, clone(v)]))],
+    ['projects', new Map()]
+  ]);
+  const stats = { readwriteTransactions: 0, puts: 0 };
+  const db = {
+    objectStoreNames: { contains(name) { return stores.has(name); } },
+    close() {},
+    transaction(names, mode) {
+      if (mode === 'readwrite') stats.readwriteTransactions++;
+      const pending = [];
+      const tx = { error: null, oncomplete: null, onerror: null, onabort: null };
+      tx.objectStore = name => ({
+        put(value) { stats.puts++; pending.push({ name, value: clone(value), putNo: stats.puts }); },
+        delete(id) { pending.push({ name, deleteId: String(id) }); },
+        get(id) {
+          const req = {};
+          setTimeout(() => { req.result = clone(stores.get(name).get(String(id))); if (req.onsuccess) req.onsuccess({ target: req }); }, 0);
+          return req;
+        },
+        getAll() {
+          const req = {};
+          setTimeout(() => { req.result = Array.from(stores.get(name).values()).map(clone); if (req.onsuccess) req.onsuccess({ target: req }); }, 0);
+          return req;
+        }
+      });
+      setTimeout(() => {
+        if (failPutAt && pending.some(op => op.putNo === failPutAt)) {
+          tx.error = new Error('injected-idb-write-failure');
+          if (tx.onabort) tx.onabort({ target: { error: tx.error } });
+          return;
+        }
+        pending.forEach(op => {
+          if (op.deleteId != null) stores.get(op.name).delete(op.deleteId);
+          else stores.get(op.name).set(String(op.value.id), clone(op.value));
+        });
+        if (tx.oncomplete) tx.oncomplete({ target: tx });
+      }, 0);
+      return tx;
+    }
+  };
+  return {
+    stores, stats,
+    open() { const req = {}; setTimeout(() => req.onsuccess && req.onsuccess({ target: { result: db } }), 0); return req; }
+  };
+}
+
+function makeContext(indexedDB, localStorage) {
+  const context = {
+    console: { log() {}, warn() {}, error() {}, info() {} },
+    Promise, Math, Date, JSON, Object, Array, Number, String, Boolean, Error,
+    Blob, Response, CompressionStream: undefined, DecompressionStream: undefined, TextDecoder,
+    setTimeout, clearTimeout, localStorage, indexedDB,
+    navigator: { storage: null }
+  };
+  context.window = context;
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(source, context, { filename: 'tm-storage.js' });
+  return context;
+}
+
+(async function main() {
+  const idb = makeIndexedDB();
+  const ctx = makeContext(idb, makeLocalStorage());
+  await ctx.TM_SaveDB.open();
+  const state = { GM: { turn: 50 }, P: {} };
+  const ok = await ctx.TM_SaveDB.saveManyAtomic([
+    { id: 'autosave', gameState: state, meta: { type: 'auto', turn: 50 } },
+    { id: 'slot_0', gameState: state, meta: { type: 'auto', turn: 50 } }
+  ]);
+  check(ok === true && idb.stats.readwriteTransactions === 1, 'both canonical slots use one IndexedDB readwrite transaction');
+  check(idb.stores.get('saves').size === 2 && idb.stores.get('saveMetadata').size === 2, 'payloads and metadata commit together');
+  let duplicateRejected = false;
+  try {
+    await ctx.TM_SaveDB.saveManyAtomic([
+      { id: 'slot_0', gameState: state },
+      { id: 'slot_0', gameState: state }
+    ]);
+  } catch (_) { duplicateRejected = true; }
+  check(duplicateRejected, 'duplicate ids are rejected before opening a batch transaction');
+
+  const oldAuto = { id: 'autosave', gameState: 'old-auto' };
+  const oldSlot = { id: 'slot_0', gameState: 'old-slot' };
+  const failingIdb = makeIndexedDB({ saves: { autosave: oldAuto, slot_0: oldSlot }, saveMetadata: {
+    autosave: { id: 'autosave', turn: 49 }, slot_0: { id: 'slot_0', turn: 49 }
+  } }, 3);
+  const failingCtx = makeContext(failingIdb, makeLocalStorage());
+  await failingCtx.TM_SaveDB.open();
+  let rejected = false;
+  try {
+    await failingCtx.TM_SaveDB.saveManyAtomic([
+      { id: 'autosave', gameState: state, meta: { turn: 50 } },
+      { id: 'slot_0', gameState: state, meta: { turn: 50 } }
+    ]);
+  } catch (_) { rejected = true; }
+  check(rejected && failingIdb.stores.get('saves').get('autosave').gameState === 'old-auto' && failingIdb.stores.get('saves').get('slot_0').gameState === 'old-slot',
+    'an injected second-slot failure aborts the complete IndexedDB batch');
+
+  const keys = {
+    auto: 'tm_idb_saves_autosave', autoMeta: 'tm_idb_saveMetadata_autosave',
+    slot: 'tm_idb_saves_slot_0', slotMeta: 'tm_idb_saveMetadata_slot_0'
+  };
+  const initial = { [keys.auto]: 'old-auto', [keys.autoMeta]: 'old-auto-meta', [keys.slot]: 'old-slot', [keys.slotMeta]: 'old-slot-meta' };
+  const local = makeLocalStorage(initial, keys.slotMeta);
+  const localCtx = makeContext(null, local);
+  await localCtx.TM_SaveDB.open();
+  rejected = false;
+  try {
+    await localCtx.TM_SaveDB.saveManyAtomic([
+      { id: 'autosave', gameState: state, meta: { turn: 50 } },
+      { id: 'slot_0', gameState: state, meta: { turn: 50 } }
+    ]);
+  } catch (_) { rejected = true; }
+  check(rejected && Object.entries(initial).every(([k, v]) => local.getItem(k) === v), 'localStorage failure restores all four prior values');
+  check(local.getItem('tm_save_batch_journal_v1') === null, 'successful rollback removes the local batch journal');
+
+  const preparedItems = Object.entries(initial).map(([key, previous]) => ({ key, previous }));
+  const crashLocal = makeLocalStorage(Object.assign({}, initial, {
+    [keys.auto]: 'new-auto',
+    tm_save_batch_journal_v1: JSON.stringify({ version: 1, phase: 'prepared', items: preparedItems })
+  }));
+  const crashCtx = makeContext(null, crashLocal);
+  await crashCtx.TM_SaveDB.open();
+  check(crashLocal.getItem(keys.auto) === 'old-auto' && crashLocal.getItem('tm_save_batch_journal_v1') === null,
+    'open recovers a crash left in prepared phase');
+
+  const committedLocal = makeLocalStorage(Object.assign({}, initial, {
+    [keys.auto]: 'new-auto',
+    [keys.autoMeta]: 'new-auto-meta',
+    [keys.slot]: 'new-slot',
+    [keys.slotMeta]: 'new-slot-meta',
+    tm_save_batch_journal_v1: JSON.stringify({ version: 1, phase: 'committed', items: preparedItems })
+  }));
+  const committedCtx = makeContext(null, committedLocal);
+  await committedCtx.TM_SaveDB.open();
+  check(committedLocal.getItem(keys.auto) === 'new-auto' && committedLocal.getItem(keys.slot) === 'new-slot' &&
+    committedLocal.getItem('tm_save_batch_journal_v1') === null,
+  'open keeps the new batch when a crash occurs after the committed journal marker');
+
+  const corruptLocal = makeLocalStorage({ tm_save_batch_journal_v1: '{broken-json' });
+  const corruptCtx = makeContext(null, corruptLocal);
+  await corruptCtx.TM_SaveDB.open();
+  check(corruptLocal.getItem('tm_save_batch_journal_v1') === null,
+    'a corrupt journal is discarded instead of permanently blocking storage startup');
+
+  console.log('[smoke-storage-atomic-batch] PASS assertions=' + assertions);
+})().catch(error => {
+  console.error(error && error.stack || error);
+  process.exit(1);
+});

--- a/web/scripts/smoke-storage-migration-collisions.js
+++ b/web/scripts/smoke-storage-migration-collisions.js
@@ -158,6 +158,11 @@ function makeFakeIndexedDB(oldRecords) {
     timestamp: 100,
     gameState: { GM: { turn: 1, source: 'local-storage' }, P: { scenario: 'local' } }
   }));
+  localStorage.setItem('tm_save_1', JSON.stringify({
+    name: '决战前备份',
+    timestamp: 300,
+    gameState: { GM: { turn: 3, source: 'same-world' }, P: { scenario: 'same' } }
+  }));
   const indexedDB = makeFakeIndexedDB([{
     id: 'slot_0',
     name: '旧 IndexedDB 档',
@@ -165,6 +170,14 @@ function makeFakeIndexedDB(oldRecords) {
     timestamp: 200,
     turn: 2,
     gameState: JSON.stringify({ GM: { turn: 2, source: 'old-db' }, P: { scenario: 'old-db' } }),
+    _compressed: false
+  }, {
+    id: 'slot_1',
+    name: '自动迁移备份',
+    type: 'manual',
+    timestamp: 301,
+    turn: 3,
+    gameState: JSON.stringify({ GM: { turn: 3, source: 'same-world' }, P: { scenario: 'same' } }),
     _compressed: false
   }]);
   const context = {
@@ -184,11 +197,12 @@ function makeFakeIndexedDB(oldRecords) {
     context.TM_SaveDB.migrateFromLocalStorage(),
     context.TM_SaveDB.migrateFromOldDB()
   ]);
-  check(migrations[0] === 1 && migrations[1] === 1, 'both legacy sources report one handled save');
+  check(migrations[0] === 2 && migrations[1] === 2, 'both legacy sources report every handled save');
 
   const listed = await context.TM_SaveDB.list();
   const ids = listed.map(record => record.id).sort();
-  check(ids.length === 2 && ids[0] === 'slot_0' && ids[1] === 'slot_0-migrated-old-db',
+  check(ids.length === 4 && ids.indexOf('slot_0') >= 0 && ids.indexOf('slot_0-migrated-old-db') >= 0 &&
+    ids.indexOf('slot_1') >= 0 && ids.indexOf('slot_1-migrated-old-db') >= 0,
     'same-id legacy saves receive deterministic distinct target ids');
 
   const localSave = await context.TM_SaveDB.load('slot_0');
@@ -197,7 +211,10 @@ function makeFakeIndexedDB(oldRecords) {
     'localStorage source survives migration without being overwritten');
   check(oldDbSave && oldDbSave.gameState.GM.source === 'old-db' && oldDbSave.gameState.GM.turn === 2,
     'old IndexedDB source survives the id collision under its renamed id');
-  check(localStorage.getItem('tm_save_0') === null && indexedDB.state.oldDeleted === true,
+  const distinctMetadataCopy = await context.TM_SaveDB.load('slot_1-migrated-old-db');
+  check(distinctMetadataCopy && distinctMetadataCopy.name === '自动迁移备份',
+    'same world payload with different user-visible metadata is preserved as a separate save');
+  check(localStorage.getItem('tm_save_0') === null && localStorage.getItem('tm_save_1') === null && indexedDB.state.oldDeleted === true,
     'legacy sources are removed only after target writes and read-back verification succeed');
   check(indexedDB.state.openOrder.join('>') === 'tianming_db>tianming_saves',
     'concurrent public migration calls serialize localStorage before the old database');

--- a/web/scripts/smoke-turn-data-commit.js
+++ b/web/scripts/smoke-turn-data-commit.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+const { createTurnDataCommitter } = require('../../main-turn-data-commit.js');
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+let assertions = 0;
+function check(value, message) {
+  if (!value) throw new Error('[smoke-turn-data-commit] ' + message);
+  assertions++;
+}
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-turn-data-'));
+function ensureWritableDir(dir) { fs.mkdirSync(dir, { recursive: true }); }
+function writeFileAtomic(file, data, encoding) {
+  ensureWritableDir(path.dirname(file));
+  const tmp = file + '.tmp-' + crypto.randomUUID();
+  fs.writeFileSync(tmp, data, encoding);
+  fs.renameSync(tmp, file);
+}
+function writeJson(file, data) { ensureWritableDir(path.dirname(file)); fs.writeFileSync(file, JSON.stringify(data), 'utf8'); }
+function writeJsonAtomic(file, data) { writeFileAtomic(file, JSON.stringify(data), 'utf8'); }
+function turnDataRoot(saveName) { return path.join(root, 'save-' + Buffer.from(String(saveName)).toString('hex')); }
+function turnSeg(turn) {
+  const value = String(turn);
+  if (!/^(0|[1-9][0-9]*)$/.test(value)) throw new Error('bad turn');
+  return value;
+}
+
+const committer = createTurnDataCommitter({
+  fs, path, crypto, turnDataDir: root, turnDataRoot, turnSeg,
+  ensureWritableDir, writeJson, writeJsonAtomic, writeFileAtomic
+});
+
+try {
+  const descriptor = {
+    saveName: '测试档', turn: 50, campaignId: 'campaign-a',
+    transactionId: 'turn-11111111-2222-4333-8444-555555555555',
+    stateChecksum: 'sha256-probe',
+    data: { context: { turn: 50 }, playerInput: { edicts: ['甲'] }, aiResults: { sc1: 'ok' }, varChanges: { money: -1 } }
+  };
+  const staged = committer.stage(descriptor);
+  const finalDir = path.join(turnDataRoot(descriptor.saveName), '50');
+  check(staged.success === true && !fs.existsSync(finalDir), 'stage must not expose an uncommitted turn directory');
+  check(fs.existsSync(path.join(root, '.staging', path.basename(turnDataRoot(descriptor.saveName)), descriptor.transactionId, 'turn', 'context.json')),
+    'stage persists the complete turn payload for recovery');
+
+  const published = committer.publish(descriptor);
+  check(published.success === true && fs.existsSync(path.join(finalDir, 'context.json')), 'publish atomically exposes the committed turn');
+  const manifest = JSON.parse(fs.readFileSync(path.join(finalDir, 'transaction.json'), 'utf8'));
+  check(manifest.transactionId === descriptor.transactionId && manifest.stateChecksum === 'sha256-probe' && manifest.status === 'committed',
+    'published manifest binds transaction/world checksum and records the committed phase');
+
+  const recovered = committer.recover(descriptor);
+  check(recovered.success === true && recovered.recovered === true, 'recovery is idempotent after publish already completed');
+
+  const second = Object.assign({}, descriptor, {
+    turn: 51,
+    transactionId: 'turn-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+    data: { context: { turn: 51 } }
+  });
+  committer.stage(second);
+  committer.discard(second);
+  check(!fs.existsSync(path.join(turnDataRoot(second.saveName), '51')),
+    'discard removes only staged data and never creates a formal turn directory');
+
+  const interrupted = Object.assign({}, descriptor, {
+    turn: 52,
+    transactionId: 'turn-99999999-8888-4777-8666-555555555555',
+    data: { context: { turn: 52 }, playerInput: { edicts: ['recover-me'] } }
+  });
+  committer.stage(interrupted);
+  const recoveredFromStage = committer.recover(interrupted);
+  check(recoveredFromStage.success === true && fs.existsSync(path.join(turnDataRoot(interrupted.saveName), '52', 'player-input.json')),
+    'next-start recovery publishes a committed save descriptor left in staging');
+
+  const mainSource = fs.readFileSync(path.join(REPO_ROOT, 'main-impl.js'), 'utf8');
+  const preloadSource = fs.readFileSync(path.join(REPO_ROOT, 'preload-impl.js'), 'utf8');
+  check(['stage', 'publish', 'recover', 'discard'].every(action => mainSource.includes("ipcMain.handle('" + action + "-turn-data'")),
+    'main process exposes every two-phase turn-data channel');
+  check(['stageTurnData', 'publishTurnData', 'recoverTurnData', 'discardTurnData'].every(name => preloadSource.includes(name + ':')),
+    'preload exposes the bounded two-phase turn-data API');
+
+  const bound = Object.assign({}, descriptor, {
+    turn: 53,
+    transactionId: 'turn-12121212-3434-4567-8787-909090909090',
+    data: { context: { turn: 53 } }
+  });
+  committer.stage(bound);
+  let mismatchRejected = false;
+  try { committer.publish(Object.assign({}, bound, { stateChecksum: 'wrong-world' })); }
+  catch (_) { mismatchRejected = true; }
+  check(mismatchRejected && !fs.existsSync(path.join(turnDataRoot(bound.saveName), '53')),
+    'publish rejects a descriptor whose world checksum does not match staging');
+  check(committer.publish(bound).success === true, 'matching campaign/turn/checksum descriptor can publish after a rejected mismatch');
+
+  console.log('[smoke-turn-data-commit] PASS assertions=' + assertions);
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}

--- a/web/tm-court-meter.js
+++ b/web/tm-court-meter.js
@@ -191,40 +191,12 @@ function _hidePostTurnCourtBanner() {
   if (_el) _el.remove();
 }
 
-function _postTurnCourtShowRenderFallback(error) {
-  var msg = (error && (error.message || error.toString())) || 'unknown render error';
-  var safeMsg = String(msg).replace(/[&<>"']/g, function(ch) {
-    return ({ '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' })[ch];
-  });
-  try { if (typeof hideLoading === 'function') hideLoading(); } catch(_hideE) {}
-  var html =
-    '<div style="padding:1rem;line-height:1.8;color:var(--txt);">' +
-      '<h3 style="color:var(--gold);margin:0 0 0.8rem;">史记弹窗渲染失败</h3>' +
-      '<p>本回合推演与数值结算已经完成，但结果弹窗在渲染时出错。游戏已解除等待状态，可继续操作；请把控制台诊断发给开发者。</p>' +
-      '<pre style="white-space:pre-wrap;color:var(--red,#c44);background:rgba(0,0,0,0.22);padding:0.75rem;border:1px solid rgba(200,80,70,0.35);">' + safeMsg + '</pre>' +
-    '</div>';
-  try {
-    if (typeof showTurnResult === 'function') {
-      var idx = Math.max(0, ((GM && GM.shijiHistory && GM.shijiHistory.length) || 1) - 1);
-      showTurnResult(html, idx);
-    } else if (typeof toast === 'function') {
-      toast('史记弹窗渲染失败，但回合推演已完成。');
-    }
-  } catch(_fallbackE) {
-    try { console.error('[postTurnCourt] fallback render failed:', _fallbackE); } catch(_){}
-  }
-  try {
-    var btn = (typeof _$ === 'function') ? (_$('btn-end') || _$('btn-end-turn')) : null;
-    if (btn) { btn.textContent = '⏳ 静待时变'; btn.style.opacity = '1'; }
-  } catch(_btnE) {}
-}
-
 function _finishPostTurnCourtState() {
   GM._isPostTurnCourt = false;
   if (GM._pendingShijiModal) GM._pendingShijiModal.courtDone = true;
 }
 
-// 朝会结束时调用——顺序：先弹史记，其他模态（keju/事件等）排队其后
+// 朝会结束时调用——先完成关键收官/原子存档/commit，再弹史记并放行其他模态。
 async function _onPostTurnCourtEnd() {
   if (!GM._pendingShijiModal) { GM._isPostTurnCourt = false; return; }
   if (GM._pendingShijiModal.courtDone !== false && !GM._pendingShijiModal.aiReady && !GM._pendingShijiModal.payload) {
@@ -242,22 +214,13 @@ async function _onPostTurnCourtEnd() {
     showLoading('\u65F6\u79FB\u4E8B\u53BB', 50);
     return;
   }
-  var _payload = GM._pendingShijiModal.payload;
   var _deferredPhase5 = GM._pendingShijiModal.deferredPhase5;
   GM._pendingShijiModal.payload = null;
   GM._pendingShijiModal.aiReady = false;
   GM._pendingShijiModal.deferredPhase5 = null;
 
-  // 1) 先弹史记（临时放开 courtDone，让 showTurnResult 直通）
-  GM._pendingShijiModal.courtDone = true;
-  try {
-    _endTurn_render.apply(null, _payload);
-  } catch(_e) {
-    (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_e, 'postTurnCourt] render:') : console.error('[postTurnCourt] render:', _e);
-    _postTurnCourtShowRenderFallback(_e);
-  }
-
-  // 2) 重新启用"队列模式"，让 phase5 产生的模态都进队列·不立即弹
+  // 收官状态与记录仍属于同一个回合事务；先保持队列模式，完成关键结算、原子存档与 commit，
+  // 再由共享事务入口显示史记。任何记录落账失败都不得伪装成 UI 故障。
   GM._pendingShijiModal.courtDone = false; // 假装朝会还在
   if (typeof _deferredPhase5 === 'function') {
     try { await _deferredPhase5(); }
@@ -269,7 +232,7 @@ async function _onPostTurnCourtEnd() {
     }
   }
 
-  // 3) 收官：恢复正常状态 + 延迟 1s 后按队列依次弹出其他模态（给用户看史记的时间）
+  // 收官：恢复正常状态 + 延迟 1s 后按队列依次弹出其他模态（给用户看史记的时间）
   _finishPostTurnCourtState();
   setTimeout(function(){
     try { if (typeof _flushPostTurnModalQueue === 'function') _flushPostTurnModalQueue(); } catch(_fq){ (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_fq, 'postTurnCourt] flush:') : console.warn('[postTurnCourt] flush:', _fq); }

--- a/web/tm-endturn-core.js
+++ b/web/tm-endturn-core.js
@@ -404,12 +404,16 @@ function _tmRestoreEndTurnObject(target, snapshot) {
 
 function _tmCaptureEndTurnTransaction() {
   var gmRef = GM, pRef = P;
+  var transactionId = '';
+  try { transactionId = 'turn-' + (window.crypto && window.crypto.randomUUID ? window.crypto.randomUUID() : (Date.now() + '-' + Math.random().toString(16).slice(2))); }
+  catch (_) { transactionId = 'turn-' + Date.now() + '-' + Math.random().toString(16).slice(2); }
   return {
     gmRef: gmRef,
     pRef: pRef,
     loadGen: (typeof window !== 'undefined' && window._tmLoadGen) || 0,
     campaignId: gmRef && gmRef._campaignId || '',
     turn: gmRef && gmRef.turn,
+    transactionId: transactionId,
     gm: _tmCaptureEndTurnObject(gmRef, ['_postTurnJobs', '_postTurnDetachedJobs', '_indices']),
     p: _tmCaptureEndTurnObject(pRef, ['scenario', '_indices']),
     committed: false,
@@ -465,14 +469,43 @@ async function _tmFinalizeEndTurnTransaction(ctx, txn) {
   ctx = ctx || { meta: {} };
   ctx.meta = ctx.meta || {};
   ctx.meta.transaction = txn;
+  ctx.meta.transactionId = txn && txn.transactionId || ctx.meta.transactionId || '';
   if (ctx.meta.deferEndTurnSave) return true;
+  if (!ctx.meta.turnPresentation) {
+    if (typeof _endTurn_finalizeRecords !== 'function' || !Array.isArray(ctx.meta.turnRenderArgs)) {
+      throw new Error('回合记录最终化入口缺失');
+    }
+    ctx.meta.turnPresentation = _endTurn_finalizeRecords.apply(null, ctx.meta.turnRenderArgs);
+    // presentation 已取得原始 AI/玩家活动引用；现在清临时上下文，最终存档不携带易膨胀字段。
+    delete GM._turnContext;
+    delete GM._turnTyrantActivities;
+    if (!GM._postTurnJobs || !Array.isArray(GM._postTurnJobs.pending) || GM._postTurnJobs.pending.length === 0) delete GM._turnAiResults;
+  }
   if (!ctx.meta.endTurnSavePromise && typeof _endTurn_saveSnapshot === 'function') {
-    ctx.meta.endTurnSavePromise = _endTurn_saveSnapshot();
+    ctx.meta.endTurnSavePromise = _endTurn_saveSnapshot(ctx);
   }
   if (!ctx.meta.endTurnSavePromise) throw new Error('回合最终存档入口缺失');
   var saved = await ctx.meta.endTurnSavePromise;
   if (saved !== true) throw new Error('回合最终存档失败，已回滚本回合');
   if (!_tmCommitEndTurnTransaction(txn)) throw new Error('回合提交时世界身份已变化');
+  try {
+    if (typeof _endTurn_publishStagedTurnData === 'function') await _endTurn_publishStagedTurnData(ctx);
+  } catch (publishError) {
+    ctx.results = ctx.results || {};
+    ctx.results.turnDataPublishError = publishError;
+    try { if (window.TM && TM.errors && TM.errors.capture) TM.errors.capture(publishError, 'endTurn] turn-data publish'); } catch (_) {}
+    try { if (typeof toast === 'function') toast('回合已安全保存；分卷将在下次读档时自动补发。'); } catch (_) {}
+  }
+  try { if (typeof _endTurn_clearCommittedInputs === 'function') _endTurn_clearCommittedInputs(); }
+  catch (draftError) { try { if (window.TM && TM.errors && TM.errors.capture) TM.errors.capture(draftError, 'endTurn] clear committed drafts'); } catch (_) {} }
+  try {
+    if (typeof _endTurn_render === 'function') _endTurn_render(ctx.meta.turnPresentation);
+  } catch (renderError) {
+    ctx.results = ctx.results || {};
+    ctx.results.renderError = renderError;
+    try { if (window.TM && TM.errors && TM.errors.capture) TM.errors.capture(renderError, 'endTurn] post-commit render'); } catch (_) {}
+    try { if (typeof _endTurn_showRenderFallback === 'function') _endTurn_showRenderFallback(renderError); } catch (_) {}
+  }
   return true;
 }
 
@@ -747,13 +780,6 @@ async function _endTurnCore(options){
     // 年度编年史由 ChronicleSystem._tryGenerateYearChronicle 异步生成（含6.1伏笔/6.5摘要整合）
     // 不在此处重复生成——ChronicleSystem.addMonthDraft 的跨年检测会自动触发
     _dbg('[Chronicle] \u8DE8\u5E74\u68C0\u6D4B\uFF0C\u5E74\u5EA6\u7F16\u5E74\u53F2\u7531ChronicleSystem\u5F02\u6B65\u751F\u6210');
-  }
-
-  // 清理回合临时上下文
-  delete GM._turnContext;
-  delete GM._turnTyrantActivities;
-  if (!GM._postTurnJobs || !Array.isArray(GM._postTurnJobs.pending) || GM._postTurnJobs.pending.length === 0) {
-    delete GM._turnAiResults;
   }
 
   // 玩家角色死亡 → 终局（鼎革R1e·2026-07-07·两套终局屏合一）：此前走简版「天命已尽」屏——

--- a/web/tm-endturn-pipeline-steps.js
+++ b/web/tm-endturn-pipeline-steps.js
@@ -586,8 +586,7 @@
             }
           } catch(_) {}
         }
-        // 注：oldVars 在 ctx.input·edicts/xinglu 同
-        // _renderArgs 17 字段顺序按 _endTurn_render 期望
+        // 注：oldVars 在 ctx.input·edicts/xinglu 同；记录最终化在 core 的 commit barrier 前统一执行。
         try {
           if (typeof window !== 'undefined' && window.TM && TM.SocialPoliticalSignals && typeof TM.SocialPoliticalSignals.recordTurnResult === 'function') {
             ctx.results.turnResultSocialSignals = await Promise.resolve(TM.SocialPoliticalSignals.recordTurnResult(GM, ctx, {
@@ -635,6 +634,7 @@
             source: 'sc1d'
           }
         ];
+        ctx.meta.turnRenderArgs = _renderArgs;
         // [slice 6.5·2026-05-07] deferred 路径·shijiModal 后朝进行中
         // 暂存 payload + 用 ctx.deferredSteps 显式登记 phase5·替代闭包模式 (audit 决定 2)
         // 兼容性：仍 mirror 到 _pendingShijiModal.deferredPhase5·让 legacy 触发器继续工作
@@ -734,15 +734,10 @@
                 }
               }
               await _runPostRenderTurnOpeners(ctx);
-              if (!ctx.meta.endTurnSavePromise && typeof _endTurn_saveSnapshot === 'function') {
-                ctx.meta.endTurnSavePromise = _endTurn_saveSnapshot();
-              }
-              if (!ctx.meta.endTurnSavePromise || await ctx.meta.endTurnSavePromise !== true) {
-                throw new Error('朝会收官存档失败');
-              }
-              if (typeof _tmCommitEndTurnTransaction !== 'function' || !_tmCommitEndTurnTransaction(ctx.meta.transaction)) {
-                throw new Error('朝会收官提交时世界身份已变化');
-              }
+              ctx.meta.deferEndTurnSave = false;
+              if (typeof _finishPostTurnCourtState === 'function') _finishPostTurnCourtState();
+              if (typeof _tmFinalizeEndTurnTransaction !== 'function') throw new Error('朝会收官事务入口缺失');
+              await _tmFinalizeEndTurnTransaction(ctx, ctx.meta.transaction);
             } catch (e) {
               try { if (typeof _tmRollbackEndTurnTransaction === 'function') _tmRollbackEndTurnTransaction(ctx.meta.transaction, e); } catch (_) {}
               throw e;
@@ -751,46 +746,7 @@
           return ctx; // deferred 路径完成
         }
 
-        // 非 deferred 路径·正常 render + 4.5 + 4.6 + 5
-        // render 失败时弹 fallback，避免推演已完成但玩家停在 loading 遮罩。
-        if (typeof _endTurn_render === 'function') {
-          try {
-            try { if (typeof showLoading === 'function') showLoading('生成史记弹窗', 97); } catch(_progressE) {}
-            _endTurn_render.apply(null, _renderArgs);
-          } catch(_renderE) {
-            ctx.results.renderError = _renderE;
-            try {
-              if (typeof window !== 'undefined' && window.TM && TM.errors && TM.errors.capture) {
-                TM.errors.capture(_renderE, 'pipeline.render-finalize] render failed');
-              } else {
-                console.error('[pipeline.render-finalize] render failed', _renderE);
-              }
-            } catch(_diagE) {
-              try { console.error('[pipeline.render-finalize] render failure diagnostic failed', _diagE); } catch(_){}
-            }
-            try { if (typeof hideLoading === 'function') hideLoading(); } catch(_hideE) {
-              try { console.warn('[pipeline.render-finalize] hideLoading after render failure failed', _hideE); } catch(_){}
-            }
-            try {
-              if (typeof showTurnResult === 'function') {
-                var _renderErrMsg = (_renderE && (_renderE.message || _renderE.toString())) || 'unknown render error';
-                var _safeRenderErr = String(_renderErrMsg).replace(/[&<>"']/g, function(ch) {
-                  return ({ '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' })[ch];
-                });
-                showTurnResult(
-                  '<div style="padding:1rem;line-height:1.8;color:var(--txt);">' +
-                  '<h3 style="color:var(--gold);margin:0 0 0.8rem;">史记弹窗渲染失败</h3>' +
-                  '<p>本回合推演与数值结算已经完成，但结果弹窗在渲染时出错。游戏已解除等待状态，可继续操作；请把控制台诊断发给开发者。</p>' +
-                  '<pre style="white-space:pre-wrap;color:var(--red,#c44);background:rgba(0,0,0,0.22);padding:0.75rem;border:1px solid rgba(200,80,70,0.35);">' + _safeRenderErr + '</pre>' +
-                  '</div>'
-                );
-              }
-            } catch(_fallbackE) {
-              try { console.warn('[pipeline.render-finalize] fallback render failed', _fallbackE); } catch(_){}
-            }
-            try { if (typeof toast === 'function') toast('回合推演已完成，但史记弹窗渲染失败，请查看控制台诊断。'); } catch(_toastE) {}
-          }
-        }
+        // 所有 GM/P 记录落账由 core 的 finalizeTurnRecords 关键阶段执行；纯 DOM 渲染只在 commit 后运行。
         if (GM._pendingShijiModal) { GM._pendingShijiModal.aiReady = false; GM._pendingShijiModal.payload = null; }
         if (typeof GM !== 'undefined') {
           GM._lastEndturnAiContext = {
@@ -934,10 +890,10 @@
         await _runPostRenderTurnOpeners(ctx);
         return ctx;
       },
-      // 只有上方明确包住的 DOM 渲染允许降级；任何状态结算异常都必须到达外层事务。
+      // 本 step 仅准备记录参数并执行剩余状态结算；纯 UI 渲染已移到 canonical commit 之后。
       onError: 'abort',
       reads: ['ctx.results.aiResult', 'ctx.results.queueResult', 'ctx.results.tyrantResult', 'ctx.input.edicts', 'ctx.input.xinglu', 'ctx.input.oldVars', 'GM._pendingShijiModal'],
-      writes: ['GM.shijiHistory', 'GM.eraName', 'GM._pendingToasts', 'GM._lastFixedExpense', 'GM._facIndex', 'GM.facs[*].derivedHealth', 'ctx.input._renderFinalizeRan']
+      writes: ['GM._lastFixedExpense', 'GM._facIndex', 'GM.facs[*].derivedHealth', 'ctx.input._renderFinalizeRan', 'ctx.meta.turnRenderArgs']
     },
     {
       name: 'prepare-commit-barrier',

--- a/web/tm-endturn-render.js
+++ b/web/tm-endturn-render.js
@@ -2,12 +2,12 @@
 /// <reference path="types.d.ts" />
 // ============================================================
 // EndTurn 渲染模块（从 tm-endturn.js 拆分）
-// 包含：_endTurn_render, Delta面板, 角色高亮, 信息源渲染
+// 包含：_endTurn_finalizeRecords（事务内状态落账）、_endTurn_render（commit 后纯 UI）、Delta面板等
 // Requires: tm-endturn.js (must load before this file)
 //
 // 2026-07-06 重做：弹窗 HTML 组装全部迁至 tm-endturn-shiji-compose.js（御览分卷）。
-// 本文件保留：渲染前清洗（_unescNarr/死亡过滤/年号）·全部副作用（digest/风闻转录/shijiHistory 落账/
-// 起居注/清输入/快照/自动存档/回合收尾）。组装函数纯读零写·弹窗结构见 compose 文件头。
+// 本文件把记录落账与 UI 明确分层：digest/风闻/史记/起居注/指标属于事务内 finalization；
+// DOM、动画和提示只在 canonical 存档 commit 后运行。组装函数纯读零写·弹窗结构见 compose 文件头。
 // Domain: 回合结果展示 (战况 / 兵备 / 财政 / 起居)
 // Refactor notes:
 //   Phase 3·**Codex own·Claude review at merge** (我刚 #5 加 affectedArmies/militarySystems)
@@ -30,10 +30,81 @@ function _clearPreEndturnMarkerAfterSave(expectedId) {
   } catch (_) { return false; }
 }
 
-// 回合存档唯一入口：必须由 pipeline 在 Phase5 全部状态写入后触发。
-// 函数保持 detached 语义，但先绑定局/回合/loadGen 租约；后台等待结束后仍会复验，旧局绝不落库。
-function _endTurn_saveSnapshot() {
-  if (typeof TM_SaveDB === 'undefined' || typeof _buildSaveState !== 'function') return Promise.resolve(false);
+function _endTurn_stripCommittedDraftsFromSnapshot(snapshot) {
+  var snapGM = snapshot && snapshot.GM;
+  if (!snapGM || typeof snapGM !== 'object') return snapshot;
+  try { delete snapGM._savedEdictDrafts; } catch (_) {}
+  if (snapGM._phase8FormalDrafts && typeof snapGM._phase8FormalDrafts === 'object') {
+    snapGM._phase8FormalDrafts.edictDraft = [];
+    snapGM._phase8FormalDrafts.edictDrafts = {};
+    snapGM._phase8FormalDrafts.playerAction = '';
+  }
+  return snapshot;
+}
+
+async function _endTurn_stateChecksum(snapshot) {
+  var json = JSON.stringify(snapshot);
+  try {
+    if (typeof crypto !== 'undefined' && crypto.subtle && typeof TextEncoder !== 'undefined') {
+      var digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(json));
+      return Array.prototype.map.call(new Uint8Array(digest), function(b) { return b.toString(16).padStart(2, '0'); }).join('');
+    }
+  } catch (_) {}
+  var hash = 2166136261;
+  for (var i = 0; i < json.length; i++) { hash ^= json.charCodeAt(i); hash = Math.imul(hash, 16777619); }
+  return 'fnv1a-' + (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+async function _endTurn_stageTurnData(ctx, snapshot) {
+  ctx = ctx || { meta: {} };
+  ctx.meta = ctx.meta || {};
+  var presentation = ctx.meta.turnPresentation;
+  if (!(window.tianming && window.tianming.isDesktop && GM.saveName && presentation && presentation.turnData)) return true;
+  if (typeof window.tianming.stageTurnData !== 'function') throw new Error('桌面回合分卷暂存接口缺失');
+  var checksum = await _endTurn_stateChecksum(snapshot);
+  var marker = {
+    saveName: GM.saveName,
+    turn: GM.turn - 1,
+    campaignId: String(GM._campaignId || ''),
+    transactionId: String(ctx.meta.transactionId || ''),
+    stateChecksum: checksum
+  };
+  var result = await window.tianming.stageTurnData(Object.assign({ data: presentation.turnData }, marker));
+  if (!(result && result.success === true)) throw new Error('回合分卷暂存失败' + (result && result.error ? '：' + result.error : ''));
+  ctx.meta.stagedTurnData = marker;
+  GM._pendingTurnDataPublish = deepClone(marker); // arch-ok: end-turn commit coordinator owns durable desktop publish marker
+  snapshot.GM._pendingTurnDataPublish = deepClone(marker);
+  return true;
+}
+
+async function _endTurn_discardStagedTurnData(ctx) {
+  var marker = ctx && ctx.meta && ctx.meta.stagedTurnData;
+  if (!marker) return true;
+  try {
+    if (window.tianming && typeof window.tianming.discardTurnData === 'function') await window.tianming.discardTurnData(marker);
+  } finally {
+    if (GM && GM._pendingTurnDataPublish && GM._pendingTurnDataPublish.transactionId === marker.transactionId) delete GM._pendingTurnDataPublish; // arch-ok: discard owns its staged marker cleanup
+    ctx.meta.stagedTurnData = null;
+  }
+  return true;
+}
+
+async function _endTurn_publishStagedTurnData(ctx) {
+  var marker = ctx && ctx.meta && ctx.meta.stagedTurnData;
+  if (!marker) return true;
+  if (!(window.tianming && typeof window.tianming.publishTurnData === 'function')) throw new Error('桌面回合分卷发布接口缺失');
+  var result = await window.tianming.publishTurnData(marker);
+  if (!(result && result.success === true)) throw new Error('回合分卷发布失败' + (result && result.error ? '：' + result.error : ''));
+  if (GM && GM._pendingTurnDataPublish && GM._pendingTurnDataPublish.transactionId === marker.transactionId) delete GM._pendingTurnDataPublish; // arch-ok: publish owns its committed marker cleanup
+  ctx.meta.stagedTurnData = null;
+  return true;
+}
+
+// 回合存档唯一入口：必须由 core 在全部状态写入和记录最终化后触发。
+// autosave/slot_0 共用一个数据库事务；桌面分卷只在该事务提交后发布。
+function _endTurn_saveSnapshot(ctx) {
+  if (typeof TM_SaveDB === 'undefined' || typeof TM_SaveDB.saveManyAtomic !== 'function' || typeof _buildSaveState !== 'function') return Promise.resolve(false);
+  ctx = ctx || { meta: {} };
   var _endturnSaveGM = GM;
   var _endturnSaveP = P;
   var _endturnSaveLoadGen = (typeof window !== 'undefined' && window._tmLoadGen) || 0;
@@ -57,6 +128,8 @@ function _endTurn_saveSnapshot() {
       try { if (typeof _wtRunFulfillAudit === 'function') _wtRunFulfillAudit(); } catch (_wtFaHkE) {}
       var _autoT0 = Date.now();
       var _autoState = _buildSaveState({format:'idb',gm:_endturnSaveGM,p:_endturnSaveP});
+      _endTurn_stripCommittedDraftsFromSnapshot(_autoState);
+      await _endTurn_stageTurnData(ctx, _autoState);
       var _autoSnapMs = Date.now() - _autoT0;
       if (_autoSnapMs > 800) console.warn('[AutoSave] 端回合 snapshot 耗 '+_autoSnapMs+'ms·考虑 A-2');
       var _sc3 = typeof findScenarioById === 'function' ? findScenarioById(_endturnSaveSid) : null;
@@ -66,25 +139,14 @@ function _endTurn_saveSnapshot() {
         scenarioName: _sc3 ? _sc3.name : '', eraName: _endturnSaveGM.eraName || ''
       };
       var _autoWriteOptions = { writeGuard: _endturnSaveStillCurrent };
-      var _autoWrite = TM_SaveDB.save('autosave', _autoState, _autoMeta, _autoWriteOptions).then(function(ok) {
-        if (ok !== true) throw new Error('autosave 未落库·保留 pre_endturn 恢复标记');
-        return _endturnSaveStillCurrent();
-      }).catch(function(e) {
-        (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'AutoSave] autosave写入失败:') : console.warn('[AutoSave] autosave写入失败:', e);
-        return false;
-      });
-      var _slotWrite = TM_SaveDB.save('slot_0', _autoState, _autoMeta, _autoWriteOptions).then(function(ok) {
-        if (ok !== true) throw new Error('slot_0 未落库·不更新案卷索引');
-        return _endturnSaveStillCurrent();
-      }).catch(function(e) {
-        (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'AutoSave] slot_0写入失败:') : console.warn('[AutoSave] slot_0写入失败:', e);
-        return false;
-      });
-      var _writeResults = await Promise.all([_autoWrite, _slotWrite]);
-      if (_writeResults[0] !== true || _writeResults[1] !== true || !_endturnSaveStillCurrent()) return false;
+      var _writeOk = await TM_SaveDB.saveManyAtomic([
+        { id: 'autosave', gameState: _autoState, meta: _autoMeta },
+        { id: 'slot_0', gameState: _autoState, meta: _autoMeta }
+      ], _autoWriteOptions);
+      if (_writeOk !== true || !_endturnSaveStillCurrent()) throw new Error('canonical 回合存档未原子落库');
       // 两个 canonical 槽位都提交后，才清恢复点并发布“已安全保存”标志。
-      if (!_clearPreEndturnMarkerAfterSave(_endturnSavePreId)) return false;
-      if (typeof _updateSaveIndex === 'function') _updateSaveIndex(0, _autoMeta);
+      try { _clearPreEndturnMarkerAfterSave(_endturnSavePreId); } catch (_) {}
+      try { if (typeof _updateSaveIndex === 'function') _updateSaveIndex(0, _autoMeta); } catch (_) {}
       try {
         localStorage.setItem('tm_autosave_mark', JSON.stringify({
           turn: _autoMeta.turn, timestamp: Date.now(),
@@ -92,11 +154,11 @@ function _endTurn_saveSnapshot() {
         }));
       } catch(e) {
         try { window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-endturn-render'); } catch(_) {}
-        return false;
       }
       return true;
     } catch(e) {
       console.warn('[AutoSave] post-turn save failed:', e);
+      try { await _endTurn_discardStagedTurnData(ctx); } catch (_discardE) { console.warn('[AutoSave] discard staged turn-data failed:', _discardE); }
       return false;
     }
   })();
@@ -176,10 +238,7 @@ function buildWorldChangeDigest() {
   return '【上一回合天下变动】（据此判断时局与战机）\n' + sections.join('\n');
 }
 
-function _endTurn_render(shizhengji, zhengwen, playerStatus, playerInner, edicts, xinglu, oldVars, changeReportHtml, queueResult, suggestions, tyrantResult, turnSummary, shiluText, szjTitle, szjSummary, personnelChanges, hourenXishuo, recordLineage) {
-  // 本地获取结束回合按钮（旧代码曾引用闭包外 btn，导致 ReferenceError）
-  var btn = (typeof _$ === 'function' ? (_$("btn-end") || _$("btn-end-turn")) : null);
-  if (!btn) btn = { textContent:'', style:{} };  // stub，防止 btn.textContent 抛错
+function _endTurn_finalizeRecords(shizhengji, zhengwen, playerStatus, playerInner, edicts, xinglu, oldVars, changeReportHtml, queueResult, suggestions, tyrantResult, turnSummary, shiluText, szjTitle, szjSummary, personnelChanges, hourenXishuo, recordLineage) {
   // 默认参数兼容（旧版调用者未传新参数时不崩）
   shiluText = shiluText || '';
   szjTitle = szjTitle || '';
@@ -243,7 +302,10 @@ function _endTurn_render(shizhengji, zhengwen, playerStatus, playerInner, edicts
 
   // 世界态变更摘要：此刻 turnChanges 已满（reset→AI→apply 之后），压成纯文本存住，供下回合喂 AI
   try { GM._lastTurnDigest = buildWorldChangeDigest(); }
-  catch (_wcdE) { GM._lastTurnDigest = ''; if (window.TM && TM.errors) TM.errors.capture(_wcdE, 'endturn.worldChangeDigest'); }
+  catch (_wcdE) {
+    if (window.TM && TM.errors) TM.errors.capture(_wcdE, 'endturn.worldChangeDigest');
+    throw _wcdE;
+  }
 
   // 一句话总曰·供弹窗头部 tr-summary-bar 与 shijiHistory.turnSummary（弹窗内容已分卷·见 tm-endturn-shiji-compose.js）
   var _summaryText = turnSummary || '';
@@ -277,7 +339,10 @@ function _endTurn_render(shizhengji, zhengwen, playerStatus, playerInner, edicts
         });
       }
     }
-  } catch(_fwE) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_fwE, 'shiji→fengwen] NPC evts 转录失败') : console.warn('[shiji→fengwen] NPC evts 转录失败', _fwE); }
+  } catch(_fwE) {
+    (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_fwE, 'shiji→fengwen] NPC evts 转录失败') : console.warn('[shiji→fengwen] NPC evts 转录失败', _fwE);
+    throw _fwE;
+  }
 
   // 史记弹窗·御览分卷组装（tm-endturn-shiji-compose.js·2026-07-06 重做）——
   // 组装为纯函数（读 GM/P·零写入）·素材已经上方 _unescNarr 清洗+死亡过滤·副作用（digest/风闻/落账/存档）全留本函数
@@ -392,19 +457,9 @@ function _endTurn_render(shizhengji, zhengwen, playerStatus, playerInner, edicts
     evidenceRefs: _qijuMeta ? _qijuMeta.basisRefs : [],
     contentHash: _qijuMeta && _qijuMeta.contentHash,
     factStatus: 'recorded_narrative',
-    generatedBy: 'endturn.render'
+    generatedBy: 'endturn.finalize'
   });
-  renderQiju();
-
-  // 9. 清空输入
-  ["edict-pol","edict-mil","edict-dip","edict-eco","edict-oth","xinglu","xinglu-pub","xinglu-prv"].forEach(function(id){var el=_$(id);if(el)el.value="";});
-  try { if (window.TMPhase8FormalBridge && typeof window.TMPhase8FormalBridge.clearEdictDrafts === 'function') window.TMPhase8FormalBridge.clearEdictDrafts(); } catch(_) {}
-
-  // 10. 问对：保留聊天记录（跨回合持久），刷新角色列表，关闭弹窗
-  renderWenduiChars();
-  var _wdm=_$('wendui-modal');if(_wdm)_wdm.remove();
-
-  // 11. 新回合奏疏
+  // 9. 新回合奏疏；属于记录最终化，异常必须触发整回合回滚。
   generateMemorials();
 
   // 11.5/11.6 自然死亡和空缺检查已在 Step 6.90-6.91 中执行，此处不再重复
@@ -432,10 +487,10 @@ function _endTurn_render(shizhengji, zhengwen, playerStatus, playerInner, edicts
   // 11b. 势力历史快照（每回合记录各势力状态，供AI分析趋势）
   if (GM.facs && GM.facs.length > 0) {
     if (!GM._factionHistory) GM._factionHistory = [];
-    var _fSnapshot = { turn: GM.turn, factions: {} };
+    var _fSnapshot = { turn: GM.turn - 1, factions: {} };
     GM.facs.forEach(function(f) {
       _fSnapshot.factions[f.name] = {
-        strength: f.strength || 50,
+        strength: f.strength ?? 50,
         military: f.militaryStrength || 0,
         attitude: f.attitude || '',
         leader: f.leader || ''
@@ -452,106 +507,104 @@ function _endTurn_render(shizhengji, zhengwen, playerStatus, playerInner, edicts
   if (GM.jishiRecords && GM.jishiRecords.length > 400) GM.jishiRecords = GM.jishiRecords.slice(-400);
   // 史料权威补全(纪事)·议政记录皆实录→信史·confidence 按 mode/泄密分级·供史册库权威钤印/置信
   if (Array.isArray(GM.jishiRecords)) GM.jishiRecords.forEach(function(_r){ if (_r && !_r.authorityLevel){ _r.authorityLevel = 'official_record'; _r.confidence = (_r.leaked || _r.secret) ? 0.55 : (_r.mode === 'private' ? 0.68 : 0.78); } });
-  // 12. 更新界面·renderBiannian/renderOfficeTree/renderShijiList 已由 renderGameState 内部重渲·去冗余整树重建（性能）
-  renderGameState();
-
-  // 13. 显示史记弹窗
-  hideLoading();
-  showTurnResult(shijiHtml, GM.shijiHistory.length - 1);
-
-  // 7.2: 预加载——玩家阅读回合结果时预构建固定层prompt缓存
-  setTimeout(function() {
-    if (typeof PromptLayerCache !== 'undefined' && PromptLayerCache.preload) {
-      PromptLayerCache.preload();
-    }
-  }, 500);
-
-  // 释放延迟toast（成就等在settlement期间积攒的提示）
-  if (GM._pendingToasts && GM._pendingToasts.length > 0) {
-    GM._pendingToasts.forEach(function(msg, i) { setTimeout(function(){ toast(msg); }, 500 + i * 800); });
-    GM._pendingToasts = [];
-  }
-
-  // 13a. 自动存档已移至 pipeline 的 save-finalized-turn：必须晚于 normal/deferred Phase5 全部写入。
-
-  // 13b. 写入每回合完整数据（多文件结构）
-  if(window.tianming&&window.tianming.isDesktop&&GM.saveName){
-    try{
-      // 主上下文
-      var turnCtx={turn:GM.turn-1,time:getTSText(GM.turn-1),shizhengji:shizhengji,zhengwen:zhengwen,playerStatus:playerStatus,playerInner:playerInner,vars:deepClone(GM.vars),rels:deepClone(GM.rels),chars:deepClone(GM.chars),officeTree:deepClone(GM.officeTree||[]),families:GM.families?deepClone(GM.families):null,harem:GM.harem?deepClone(GM.harem):null};
-      // 玩家操作
-      var playerInput={edicts:edicts,xinglu:xinglu,memorialResponses:(GM.memorials||[]).map(function(m){return{from:m.from,type:m.type,status:m.status,reply:m.reply};}),tyrantActivities:GM._turnTyrantActivities||[]};
-      // AI推演全部结果（从GM临时存储中提取）
-      try {
-        if (window.TM && TM.MemoryTrace && typeof TM.MemoryTrace.finalizeTurnTrace === 'function') {
-          var _mtTrace = TM.MemoryTrace.finalizeTurnTrace(GM);
-          if (_mtTrace && _mtTrace.summary && typeof recordMemoryDiagnostic === 'function') {
-            recordMemoryDiagnostic('trace', { status: 'finalized', summary: _mtTrace.summary });
-          }
-        }
-      } catch(_mtE) {}
-      var aiResults=GM._turnAiResults||{};
-      // 变量变化
-      var varChanges={_timeScale: P.time ? P.time.perTurn : '1m', _customDays: P.time ? P.time.customDays : null};
-      Object.entries(GM.vars).forEach(function(e){
-        var d=e[1].value-(oldVars[e[0]]||0);
-        if(Math.abs(d)>=0.1) {
-          var entry = {old:oldVars[e[0]]||0, now:e[1].value, delta:d};
-          // 保留编辑者定义的单位信息
-          var unit = e[1].unit || e[1].unitName || e[1].suffix || '';
-          if (unit) entry.unit = unit;
-          varChanges[e[0]] = entry;
-        }
-      });
-      // 剧本快照（首回合）
-      var scenarioData=null;
-      var refTextData=null;
-      if(GM.turn<=2){
-        var _sc4=findScenarioById&&findScenarioById(GM.sid);
-        if(_sc4) scenarioData=deepClone(_sc4);
-        if(_sc4&&_sc4.refText) refTextData=_sc4.refText;
+  // 这些旧 UI 入口过去会在渲染时顺手规范化状态。现在先在事务内完成，
+  // commit 后的 renderer 只读已经准备好的财政、问对和地图展示数据。
+  if (typeof _syncFiscalScalars === 'function') _syncFiscalScalars(GM);
+  if (typeof _wdPrepareAudienceRenderState === 'function') _wdPrepareAudienceRenderState();
+  if (P.map && P.map.enabled && typeof updateMapColors === 'function') updateMapColors({ refresh: false });
+  var _pendingToasts = Array.isArray(GM._pendingToasts) ? GM._pendingToasts.slice() : [];
+  GM._pendingToasts = [];
+  var turnData = null;
+  if (window.tianming && window.tianming.isDesktop && GM.saveName) {
+    if (window.TM && TM.MemoryTrace && typeof TM.MemoryTrace.finalizeTurnTrace === 'function') {
+      var _mtTrace = TM.MemoryTrace.finalizeTurnTrace(GM);
+      if (_mtTrace && _mtTrace.summary && typeof recordMemoryDiagnostic === 'function') {
+        recordMemoryDiagnostic('trace', { status: 'finalized', summary: _mtTrace.summary });
       }
-      var turnData={context:turnCtx,playerInput:playerInput,aiResults:aiResults,varChanges:varChanges};
-      if(scenarioData) turnData.scenario=scenarioData;
-      if(refTextData) turnData.refText=refTextData;
-      window.tianming.writeTurnData(GM.saveName,GM.turn-1,turnData).then(function(result){
-        if (!(result && result.success === true)) throw new Error('回合分卷写入失败' + (result && result.error ? '：' + result.error : ''));
-      }).catch(function(e){ (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'catch] async:') : console.warn('[catch] async:', e); });
-    }catch(e){ console.warn("[catch] \u9759\u9ED8\u5F02\u5E38:", e.message || e); }
-    // Electron 崩溃恢复档只由 tm-save-lifecycle 的 60s 单写口维护；端回合不再并发写同一 __autosave__.json.tmp。
+    }
+    var turnCtx={turn:GM.turn-1,time:getTSText(GM.turn-1),shizhengji:shizhengji,zhengwen:zhengwen,playerStatus:playerStatus,playerInner:playerInner,vars:deepClone(GM.vars),rels:deepClone(GM.rels),chars:deepClone(GM.chars),officeTree:deepClone(GM.officeTree||[]),families:GM.families?deepClone(GM.families):null,harem:GM.harem?deepClone(GM.harem):null};
+    var playerInput={edicts:edicts,xinglu:xinglu,memorialResponses:(GM.memorials||[]).map(function(m){return{from:m.from,type:m.type,status:m.status,reply:m.reply};}),tyrantActivities:GM._turnTyrantActivities||[]};
+    var aiResults=GM._turnAiResults||{};
+    var varChanges={_timeScale: P.time ? P.time.perTurn : '1m', _customDays: P.time ? P.time.customDays : null};
+    Object.entries(GM.vars || {}).forEach(function(e){
+      var oldValue = oldVars && oldVars[e[0]] != null ? oldVars[e[0]] : 0;
+      var d=e[1].value-oldValue;
+      if(Math.abs(d)>=0.1) {
+        var entry = {old:oldValue, now:e[1].value, delta:d};
+        var unit = e[1].unit || e[1].unitName || e[1].suffix || '';
+        if (unit) entry.unit = unit;
+        varChanges[e[0]] = entry;
+      }
+    });
+    var scenarioData=null;
+    var refTextData=null;
+    if(GM.turn<=2){
+      var _sc4=typeof findScenarioById === 'function' && findScenarioById(GM.sid);
+      if(_sc4) scenarioData=deepClone(_sc4);
+      if(_sc4&&_sc4.refText) refTextData=_sc4.refText;
+    }
+    turnData={context:turnCtx,playerInput:playerInput,aiResults:aiResults,varChanges:varChanges};
+    if(scenarioData) turnData.scenario=scenarioData;
+    if(refTextData) turnData.refText=refTextData;
   }
 
-  btn.textContent="\u23F3 \u9759\u5F85\u65F6\u53D8";btn.style.opacity="1";
-
-  // 更新新UI的时间显示和变量显示
-  if (typeof updateTimeDisplay === 'function') {
-    updateTimeDisplay();
+  var _aiDiagnosticSummary = '';
+  var _aiDiag = GM._lastAIDiagnostics;
+  if (_aiDiag && !_aiDiag._announced) {
+    var _fw = Array.isArray(_aiDiag.failedWrites) ? _aiDiag.failedWrites.length : 0;
+    var _warn = Array.isArray(_aiDiag.warnings) ? _aiDiag.warnings.length : 0;
+    var _rep = Array.isArray(_aiDiag.repairedJson) ? _aiDiag.repairedJson.length : 0;
+    if (_fw || _warn || _rep) {
+      _aiDiagnosticSummary = 'write_gate=' + _fw + ', warnings=' + _warn + ', json_repair=' + _rep;
+      _aiDiag._announced = true;
+    }
   }
-  if (typeof updateTopVariables === 'function') {
-    updateTopVariables();
-  }
 
-  // 存档写口已在 13a 统一完成；不再调用 SaveManager.autoSave 重复覆盖 slot_0。
+  return {
+    shijiHtml: shijiHtml,
+    shijiIndex: GM.shijiHistory.length - 1,
+    pendingToasts: _pendingToasts,
+    turnData: turnData,
+    aiDiagnosticSummary: _aiDiagnosticSummary
+  };
+}
 
-  // 输出回合结算日志
+// 玩家输入必须在世界与 canonical 存档都提交以后才清空；失败回滚无需重建 DOM 草稿。
+function _endTurn_clearCommittedInputs() {
+  ["edict-pol","edict-mil","edict-dip","edict-eco","edict-oth","xinglu","xinglu-pub","xinglu-prv"].forEach(function(id){var el=typeof _$ === 'function' ? _$(id) : null;if(el)el.value="";});
+  if (window.TMPhase8FormalBridge && typeof window.TMPhase8FormalBridge.clearEdictDrafts === 'function') window.TMPhase8FormalBridge.clearEdictDrafts();
+}
+
+// 纯展示阶段：只在事务 commit 后调用。这里的异常可降级，不能反向回滚已提交世界。
+function _endTurn_render(presentation) {
+  presentation = presentation || {};
+  var btn = (typeof _$ === 'function' ? (_$("btn-end") || _$("btn-end-turn")) : null);
+  if (typeof renderQiju === 'function') renderQiju();
+  if (typeof renderWenduiChars === 'function') renderWenduiChars(false, { skipStatePreparation: true });
+  var _wdm=typeof _$ === 'function' ? _$('wendui-modal') : null;if(_wdm)_wdm.remove();
+  if (typeof renderGameState === 'function') renderGameState({ skipStateSync: true });
+  if (typeof hideLoading === 'function') hideLoading();
+  if (typeof showTurnResult === 'function') showTurnResult(presentation.shijiHtml || '', presentation.shijiIndex);
+  setTimeout(function() {
+    if (typeof PromptLayerCache !== 'undefined' && PromptLayerCache.preload) PromptLayerCache.preload();
+  }, 500);
+  (presentation.pendingToasts || []).forEach(function(msg, i) { setTimeout(function(){ toast(msg); }, 500 + i * 800); });
+  if (btn) { btn.textContent="\u23F3 \u9759\u5F85\u65F6\u53D8";btn.style.opacity="1"; }
+  if (typeof updateTimeDisplay === 'function') updateTimeDisplay();
+  if (typeof updateTopVariables === 'function') updateTopVariables();
   _dbg('========== 回合结算完成 (T' + GM.turn + ') ==========');
   _dbg('[endTurn] 财务报表:', (typeof AccountingSystem !== 'undefined' && AccountingSystem.getLedger) ? AccountingSystem.getLedger() : null);
   _dbg('[endTurn] 变动队列已清空，准备进入下一回合');
-  try {
-    var _aiDiag = GM._lastAIDiagnostics;
-    if (_aiDiag && !_aiDiag._announced) {
-      var _fw = Array.isArray(_aiDiag.failedWrites) ? _aiDiag.failedWrites.length : 0;
-      var _warn = Array.isArray(_aiDiag.warnings) ? _aiDiag.warnings.length : 0;
-      var _rep = Array.isArray(_aiDiag.repairedJson) ? _aiDiag.repairedJson.length : 0;
-      if (_fw || _warn || _rep) {
-        _dbg('[AIDiagnostics] hidden summary: write_gate=' + _fw + ', warnings=' + _warn + ', json_repair=' + _rep);
-        _aiDiag._announced = true;
-      }
-    }
-  } catch(_aiDiagE) { console.warn('[AIDiagnostics] render summary failed:', _aiDiagE); }
+  if (presentation.aiDiagnosticSummary) _dbg('[AIDiagnostics] hidden summary: ' + presentation.aiDiagnosticSummary);
+  if (P.map && P.map.enabled && typeof refreshMapDisplay === 'function') refreshMapDisplay();
+}
 
-  // 更新地图颜色（根据占领者实时更新）
-  if (P.map && P.map.enabled) {
-    updateMapColors();
+function _endTurn_showRenderFallback(error) {
+  try { if (typeof hideLoading === 'function') hideLoading(); } catch (_) {}
+  var message = String(error && (error.message || error) || 'unknown render error');
+  var safe = message.replace(/[&<>"']/g, function(ch) { return ({ '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' })[ch]; });
+  if (typeof showTurnResult === 'function') {
+    showTurnResult('<div style="padding:1rem;line-height:1.8;color:var(--txt);"><h3 style="color:var(--gold);margin:0 0 0.8rem;">史记弹窗渲染失败</h3><p>本回合已安全保存，但结果界面渲染失败。可继续操作，请把控制台诊断发给开发者。</p><pre style="white-space:pre-wrap;color:var(--red,#c44);">' + safe + '</pre></div>');
   }
+  try { if (typeof toast === 'function') toast('回合已安全保存，但史记弹窗渲染失败，请查看控制台诊断。'); } catch (_) {}
 }

--- a/web/tm-game-ui-shell.js
+++ b/web/tm-game-ui-shell.js
@@ -54,9 +54,12 @@ function _renderEdictArchiveBody() {
   _bodyEl.innerHTML = _h;
 }
 
-function renderGameState(){
+function renderGameState(options){
+  options = options || {};
   // ★ 财政三字段同步守卫·防 money/balance/ledgers.stock 跑偏导致顶栏与面板数值不一致
-  try { if (typeof _syncFiscalScalars === 'function' && typeof GM !== 'undefined') _syncFiscalScalars(GM); } catch(_syE) { try { window.TM && TM.errors && TM.errors.captureSilent && TM.errors.captureSilent(_syE, 'renderGameState/sync'); } catch(__){} }
+  if (!options.skipStateSync) {
+    try { if (typeof _syncFiscalScalars === 'function' && typeof GM !== 'undefined') _syncFiscalScalars(GM); } catch(_syE) { try { window.TM && TM.errors && TM.errors.captureSilent && TM.errors.captureSilent(_syE, 'renderGameState/sync'); } catch(__){} }
+  }
   // 旧 UI
   renderLeftPanel();
   renderBarResources();

--- a/web/tm-map-system.js
+++ b/web/tm-map-system.js
@@ -722,7 +722,8 @@ function createTerrainPattern(ctx, patternType) {
  * 说明：地图主要用于可视化和帮助AI理解地理关系
  * 实际游戏推演以行政区划（cities/territories）为准
  */
-function updateMapColors() {
+function updateMapColors(options) {
+  options = options || {};
   var runtimeMap = getLiveMapData();
   if (!runtimeMap) return;
   var runtimeGM = (typeof GM !== 'undefined' && GM) ? GM : null;
@@ -848,7 +849,7 @@ function updateMapColors() {
   _dbg('[Map] 地图颜色更新完成，更新了 ' + updateCount + ' 个地块');
 
   // 如果有地图显示组件，触发重绘
-  if (typeof refreshMapDisplay === 'function') {
+  if (options.refresh !== false && typeof refreshMapDisplay === 'function') {
     refreshMapDisplay();
   }
 }

--- a/web/tm-save-lifecycle.js
+++ b/web/tm-save-lifecycle.js
@@ -864,6 +864,21 @@ var PREF_CONF_KEYS = [
   'insecureTlsRelay'
 ];
 
+function _recoverPendingTurnDataPublish() {
+  if (!(GM && GM._pendingTurnDataPublish && window.tianming && typeof window.tianming.recoverTurnData === 'function')) return;
+  var targetGM = GM;
+  var marker = deepClone(GM._pendingTurnDataPublish);
+  window.tianming.recoverTurnData(marker).then(function(result) {
+    if (GM !== targetGM || !GM._pendingTurnDataPublish || GM._pendingTurnDataPublish.transactionId !== marker.transactionId) return;
+    if (!(result && result.success === true)) throw new Error(result && result.error || '回合分卷恢复失败');
+    delete GM._pendingTurnDataPublish;
+  }).catch(function(error) {
+    if (GM !== targetGM) return;
+    try { if (window.TM && TM.errors && TM.errors.capture) TM.errors.capture(error, 'fullLoadGame] recover turn-data'); } catch (_) {}
+    try { if (typeof toast === 'function') toast('存档已载入；回合分卷仍待补发，将在下次读档重试。'); } catch (_) {}
+  });
+}
+
 function fullLoadGame(data, loadOptions){
   loadOptions = loadOptions || {};
   // 跨档保留 API 设置：localStorage 的 tm_api 是用户的"机器"配置·不应被存档覆盖
@@ -1189,6 +1204,8 @@ function fullLoadGame(data, loadOptions){
     if(typeof renderGameCivic==="function")renderGameCivic();
     if(typeof renderRenwu==="function")renderRenwu();
     if(typeof renderSidePanels==="function")renderSidePanels();
+
+    _recoverPendingTurnDataPublish();
 
     toast("\u2705 \u5DF2\u52A0\u8F7D: T"+GM.turn+" "+getTSText(GM.turn));
   }else{

--- a/web/tm-storage.js
+++ b/web/tm-storage.js
@@ -60,9 +60,38 @@ var TM_SaveDB = (function() {
   var _available = false;
   var _openPromise = null; // 防止重复打开
   var _migrationTail = Promise.resolve(); // 两类旧源必须串行探测/占用目标 ID
+  var LOCAL_SAVE_BATCH_JOURNAL = 'tm_save_batch_journal_v1';
+
+  function _restoreLocalSaveBatchItems(items) {
+    items = Array.isArray(items) ? items : [];
+    for (var i = items.length - 1; i >= 0; i--) {
+      var item = items[i] || {};
+      if (!item.key) continue;
+      if (item.previous == null) localStorage.removeItem(item.key);
+      else localStorage.setItem(item.key, item.previous);
+    }
+  }
+
+  // localStorage 没有事务。批量存档在任何 payload/metadata 写入前先持久化旧值；
+  // 页面若在中途崩溃，下次 open() 会恢复整批旧值，避免 autosave/slot_0 分叉。
+  function _recoverLocalSaveBatchJournal() {
+    var raw = localStorage.getItem(LOCAL_SAVE_BATCH_JOURNAL);
+    if (!raw) return;
+    var journal;
+    try { journal = JSON.parse(raw); }
+    catch (_) { localStorage.removeItem(LOCAL_SAVE_BATCH_JOURNAL); return; }
+    if (!journal || !Array.isArray(journal.items)) {
+      localStorage.removeItem(LOCAL_SAVE_BATCH_JOURNAL);
+      return;
+    }
+    if (journal.phase !== 'committed') _restoreLocalSaveBatchItems(journal.items);
+    localStorage.removeItem(LOCAL_SAVE_BATCH_JOURNAL);
+  }
 
   // ── 打开数据库 ──
   function open() {
+    try { _recoverLocalSaveBatchJournal(); }
+    catch (journalError) { return Promise.reject(new Error('localStorage 批量存档恢复失败：' + (journalError && journalError.message || journalError))); }
     if (_db) return Promise.resolve(_db);
     if (_openPromise) return _openPromise;
 
@@ -225,6 +254,62 @@ var TM_SaveDB = (function() {
         tx.onerror = handleWriteFailure;
         tx.onabort = handleWriteFailure;
       } catch (e) { reject(e); }
+    });
+  }
+
+  function _putSaveRecordsAtomic(records, writeGuard) {
+    records = Array.isArray(records) ? records : [];
+    if (!records.length) return Promise.resolve(false);
+    if (!_writeGuardAllows(writeGuard)) return Promise.resolve(false);
+    if (!_available || !_db) {
+      var items = [];
+      records.forEach(function(record) {
+        var payloadKey = 'tm_idb_' + SAVE_STORE + '_' + record.id;
+        var metadataKey = 'tm_idb_' + SAVE_META_STORE + '_' + record.id;
+        items.push({ key: payloadKey, previous: localStorage.getItem(payloadKey) });
+        items.push({ key: metadataKey, previous: localStorage.getItem(metadataKey) });
+      });
+      var journal = { version: 1, phase: 'prepared', createdAt: Date.now(), items: items };
+      try {
+        localStorage.setItem(LOCAL_SAVE_BATCH_JOURNAL, JSON.stringify(journal));
+        records.forEach(function(record) {
+          localStorage.setItem('tm_idb_' + SAVE_STORE + '_' + record.id, JSON.stringify(record));
+          localStorage.setItem('tm_idb_' + SAVE_META_STORE + '_' + record.id, JSON.stringify(_toSaveMetadata(record)));
+        });
+        journal.phase = 'committed';
+        localStorage.setItem(LOCAL_SAVE_BATCH_JOURNAL, JSON.stringify(journal));
+        localStorage.removeItem(LOCAL_SAVE_BATCH_JOURNAL);
+        return Promise.resolve(true);
+      } catch (error) {
+        try {
+          _restoreLocalSaveBatchItems(items);
+          localStorage.removeItem(LOCAL_SAVE_BATCH_JOURNAL);
+        } catch (_) {
+          // 保留 prepared journal；下次 open() 会继续恢复旧值。
+        }
+        return Promise.reject(error);
+      }
+    }
+    return new Promise(function(resolve, reject) {
+      try {
+        if (!_writeGuardAllows(writeGuard)) { resolve(false); return; }
+        var tx = _db.transaction([SAVE_STORE, SAVE_META_STORE], 'readwrite');
+        var payloadStore = tx.objectStore(SAVE_STORE);
+        var metadataStore = tx.objectStore(SAVE_META_STORE);
+        var settled = false;
+        records.forEach(function(record) {
+          payloadStore.put(record);
+          metadataStore.put(_toSaveMetadata(record));
+        });
+        tx.oncomplete = function() { if (!settled) { settled = true; resolve(true); } };
+        function fail(e) {
+          if (settled) return;
+          settled = true;
+          reject(e && e.target && e.target.error || tx.error || new Error('IndexedDB 批量存档事务失败'));
+        }
+        tx.onerror = fail;
+        tx.onabort = fail;
+      } catch (error) { reject(error); }
     });
   }
 
@@ -508,6 +593,58 @@ var TM_SaveDB = (function() {
     });
   }
 
+  /** 同一事务保存多个 canonical 槽位；任一 payload/metadata 失败则整批不推进。 */
+  function saveManyAtomic(entries, options) {
+    entries = Array.isArray(entries) ? entries : [];
+    options = options || {};
+    if (!entries.length) return Promise.resolve(false);
+    function _writeStillAllowed() {
+      if (typeof options.writeGuard !== 'function') return true;
+      try { return options.writeGuard() === true; }
+      catch (_) { return false; }
+    }
+    var frozen;
+    try {
+      var seenIds = Object.create(null);
+      frozen = entries.map(function(entry) {
+        if (!entry || entry.id == null || entry.id === '') throw new Error('批量存档缺少 id');
+        var id = String(entry.id);
+        if (seenIds[id]) throw new Error('批量存档 id 重复：' + id);
+        seenIds[id] = true;
+        var json = JSON.stringify(entry.gameState);
+        if (typeof json !== 'string') throw new Error('批量存档正文不可序列化：' + id);
+        return { id: id, json: json, meta: Object.assign({}, entry.meta || {}) };
+      });
+    } catch (error) { return Promise.reject(error); }
+    if (!_writeStillAllowed()) return Promise.resolve(false);
+    return _ensureOpen().then(async function() {
+      var timestamp = Date.now();
+      var records = [];
+      for (var i = 0; i < frozen.length; i++) {
+        var item = frozen[i];
+        var compressed = await SaveCompression.compress(item.json);
+        var isCompressed = !!(_available && _db && compressed !== item.json);
+        records.push({
+          id: item.id,
+          type: item.meta.type || 'manual',
+          name: item.meta.name || item.id,
+          timestamp: timestamp,
+          turn: item.meta.turn != null ? item.meta.turn : 0,
+          scenarioName: item.meta.scenarioName || '',
+          eraName: item.meta.eraName || '',
+          date: item.meta.date || '',
+          dynastyPhase: item.meta.dynastyPhase || '',
+          snapshotId: item.meta.snapshotId || '',
+          commitState: item.meta.commitState || '',
+          gameState: isCompressed ? compressed : item.json,
+          _compressed: isCompressed
+        });
+      }
+      if (!_writeStillAllowed()) return false;
+      return _putSaveRecordsAtomic(records, _writeStillAllowed);
+    });
+  }
+
   /** 读取游戏存档（7.1: 支持gzip解压，兼容旧存档） */
   function load(id) {
     return _ensureOpen().then(function() {
@@ -585,10 +722,33 @@ var TM_SaveDB = (function() {
     try { return 'j:' + JSON.stringify(payload); } catch (_) { return null; }
   }
 
+  function _migrationStableValue(value) {
+    if (Array.isArray(value)) return value.map(_migrationStableValue);
+    if (value && typeof value === 'object') {
+      var out = {};
+      Object.keys(value).sort().forEach(function(key) { out[key] = _migrationStableValue(value[key]); });
+      return out;
+    }
+    return value;
+  }
+
+  function _migrationMetadataSignature(record) {
+    if (!record || typeof record !== 'object') return null;
+    var metadata = {};
+    Object.keys(record).sort().forEach(function(key) {
+      if (key === 'id' || key === 'gameState' || key === '_compressed') return;
+      metadata[key] = _migrationStableValue(record[key]);
+    });
+    try { return JSON.stringify(metadata); } catch (_) { return null; }
+  }
+
   function _migrationRecordsEquivalent(left, right) {
     var leftSig = _migrationPayloadSignature(left);
     var rightSig = _migrationPayloadSignature(right);
-    return leftSig != null && rightSig != null && leftSig === rightSig;
+    var leftMeta = _migrationMetadataSignature(left);
+    var rightMeta = _migrationMetadataSignature(right);
+    return leftSig != null && rightSig != null && leftSig === rightSig &&
+      leftMeta != null && rightMeta != null && leftMeta === rightMeta;
   }
 
   async function _prepareMigrationRecords(records, sourceTag) {
@@ -767,6 +927,7 @@ var TM_SaveDB = (function() {
   return {
     open: open,
     save: save,
+    saveManyAtomic: saveManyAtomic,
     load: load,
     list: list,
     delete: deleteSave,

--- a/web/tm-wendui.js
+++ b/web/tm-wendui.js
@@ -112,7 +112,22 @@ function _wdCanDirectAudience(ch) {
 /**
  * 渲染问对面板中的角色网格（仅在京臣子可点击）
  */
-function renderWenduiChars(force){
+function _wdPrepareAudienceRenderState() {
+  if (Array.isArray(GM._pendingAudiences) && GM._pendingAudiences.length > 0) {
+    _wdCleansePendingAudiences(function(q) {
+      if (!q || !q.name) return true;
+      if (q.isEnvoy || q.fromFaction || q.isConsort || q._sid || q._opening) return true;
+      var ch = (typeof findCharByName === 'function') ? findCharByName(q.name) : null;
+      if (!ch) return true;
+      if (typeof _tmIsForeignCourtChar === 'function' && _tmIsForeignCourtChar(ch)) return false;
+      return true;
+    });
+  }
+  _wdEnsurePendingQids();
+}
+
+function renderWenduiChars(force, options){
+  options = options || {};
   // 性能·2026-06-10·与纪录类面板同范式:gt-wendui 隐藏时跳过(renderGameState 尾部无条件调它·
   // 全名册数百卡+肖像重建纯浪费)·切到该页时 switchGTab 传 force=true 强制渲染
   if(!force && typeof _gtTabVisible==='function' && !_gtTabVisible('gt-wendui')) return;
@@ -151,17 +166,7 @@ function renderWenduiChars(force){
 
   // 【阶下待见】使节/外藩/AI推送
   // 存量清洗(2026-07-04)：旧版 NPC 社交行动无阵营闸·外邦君主(皇太极等)曾被排进求见队列并喂入推演。渲染时滤除已混入的明确异势力人物·救活污染存档免回档。使节(isEnvoy/fromFaction)/后妃(isConsort·消费侧另有专检)/剧本预置(_sid/_opening·作者意图)/空 faction 者均放行;查无此人留给消费侧既有兜底。
-  if (Array.isArray(GM._pendingAudiences) && GM._pendingAudiences.length > 0) {
-    _wdCleansePendingAudiences(function(q) {
-      if (!q || !q.name) return true;
-      if (q.isEnvoy || q.fromFaction || q.isConsort || q._sid || q._opening) return true;
-      var _qCh = (typeof findCharByName === 'function') ? findCharByName(q.name) : null;
-      if (!_qCh) return true;
-      if (typeof _tmIsForeignCourtChar === 'function' && _tmIsForeignCourtChar(_qCh)) return false;
-      return true;
-    });
-  }
-  _wdEnsurePendingQids();
+  if (!options.skipStatePreparation) _wdPrepareAudienceRenderState();
   if (Array.isArray(GM._pendingAudiences) && GM._pendingAudiences.length > 0) {
     html += '<div class="wdp-group wdp-g-envoy">';
     html += '<div class="wdp-group-title"><span class="tag">\u9636 \u4E0B \u5F85 \u89C1</span><span class="desc">\u4F7F\u8282\u00B7\u5916\u85E9\u00B7\u7279\u8BF7\u00B7\u7B49\u5F85\u9661\u4E0B\u51B3\u65AD</span><span class="count">' + GM._pendingAudiences.length + ' \u4EBA</span></div>';


### PR DESCRIPTION
## Summary

- split transaction-critical turn record finalization from post-commit UI rendering
- atomically save autosave and slot_0 across payload and metadata stores, with localStorage crash journal recovery
- stage desktop turn bundles before save and publish only after world commit, with idempotent load recovery
- keep player edict drafts intact until commit, preserve faction strength zero, and retain metadata-distinct legacy saves
- move hidden fiscal, audience, and map state preparation inside the turn transaction

## Regression coverage

- record finalization partial failures roll back Shiji and Qiju state
- canonical dual-slot failure leaves both slots unchanged
- desktop staging is discarded on save failure and recovered after interrupted publish
- committed drafts clear only after successful save
- zero faction strength and completed-turn labels remain exact
- legacy saves with equal payload but different visible metadata are both retained

## Local gates

- npm ci --ignore-scripts
- official scenario sync and parity: PASS
- architecture guards: 8/8 PASS
- release contract: 166 assertions PASS
- hot builder gates: 27 assertions PASS
- canonical hot baseline: 1081 files PASS with full asset overlay
- ci-smokes: 843/845 PASS; 2 existing missing-large-asset whitelist exemptions

No package, release, hot update, or Pages deployment is included.