### PR TITLE
fix: close sixth-round audit state and archive gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
           cache: npm
       - name: Install release-gate dependencies
         run: npm ci --ignore-scripts
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high --registry=https://registry.npmjs.org
       - name: Regenerate official scenario products
         run: node web/scripts/sync-official-scenarios.js
       - name: Reject stale generated products

--- a/main-impl.js
+++ b/main-impl.js
@@ -14,7 +14,6 @@ const crypto = require('crypto');
 const dns = require('dns').promises;
 const nodeNet = require('net');
 const { pathToFileURL, fileURLToPath } = require('url');
-const AdmZip = require('adm-zip');
 const yauzl = require('yauzl');
 const { pipeline } = require('stream');
 const { autoUpdater } = require('electron-updater');
@@ -799,6 +798,16 @@ const WORKSHOP_ZIP_LIMITS = Object.freeze({
   maxNameBytes: 240,
   maxDepth: 16
 });
+const HOT_UPDATE_ZIP_LIMITS = Object.freeze({
+  maxEntries: 8192,
+  maxArchiveBytes: 2 * 1024 * 1024 * 1024,
+  maxTotalBytes: 2 * 1024 * 1024 * 1024,
+  maxFileBytes: 1024 * 1024 * 1024,
+  maxCompressionRatio: 1000,
+  compressionRatioMinBytes: 1024 * 1024,
+  maxNameBytes: 320,
+  maxDepth: 32
+});
 
 function walkPackFiles(root) {
   const out = [];
@@ -891,13 +900,15 @@ function openWorkshopZip(zipPath) {
   });
 }
 
-function validateWorkshopZipEntry(entry, seenPaths) {
+function validateZipEntryByPolicy(entry, seenPaths, limits, blockedExts, allowedExts, label) {
+  limits = limits || WORKSHOP_ZIP_LIMITS;
+  label = label || '压缩包';
   const rawName = String(entry && entry.fileName || '');
   if (!rawName || rawName.indexOf('\0') >= 0) throw new Error('压缩包包含空文件名或 NUL 字节');
   if (rawName.indexOf('\\') >= 0 || rawName[0] === '/' || /^[a-zA-Z]:/.test(rawName)) {
     throw new Error('压缩包包含绝对或非规范路径: ' + rawName);
   }
-  if (Buffer.byteLength(rawName, 'utf8') > WORKSHOP_ZIP_LIMITS.maxNameBytes) {
+  if (Buffer.byteLength(rawName, 'utf8') > limits.maxNameBytes) {
     throw new Error('压缩包文件名过长: ' + rawName.slice(0, 80));
   }
   const isDirectory = /\/$/.test(rawName);
@@ -906,7 +917,7 @@ function validateWorkshopZipEntry(entry, seenPaths) {
   if (!normalized || segments.some(part => !part || part === '.' || part === '..')) {
     throw new Error('压缩包包含越界或非规范路径: ' + rawName);
   }
-  if (segments.length > WORKSHOP_ZIP_LIMITS.maxDepth) {
+  if (segments.length > limits.maxDepth) {
     throw new Error('压缩包目录层级过深: ' + rawName);
   }
   const canonical = segments.join('/');
@@ -915,8 +926,8 @@ function validateWorkshopZipEntry(entry, seenPaths) {
   if (seenPaths) seenPaths.add(duplicateKey);
 
   const mode = (Number(entry.externalFileAttributes) >>> 16) & 0xffff;
-  if ((mode & 0xf000) === 0xa000) throw new Error('工坊包不允许包含符号链接: ' + rawName);
-  if ((Number(entry.generalPurposeBitFlag) & 1) !== 0) throw new Error('工坊包不允许加密条目: ' + rawName);
+  if ((mode & 0xf000) === 0xa000) throw new Error(label + '不允许包含符号链接: ' + rawName);
+  if ((Number(entry.generalPurposeBitFlag) & 1) !== 0) throw new Error(label + '不允许加密条目: ' + rawName);
 
   const compressedSize = Number(entry.compressedSize);
   const uncompressedSize = Number(entry.uncompressedSize);
@@ -924,26 +935,39 @@ function validateWorkshopZipEntry(entry, seenPaths) {
       !Number.isSafeInteger(uncompressedSize) || uncompressedSize < 0) {
     throw new Error('压缩包条目大小非法: ' + rawName);
   }
-  if (uncompressedSize > WORKSHOP_ZIP_LIMITS.maxFileBytes) {
-    throw new Error('工坊包单文件超过 128MB 上限: ' + rawName);
+  if (uncompressedSize > limits.maxFileBytes) {
+    throw new Error(label + '单文件声明解压体积超过上限: ' + rawName);
   }
-  if (!isDirectory && uncompressedSize >= WORKSHOP_ZIP_LIMITS.compressionRatioMinBytes) {
+  if (!isDirectory && uncompressedSize >= limits.compressionRatioMinBytes) {
     const ratio = compressedSize > 0 ? uncompressedSize / compressedSize : Infinity;
-    if (ratio > WORKSHOP_ZIP_LIMITS.maxCompressionRatio) {
-      throw new Error('工坊包条目压缩比异常，疑似 ZIP 炸弹: ' + rawName);
+    if (ratio > limits.maxCompressionRatio) {
+      throw new Error(label + '条目压缩比异常，疑似 ZIP 炸弹: ' + rawName);
     }
   }
   if (!isDirectory) {
     const ext = path.posix.extname(canonical).toLowerCase();
-    if (BLOCKED_PACK_EXTS.has(ext)) throw new Error('工坊包含有禁止类型文件: ' + rawName);
-    if (!ALLOWED_PACK_EXTS.has(ext)) throw new Error('工坊包含有未允许的文件类型: ' + rawName);
+    if (blockedExts && blockedExts.has(ext)) throw new Error(label + '包含有禁止类型文件: ' + rawName);
+    if (allowedExts && !allowedExts.has(ext)) throw new Error(label + '包含有未允许的文件类型: ' + rawName);
   }
   return { rawName, canonical, isDirectory, compressedSize, uncompressedSize };
 }
 
-async function preflightWorkshopZip(zipPath) {
+function validateWorkshopZipEntry(entry, seenPaths) {
+  return validateZipEntryByPolicy(entry, seenPaths, WORKSHOP_ZIP_LIMITS, BLOCKED_PACK_EXTS, ALLOWED_PACK_EXTS, '工坊包');
+}
+
+function validateHotUpdateZipEntry(entry, seenPaths) {
+  return validateZipEntryByPolicy(entry, seenPaths, HOT_UPDATE_ZIP_LIMITS, null, ALLOWED_HOT_UPDATE_EXTS, '热更新包');
+}
+
+async function preflightCheckedZip(zipPath, limits, validateEntry, label) {
+  limits = limits || WORKSHOP_ZIP_LIMITS;
+  label = label || '压缩包';
   const archiveStat = fs.statSync(zipPath);
-  if (!archiveStat.isFile()) throw new Error('工坊压缩包不是普通文件');
+  if (!archiveStat.isFile()) throw new Error(label + '不是普通文件');
+  if (limits.maxArchiveBytes && archiveStat.size > limits.maxArchiveBytes) {
+    throw new Error(label + '压缩体积超过上限');
+  }
   const zip = await openWorkshopZip(zipPath);
   return new Promise((resolve, reject) => {
     const seenPaths = new Set();
@@ -974,13 +998,13 @@ async function preflightWorkshopZip(zipPath) {
     zip.on('entry', entry => {
       try {
         entries += 1;
-        if (entries > WORKSHOP_ZIP_LIMITS.maxEntries) throw new Error('工坊包文件数量超过 4096 上限');
-        const info = validateWorkshopZipEntry(entry, seenPaths);
+        if (entries > limits.maxEntries) throw new Error(label + '文件数量超过上限');
+        const info = validateEntry(entry, seenPaths);
         if (!info.isDirectory) {
           files += 1;
           totalBytes += info.uncompressedSize;
-          if (!Number.isSafeInteger(totalBytes) || totalBytes > WORKSHOP_ZIP_LIMITS.maxTotalBytes) {
-            throw new Error('工坊包声明解压体积超过 250MB 上限');
+          if (!Number.isSafeInteger(totalBytes) || totalBytes > limits.maxTotalBytes) {
+            throw new Error(label + '声明解压体积超过上限');
           }
         }
         zip.readEntry();
@@ -989,15 +1013,25 @@ async function preflightWorkshopZip(zipPath) {
       }
     });
     zip.on('end', finish);
-    if (Number(zip.entryCount) > WORKSHOP_ZIP_LIMITS.maxEntries) {
-      fail(new Error('工坊包文件数量超过 4096 上限'));
+    if (Number(zip.entryCount) > limits.maxEntries) {
+      fail(new Error(label + '文件数量超过上限'));
       return;
     }
     zip.readEntry();
   });
 }
 
-function streamWorkshopEntry(zip, entry, target, counters) {
+function preflightWorkshopZip(zipPath) {
+  return preflightCheckedZip(zipPath, WORKSHOP_ZIP_LIMITS, validateWorkshopZipEntry, '工坊包');
+}
+
+function preflightHotUpdateZip(zipPath) {
+  return preflightCheckedZip(zipPath, HOT_UPDATE_ZIP_LIMITS, validateHotUpdateZipEntry, '热更新包');
+}
+
+function streamCheckedZipEntry(zip, entry, target, counters, limits, label) {
+  limits = limits || WORKSHOP_ZIP_LIMITS;
+  label = label || '压缩包';
   return new Promise((resolve, reject) => {
     zip.openReadStream(entry, (openError, readStream) => {
       if (openError) { reject(openError); return; }
@@ -1007,10 +1041,10 @@ function streamWorkshopEntry(zip, entry, target, counters) {
       readStream.on('data', chunk => {
         entryBytes += chunk.length;
         counters.totalBytes += chunk.length;
-        if (entryBytes > WORKSHOP_ZIP_LIMITS.maxFileBytes ||
-            counters.totalBytes > WORKSHOP_ZIP_LIMITS.maxTotalBytes ||
+        if (entryBytes > limits.maxFileBytes ||
+            counters.totalBytes > limits.maxTotalBytes ||
             entryBytes > Number(entry.uncompressedSize)) {
-          quotaError = new Error('工坊包实际解压体积超过配额: ' + entry.fileName);
+          quotaError = new Error(label + '实际解压体积超过配额: ' + entry.fileName);
           readStream.destroy(quotaError);
         }
       });
@@ -1023,7 +1057,7 @@ function streamWorkshopEntry(zip, entry, target, counters) {
         }
         if (entryBytes !== Number(entry.uncompressedSize)) {
           try { fs.rmSync(target, { force: true }); } catch (_) {}
-          reject(new Error('工坊包条目解压大小与中央目录不一致: ' + entry.fileName));
+          reject(new Error(label + '条目解压大小与中央目录不一致: ' + entry.fileName));
           return;
         }
         resolve(entryBytes);
@@ -1032,7 +1066,9 @@ function streamWorkshopEntry(zip, entry, target, counters) {
   });
 }
 
-async function extractWorkshopZipStreamed(zipPath, temp, expected) {
+async function extractCheckedZipStreamed(zipPath, temp, expected, limits, validateEntry, label) {
+  limits = limits || WORKSHOP_ZIP_LIMITS;
+  label = label || '压缩包';
   const zip = await openWorkshopZip(zipPath);
   return new Promise((resolve, reject) => {
     const seenPaths = new Set();
@@ -1049,7 +1085,7 @@ async function extractWorkshopZipStreamed(zipPath, temp, expected) {
       if (settled) return;
       if (counters.entries !== expected.entries || counters.files !== expected.files ||
           counters.totalBytes !== expected.totalBytes) {
-        fail(new Error('工坊包在预检后发生变化，拒绝安装'));
+        fail(new Error(label + '在预检后发生变化，拒绝安装'));
         return;
       }
       settled = true;
@@ -1062,8 +1098,8 @@ async function extractWorkshopZipStreamed(zipPath, temp, expected) {
       let info;
       try {
         counters.entries += 1;
-        if (counters.entries > WORKSHOP_ZIP_LIMITS.maxEntries) throw new Error('工坊包文件数量超过 4096 上限');
-        info = validateWorkshopZipEntry(entry, seenPaths);
+        if (counters.entries > limits.maxEntries) throw new Error(label + '文件数量超过上限');
+        info = validateEntry(entry, seenPaths);
         const target = path.resolve(temp, info.canonical);
         if (!isInsideDir(temp, target)) throw new Error('压缩包包含越界路径: ' + info.rawName);
         if (info.isDirectory) {
@@ -1073,7 +1109,7 @@ async function extractWorkshopZipStreamed(zipPath, temp, expected) {
         }
         fs.mkdirSync(path.dirname(target), { recursive: true });
         counters.files += 1;
-        streamWorkshopEntry(zip, entry, target, counters).then(() => {
+        streamCheckedZipEntry(zip, entry, target, counters, limits, label).then(() => {
           if (!settled) zip.readEntry();
         }, fail);
       } catch (error) {
@@ -1083,6 +1119,14 @@ async function extractWorkshopZipStreamed(zipPath, temp, expected) {
     zip.on('end', finish);
     zip.readEntry();
   });
+}
+
+function extractWorkshopZipStreamed(zipPath, temp, expected) {
+  return extractCheckedZipStreamed(zipPath, temp, expected, WORKSHOP_ZIP_LIMITS, validateWorkshopZipEntry, '工坊包');
+}
+
+function extractHotUpdateZipStreamed(zipPath, temp, expected) {
+  return extractCheckedZipStreamed(zipPath, temp, expected, HOT_UPDATE_ZIP_LIMITS, validateHotUpdateZipEntry, '热更新包');
 }
 
 async function extractZipToTemp(zipPath) {
@@ -1106,15 +1150,26 @@ async function extractZipToTemp(zipPath) {
   }
 }
 
-function extractZipToTempChecked(zipPath, prefix) {
+async function extractZipToTempChecked(zipPath, prefix) {
+  // 热更新 ZIP 同样先完整扫描中央目录，再以实际字节配额逐项流式解压。
+  // 这里不能调用 adm-zip：受污染的 size header 会在业务配额检查前触发巨量 Buffer 分配。
+  const preflight = await preflightHotUpdateZip(zipPath);
+  const currentStat = fs.statSync(zipPath);
+  if (currentStat.size !== preflight.archiveSize || currentStat.mtimeMs !== preflight.archiveMtimeMs) {
+    throw new Error('热更新包在预检后发生变化，拒绝安装');
+  }
   const temp = createTempDir(prefix || 'tianming-hot-');
-  const zip = new AdmZip(zipPath);
-  zip.getEntries().forEach(entry => {
-    const target = path.resolve(temp, entry.entryName);
-    if (!isInsideDir(temp, target)) throw new Error('压缩包包含越界路径: ' + entry.entryName);
-  });
-  zip.extractAllTo(temp, true);
-  return temp;
+  try {
+    await extractHotUpdateZipStreamed(zipPath, temp, preflight);
+    return temp;
+  } catch (error) {
+    try {
+      if (isInsideDir(os.tmpdir(), temp) && path.basename(temp).indexOf(prefix || 'tianming-hot-') === 0) {
+        fs.rmSync(temp, { recursive: true, force: true });
+      }
+    } catch (_) {}
+    throw error;
+  }
 }
 
 function createScenarioPackFromJson(jsonPath) {
@@ -2174,7 +2229,7 @@ async function installHotUpdateFromFeed_zipFallback(feedInfo, options = {}) {
       throw new Error('hot update package sha256 mismatch');
     }
     sendHotUpdateStatus('downloaded', { version: feedInfo.version, size: fileInfo.size, sha256: fileInfo.sha256 });
-    tempDir = extractZipToTempChecked(zipPath, 'tianming-hot-');
+    tempDir = await extractZipToTempChecked(zipPath, 'tianming-hot-');
     sendHotUpdateStatus('verifying', { version: feedInfo.version });
     const installed = installHotUpdateFromBundle(tempDir, {
       feedUrl: feedInfo.feedUrl,
@@ -3866,6 +3921,9 @@ if (TEST_MODE) {
     preflightWorkshopZip,
     extractZipToTemp,
     WORKSHOP_ZIP_LIMITS,
+    preflightHotUpdateZip,
+    extractZipToTempChecked,
+    HOT_UPDATE_ZIP_LIMITS,
     verifyAuthenticatedUpdateDocument,
     getCurrentComparableVersion,
     getPackageBuildVersion,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "tianming",
       "version": "1.3.411",
       "dependencies": {
-        "adm-zip": "^0.5.17",
-        "electron-updater": "^6.8.3",
+        "adm-zip": "^0.6.0",
+        "electron-updater": "^6.8.9",
         "yauzl": "^2.10.0"
       },
       "devDependencies": {
@@ -61,9 +61,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -340,9 +340,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -671,9 +671,9 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmmirror.com/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -789,9 +789,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmmirror.com/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.14.tgz",
+      "integrity": "sha512-T4EDRUBVZYRldYApjEJiU0e1stYWaRAX7CuSnKzrpwdZKo53zGV8/pqfzV6FfwNl9YThD2OumQYvqtvjvgG7aQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -813,12 +813,12 @@
       "license": "ISC"
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmmirror.com/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmmirror.com/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -1250,16 +1250,16 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer": {
@@ -1418,9 +1418,9 @@
       "license": "MIT"
     },
     "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1762,9 +1762,9 @@
       "license": "MIT"
     },
     "node_modules/config-file-ts/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1772,9 +1772,10 @@
       }
     },
     "node_modules/config-file-ts/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmmirror.com/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2048,9 +2049,9 @@
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2414,12 +2415,12 @@
       }
     },
     "node_modules/electron-updater": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmmirror.com/electron-updater/-/electron-updater-6.8.3.tgz",
-      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
       "license": "MIT",
       "dependencies": {
-        "builder-util-runtime": "9.5.1",
+        "builder-util-runtime": "9.7.0",
         "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
@@ -2430,9 +2431,9 @@
       }
     },
     "node_modules/electron-updater/node_modules/builder-util-runtime": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmmirror.com/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
-      "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+      "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -2695,9 +2696,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2748,17 +2749,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmmirror.com/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -2933,9 +2934,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3113,9 +3114,9 @@
       "license": "ISC"
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3296,9 +3297,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmmirror.com/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3421,9 +3422,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3544,9 +3555,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmmirror.com/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -4436,9 +4447,9 @@
       "peer": true
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -5031,9 +5042,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmmirror.com/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -155,8 +155,8 @@
     "electron-builder": "^25.1.8"
   },
   "dependencies": {
-    "adm-zip": "^0.5.17",
-    "electron-updater": "^6.8.3",
+    "adm-zip": "^0.6.0",
+    "electron-updater": "^6.8.9",
     "yauzl": "^2.10.0"
   }
 }

--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-19T12:13:12.764Z",
+  "generatedAt": "2026-08-19T15:25:31.053Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -2591,8 +2591,8 @@
     },
     {
       "path": "phase8-formal-drafts.js",
-      "sha256": "1dee02ff41b5b590e1f39233095e35d29d0a7fafb9c421e07bc0b4985bf7cea0",
-      "size": 210892
+      "sha256": "6a6096d7bb0e2cdb0f5cd50ca5882f3d84807c7d6afd1a7d966b1e3dfa1a0217",
+      "size": 211230
     },
     {
       "path": "phase8-formal-map-dossier.js",
@@ -3691,8 +3691,8 @@
     },
     {
       "path": "tm-chronicle-system.js",
-      "sha256": "646684c6fbd498fb42ea0d2c06de3fe3e1d544b4ef91d62d39cffe9bb881f79a",
-      "size": 10851
+      "sha256": "839b0456f1af48c1f8259b4ab29f7d9eccde4ae6b35cc45eab24249fdde6c9d4",
+      "size": 16890
     },
     {
       "path": "tm-chronicle-tracker.js",
@@ -4006,8 +4006,8 @@
     },
     {
       "path": "tm-endturn-render.js",
-      "sha256": "36a08311472f0d4d5ddcf20e9643f6d8f532904e3143f3c7a9a5d1d2b07ba4bb",
-      "size": 32769
+      "sha256": "30feded52da0199f11713d5d51af2b34de90feedbe0290e41ec1b752cccd9710",
+      "size": 34639
     },
     {
       "path": "tm-endturn-shiji-compose.js",
@@ -5096,8 +5096,8 @@
     },
     {
       "path": "tm-save-lifecycle.js",
-      "sha256": "49cabbe8bddf3fb3af018e7426c7dbbb3f6d158c80310b6d4d591d12119dbf04",
-      "size": 107162
+      "sha256": "d030e54ce7abed09ef3920e82b3ad133062d1ac9b9f0e807d601c8e1f9510222",
+      "size": 108231
     },
     {
       "path": "tm-save-manager.js",
@@ -5156,8 +5156,8 @@
     },
     {
       "path": "tm-storage.js",
-      "sha256": "9c7cc1b75da43ad9c81c515f455f67c79b17b63ac75d5526b4a8bd6112049ac7",
-      "size": 42608
+      "sha256": "f056046c3ea4ecb573cc1aaf7fd5f0aec40e351dc002dc3cd2be508c3e971ad7",
+      "size": 45985
     },
     {
       "path": "tm-talent-backlash.js",

--- a/web/phase8-formal-drafts.js
+++ b/web/phase8-formal-drafts.js
@@ -1915,11 +1915,16 @@
   }
 
   function clearFormalEdictDrafts(){
+    var errors = [];
+    // 先清内存真值；即使后续 localStorage/DOM 清理失败，也不能让已提交诏令再次回灌下一回合。
     state.edictDraft = [];
     state.edictDrafts = {};
     state.playerAction = '';
-    clearFormalDraftStore(['edictDraft', 'edictDrafts', 'playerAction']);
-    removeFormalEdictHiddenInputs();
+    try { clearFormalDraftStore(['edictDraft', 'edictDrafts', 'playerAction']); }
+    catch (storeError) { errors.push(storeError); }
+    try { removeFormalEdictHiddenInputs(); }
+    catch (domError) { errors.push(domError); }
+    return { ok: errors.length === 0, committed: true, errors: errors };
   }
 
   function appendFormalEdictDraft(catId, block, root){

--- a/web/scripts/smoke-chronicle-world-lease.js
+++ b/web/scripts/smoke-chronicle-world-lease.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const WEB = path.resolve(__dirname, '..');
+const timeSource = fs.readFileSync(path.join(WEB, 'tm-time-utils.js'), 'utf8');
+const chronicleSource = fs.readFileSync(path.join(WEB, 'tm-chronicle-system.js'), 'utf8');
+const coreSource = fs.readFileSync(path.join(WEB, 'tm-endturn-core.js'), 'utf8');
+let assertions = 0;
+function check(value, message) {
+  if (!value) throw new Error('[smoke-chronicle-world-lease] ' + message);
+  assertions++;
+}
+function sourceBetween(source, startText, endText) {
+  const start = source.indexOf(startText);
+  const end = source.indexOf(endText, start);
+  if (start < 0 || end <= start) throw new Error('source slice missing: ' + startText);
+  return source.slice(start, end);
+}
+function clone(value) { return JSON.parse(JSON.stringify(value)); }
+function deferred() {
+  let resolve;
+  const promise = new Promise(done => { resolve = done; });
+  return { promise, resolve };
+}
+
+let daysPerTurn = 30;
+let aiCalls = 0;
+let aiQueue = [];
+const ctx = {
+  console,
+  Date,
+  Promise,
+  Object,
+  Array,
+  Number,
+  String,
+  Boolean,
+  JSON,
+  Math,
+  Error,
+  setTimeout,
+  clearTimeout,
+  deepClone: clone,
+  _getDaysPerTurn: () => daysPerTurn,
+  findScenarioById: () => ({ dynasty: '测试朝', emperor: '测试帝' }),
+  _getCharRange: () => [100, 200],
+  _charRangeText: () => '100-200字',
+  _charRangeScaled: () => '50-100字',
+  _buildTemporalConstraint: () => '',
+  extractJSON: value => typeof value === 'string' ? JSON.parse(value) : value,
+  callAI() {
+    aiCalls++;
+    const task = deferred();
+    aiQueue.push(task);
+    return task.promise;
+  },
+  _dbg() {},
+  addEB() {},
+  buildIndices() {},
+  renderGameState() {},
+  _tmLoadGen: 0,
+  TM: { errors: { capture() {} } }
+};
+ctx.window = ctx;
+vm.createContext(ctx);
+vm.runInContext(timeSource, ctx, { filename: 'tm-time-utils.js' });
+vm.runInContext(chronicleSource, ctx, { filename: 'tm-chronicle-system.js' });
+vm.runInContext(sourceBetween(coreSource, 'function _tmCaptureEndTurnObject', 'async function _tmFinalizeEndTurnTransaction'), ctx, { filename: 'tm-endturn-core-transaction.js' });
+
+function setWorld(id, time) {
+  ctx.GM = { turn: 1, sid: 'scenario-1', _campaignId: id, busy: false };
+  ctx.P = {
+    ai: { key: 'test-key' }, conf: { chronicleKeep: 10 }, chronicleConfig: {},
+    time: Object.assign({ year: 2026, startYear: 2026, startMonth: 1, startDay: 1 }, time || {})
+  };
+  ctx.ChronicleSystem.reset(ctx.GM);
+}
+
+(async function main() {
+  setWorld('calendar-start', { year: 2026, startYear: 2026, startMonth: 9, startDay: 1 });
+  daysPerTurn = 30;
+  ctx.ChronicleSystem.addMonthDraft(1, '九月首稿', '一');
+  ctx.ChronicleSystem.addMonthDraft(2, '十月次稿', '二');
+  ctx.ChronicleSystem.addMonthDraft(3, '十月末稿', '三');
+  const drafts = ctx.ChronicleSystem.serialize().monthDrafts;
+  check(Object.keys(drafts).join(',') === '1,2,3', 'same-quarter turns are retained under append-only turn keys');
+  check(drafts['1'].year === 2026 && drafts['1'].month === 9 && drafts['1'].day === 1, 'September scenario start uses canonical start month/day');
+  check(drafts['2'].month === 10 && drafts['2'].day === 1 && drafts['3'].month === 10 && drafts['3'].day === 31,
+    'turn dates follow TimeUtils instead of fixed quarter arithmetic');
+
+  const beforeRollback = ctx.ChronicleSystem.serialize();
+  const txn = ctx._tmCaptureEndTurnTransaction();
+  ctx.ChronicleSystem.addMonthDraft(4, '事务内月稿', '应回滚');
+  check(Object.keys(ctx.ChronicleSystem.monthDrafts).length === 4, 'chronicle mutation lands inside GM campaign state');
+  ctx._tmRollbackEndTurnTransaction(txn, new Error('forced later finalization failure'));
+  check(JSON.stringify(ctx.ChronicleSystem.serialize()) === JSON.stringify(beforeRollback), 'GM/P rollback also restores ChronicleSystem state');
+
+  setWorld('leap-calendar', { year: 2024, startYear: 2024, startMonth: 2, startDay: 28 });
+  daysPerTurn = 1;
+  ctx.ChronicleSystem.addMonthDraft(1, '二月廿八', '');
+  ctx.ChronicleSystem.addMonthDraft(2, '闰日', '');
+  ctx.ChronicleSystem.addMonthDraft(3, '三月初一', '');
+  const leapDrafts = ctx.ChronicleSystem.serialize().monthDrafts;
+  check(leapDrafts['2'].year === 2024 && leapDrafts['2'].month === 2 && leapDrafts['2'].day === 29,
+    'leap-year February matches canonical calendar');
+  check(leapDrafts['3'].month === 3 && leapDrafts['3'].day === 1, 'day after leap day advances to March 1');
+
+  setWorld('campaign-A', { year: 2024, startYear: 2024 });
+  daysPerTurn = 30;
+  ctx.ChronicleSystem.addMonthDraft(1, 'A局年度素材', '');
+  aiCalls = 0;
+  aiQueue = [];
+  const requestA = ctx.ChronicleSystem._tryGenerateYearChronicle(2024);
+  check(aiCalls === 1 && aiQueue.length === 1, 'annual generation starts one background request');
+  const taskA = aiQueue.shift();
+  ctx._tmLoadGen++;
+  setWorld('campaign-B', { year: 2030, startYear: 2030 });
+  taskA.resolve(JSON.stringify({ chronicle: 'A局正史', afterword: 'A局史评' }));
+  const staleA = await requestA;
+  check(staleA && staleA.stale === true && Object.keys(ctx.ChronicleSystem.yearChronicles).length === 0,
+    'late result from campaign A cannot write into loaded campaign B');
+
+  setWorld('campaign-rollback', { year: 2024, startYear: 2024 });
+  ctx.ChronicleSystem.addMonthDraft(1, '待回滚年度素材', '');
+  const beforeAsyncRollback = ctx.ChronicleSystem.serialize();
+  const asyncTxn = ctx._tmCaptureEndTurnTransaction();
+  aiQueue = [];
+  const rolledBackRequest = ctx.ChronicleSystem._tryGenerateYearChronicle(2024);
+  const rollbackTask = aiQueue.shift();
+  ctx._tmRollbackEndTurnTransaction(asyncTxn, new Error('save failed'));
+  rollbackTask.resolve(JSON.stringify({ chronicle: '不应落地', afterword: '' }));
+  const staleRollback = await rolledBackRequest;
+  check(staleRollback && staleRollback.stale === true && JSON.stringify(ctx.ChronicleSystem.serialize()) === JSON.stringify(beforeAsyncRollback),
+    'annual result returning after transaction rollback is discarded');
+
+  setWorld('campaign-dedup', { year: 2024, startYear: 2024 });
+  ctx.ChronicleSystem.addMonthDraft(1, '去重年度素材', '');
+  aiCalls = 0;
+  aiQueue = [];
+  const first = ctx.ChronicleSystem._tryGenerateYearChronicle(2024);
+  const second = ctx.ChronicleSystem._tryGenerateYearChronicle(2024);
+  check(first === second && aiCalls === 1, 'same campaign/year reuses one in-flight request');
+  aiQueue.shift().resolve(JSON.stringify({ chronicle: '唯一年度正史', afterword: '唯一史评' }));
+  const generated = await first;
+  check(generated && generated.ok === true && ctx.ChronicleSystem.yearChronicles[2024].content === '唯一年度正史',
+    'current leased annual result commits exactly once');
+
+  const detached = { _chronicleSysState: { monthDrafts: { 9: { turn: 9, year: 1999 } }, yearChronicles: {} } };
+  check(ctx.ChronicleSystem.serialize(detached).monthDrafts['9'].year === 1999,
+    'save preparation can serialize its detached GM snapshot without reading the live world');
+
+  console.log('[smoke-chronicle-world-lease] PASS assertions=' + assertions);
+})().catch(error => {
+  console.error(error && error.stack || error);
+  process.exit(1);
+});

--- a/web/scripts/smoke-postcommit-draft-cleanup.js
+++ b/web/scripts/smoke-postcommit-draft-cleanup.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const WEB = path.resolve(__dirname, '..');
+const render = fs.readFileSync(path.join(WEB, 'tm-endturn-render.js'), 'utf8');
+const formal = fs.readFileSync(path.join(WEB, 'phase8-formal-drafts.js'), 'utf8');
+let assertions = 0;
+function check(value, message) {
+  if (!value) throw new Error('[smoke-postcommit-draft-cleanup] ' + message);
+  assertions++;
+}
+function sliceFn(source, marker) {
+  const start = source.indexOf(marker);
+  if (start < 0) throw new Error('missing function: ' + marker);
+  let pos = source.indexOf('{', start), depth = 0;
+  for (; pos < source.length; pos++) {
+    if (source[pos] === '{') depth++;
+    else if (source[pos] === '}' && --depth === 0) return source.slice(start, pos + 1);
+  }
+  throw new Error('unterminated function: ' + marker);
+}
+
+const ids = ['edict-pol','edict-mil','edict-dip','edict-eco','edict-oth','xinglu','xinglu-pub','xinglu-prv'];
+const nodes = Object.fromEntries(ids.map(id => [id, { value: 'submitted-' + id }]));
+let toastText = '';
+let captured = 0;
+const ctx = {
+  console,
+  Error,
+  Array,
+  _: id => nodes[id] || null,
+  toast(text) { toastText = String(text); },
+  TM: { errors: { capture() { captured++; } } }
+};
+ctx._$ = ctx._;
+ctx.window = ctx;
+ctx.TMPhase8FormalBridge = {
+  clearEdictDrafts() {
+    return { ok: false, committed: true, errors: [new Error('injected draft-store cleanup failure')] };
+  }
+};
+vm.createContext(ctx);
+vm.runInContext(sliceFn(render, 'function _endTurn_clearCommittedInputs()'), ctx);
+const result = ctx._endTurn_clearCommittedInputs();
+check(result === false && ids.every(id => nodes[id].value === ''), 'all legacy input values are cleared even when durable UI cleanup reports an error');
+check(captured === 1 && /已经生效/.test(toastText) && /清理不完整/.test(toastText),
+  'post-commit cleanup failure is diagnostic and explicitly tells the player the edict already committed');
+
+const clearStart = formal.indexOf('function clearFormalEdictDrafts()');
+const clearBody = sliceFn(formal, 'function clearFormalEdictDrafts()');
+check(clearStart >= 0 && clearBody.indexOf('state.edictDraft = []') < clearBody.indexOf('clearFormalDraftStore'),
+  'formal bridge clears in-memory truth before fallible persistence cleanup');
+check(/return \{ ok: errors\.length === 0, committed: true, errors: errors \}/.test(clearBody),
+  'formal bridge returns an explicit committed cleanup result instead of throwing after state clear');
+
+console.log('[smoke-postcommit-draft-cleanup] PASS assertions=' + assertions);

--- a/web/scripts/smoke-runtime-save-consistency.js
+++ b/web/scripts/smoke-runtime-save-consistency.js
@@ -103,8 +103,8 @@ ok(/rotateAutoSaveSession/.test(preloadImpl) && /_tmRotateDesktopAutoSaveSession
   && /_tmRotateDesktopAutoSaveSession\('new-game'/.test(startPatch), 'preload + 读档 + 新局共同切换 auto-save session');
 ok(/stageTurnData\([\s\S]*?result\.success === true[\s\S]*?回合分卷暂存失败/.test(render)
   && /_tmCommitEndTurnTransaction[\s\S]*?await _endTurn_publishStagedTurnData/.test(core), '回合分卷先暂存并仅在世界 commit 后发布');
-ok(/function _recoverPendingTurnDataPublish\(\)[\s\S]*?recoverTurnData\(marker\)[\s\S]*?transactionId !== marker\.transactionId[\s\S]*?delete GM\._pendingTurnDataPublish/.test(lifecycle),
-  '读档按世界身份和 transactionId 租约幂等补发未发布分卷');
+ok(/function _recoverPendingTurnDataPublish\(\)[\s\S]*?function recoveryLeaseCurrent\(\)[\s\S]*?_tmLoadGen[\s\S]*?transactionId === marker\.transactionId[\s\S]*?recoverTurnData\(marker\)[\s\S]*?clearPendingTurnDataPublishAtomic\(\['autosave', 'slot_0'\][\s\S]*?delete GM\._pendingTurnDataPublish/.test(lifecycle),
+  '读档按世界身份和 transactionId 租约补发，并在双槽 checkpoint 后清除 durable marker');
 {
   const finalizerFn = sliceFn(render, 'function _endTurn_finalizeRecords(');
   const uiRenderFn = sliceFn(render, 'function _endTurn_render(');

--- a/web/scripts/smoke-security-ipc-hardening.js
+++ b/web/scripts/smoke-security-ipc-hardening.js
@@ -168,9 +168,13 @@ assert(/if\s*\(!\/\^\[0-9a-f\]\{64\}\$\/\.test\(expectedHash\)\)\s*throw/.test(S
 assert(/expectedHash !== fileInfo\.sha256/.test(SRC),
   'src· 工坊安装仍比对 expectedHash 与本地 fileInfo.sha256（修B 未回退）');
 assert(/async function extractZipToTemp\(zipPath\)\s*\{[\s\S]*?await preflightWorkshopZip\(zipPath\)[\s\S]*?createTempDir\('tianming-pack-'\)/.test(SRC)
-  && SRC.includes('WORKSHOP_ZIP_LIMITS.maxCompressionRatio') && SRC.includes('压缩包包含重复路径')
-  && /extractWorkshopZipStreamed[\s\S]*?isInsideDir\(temp, target\)/.test(SRC),
+  && SRC.includes('WORKSHOP_ZIP_LIMITS') && SRC.includes('maxCompressionRatio') && SRC.includes('压缩包包含重复路径')
+  && /extractCheckedZipStreamed[\s\S]*?isInsideDir\(temp, target\)/.test(SRC),
   'src· 工坊 ZIP 在创建输出目录前预检总量/压缩比/重复路径，并在流式解压时复验 zip-slip');
+assert(/async function extractZipToTempChecked\(zipPath, prefix\)\s*\{[\s\S]*?await preflightHotUpdateZip\(zipPath\)[\s\S]*?await extractHotUpdateZipStreamed/.test(SRC)
+  && /tempDir = await extractZipToTempChecked\(zipPath/.test(SRC)
+  && !/require\(['"]adm-zip['"]\)/.test(SRC),
+  'src· 生产热更新 ZIP 同样先预检再有界流式解压，且不再调用 adm-zip');
 assert(/BLOCKED_PACK_EXTS\.has\(ext\)[\s\S]*?ALLOWED_PACK_EXTS\.has\(ext\)/.test(SRC),
   'src· validateWorkshopPack 仍走 BLOCKED+ALLOWED 双白名单（hash 只保完整性·安全靠此层）');
 assert(/sha256:\s*inlineHash\.digest\('hex'\)/.test(SRC) && /sha256FileStream\(dest\)/.test(SRC) && /sha256:\s*sha256File\(dest\)/.test(SRC),

--- a/web/scripts/smoke-security-trust-boundary.js
+++ b/web/scripts/smoke-security-trust-boundary.js
@@ -201,9 +201,29 @@ async function main() {
     'valid workshop ZIP is extracted entry-by-entry after preflight');
   fs.rmSync(extractedSafe, { recursive: true, force: true });
 
+  const hotBombPath = path.join(TMP, 'hot-size-header-bomb.zip');
+  const hotBombZip = new AdmZip();
+  hotBombZip.addFile('index.html', Buffer.from('<!doctype html>'));
+  const hotBombBytes = hotBombZip.toBuffer();
+  const centralHeader = hotBombBytes.indexOf(Buffer.from([0x50, 0x4b, 0x01, 0x02]));
+  check(centralHeader >= 0, 'hot-update fixture contains a central-directory header');
+  // 0xffffffff is the ZIP64 sentinel; use 4GB-2 so the parser exposes the malicious declared size
+  // to our quota validator without requiring a ZIP64 extra field.
+  hotBombBytes.writeUInt32LE(0xfffffffe, centralHeader + 24);
+  fs.writeFileSync(hotBombPath, hotBombBytes);
+  const hotTempsBefore = new Set(fs.readdirSync(os.tmpdir()).filter(name => name.startsWith('tianming-hot-')));
+  let hotBombError = null;
+  try { await T.extractZipToTempChecked(hotBombPath, 'tianming-hot-'); } catch (error) { hotBombError = error; }
+  const hotTempsAfter = fs.readdirSync(os.tmpdir()).filter(name => name.startsWith('tianming-hot-'));
+  check(hotBombError && /声明解压体积|单文件声明解压体积|ZIP 炸弹/.test(hotBombError.message),
+    'hot-update ZIP with a 4GB declared size is rejected during central-directory preflight; actual=' + String(hotBombError && hotBombError.message));
+  check(hotTempsAfter.every(name => hotTempsBefore.has(name)), 'rejected hot-update ZIP allocates no extraction directory');
+
   const mainSource = fs.readFileSync(path.join(ROOT, 'main-impl.js'), 'utf8');
   const preloadSource = fs.readFileSync(path.join(ROOT, 'preload-impl.js'), 'utf8');
   const builderSource = fs.readFileSync(path.join(ROOT, 'web', 'tools', 'build-hot-update-package.js'), 'utf8');
+  const packageJson = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+  const packageLock = JSON.parse(fs.readFileSync(path.join(ROOT, 'package-lock.json'), 'utf8'));
   check(mainSource.includes("redirect: 'manual'") && mainSource.includes('dns.lookup(hostname, { all: true')
     && mainSource.includes("credentials: 'omit'") && mainSource.includes("referrerPolicy: 'no-referrer'"), 'network proxy revalidates DNS/redirects and omits ambient credentials');
   check(mainSource.includes('WORKSHOP_CATALOG_AUTHORIZATIONS.get(packageUrl)')
@@ -212,6 +232,19 @@ async function main() {
     && !/checkForUpdate:\s*\([^)]*feedUrl/.test(preloadSource), 'renderer bridge cannot provide ordinary/hot update feed URLs');
   check(!builderSource.includes("addLocalFile(path.join(APP_ROOT, 'main")
     && !builderSource.includes("addLocalFile(path.join(APP_ROOT, 'preload"), 'content OTA builder cannot package main/preload executable code');
+  check(!/require\(['"]adm-zip['"]\)/.test(mainSource)
+    && /tempDir = await extractZipToTempChecked\(/.test(mainSource)
+    && /preflightHotUpdateZip\(zipPath\)/.test(mainSource),
+  'production hot-update extraction uses awaited bounded yauzl streaming instead of adm-zip');
+  check(/^\^?0\.6\./.test(packageJson.dependencies['adm-zip'])
+    && packageLock.packages['node_modules/adm-zip'].version === '0.6.0',
+  'remaining build-time adm-zip tooling is pinned to the patched 0.6 line');
+  check(/^\^?6\.8\.9$/.test(packageJson.dependencies['electron-updater'])
+    && packageLock.packages['node_modules/electron-updater'].version === '6.8.9'
+    && packageLock.packages['node_modules/electron-updater/node_modules/builder-util-runtime'].version === '9.7.0',
+  'runtime updater stack includes the cross-origin credential redirect fix');
+  check(packageLock.packages['node_modules/js-yaml'].version === '4.3.1',
+  'runtime YAML parser includes the merge-key and omap complexity fixes');
 
   // 打包进程即使继承测试环境变量，也不得暴露任何测试出口。
   electronStub.app.isPackaged = true;

--- a/web/scripts/smoke-storage-atomic-batch.js
+++ b/web/scripts/smoke-storage-atomic-batch.js
@@ -16,7 +16,7 @@ function check(value, message) {
 }
 function clone(value) { return value == null ? value : JSON.parse(JSON.stringify(value)); }
 
-function makeLocalStorage(initial, failKey) {
+function makeLocalStorage(initial, failKey, failureName) {
   const rows = new Map(Object.entries(initial || {}).map(([k, v]) => [k, String(v)]));
   let failed = false;
   return {
@@ -25,14 +25,19 @@ function makeLocalStorage(initial, failKey) {
     key(i) { return Array.from(rows.keys())[i] || null; },
     getItem(k) { return rows.has(String(k)) ? rows.get(String(k)) : null; },
     setItem(k, v) {
-      if (!failed && failKey && String(k) === failKey) { failed = true; throw new Error('injected-local-write-failure'); }
+      if (!failed && failKey && String(k) === failKey) {
+        failed = true;
+        const error = new Error('injected-local-write-failure');
+        error.name = failureName || 'Error';
+        throw error;
+      }
       rows.set(String(k), String(v));
     },
     removeItem(k) { rows.delete(String(k)); }
   };
 }
 
-function makeIndexedDB(initial, failPutAt) {
+function makeIndexedDB(initial, failPutAt, failureName) {
   const stores = new Map([
     ['saves', new Map(Object.entries(initial && initial.saves || {}).map(([k, v]) => [k, clone(v)]))],
     ['saveMetadata', new Map(Object.entries(initial && initial.saveMetadata || {}).map(([k, v]) => [k, clone(v)]))],
@@ -63,6 +68,7 @@ function makeIndexedDB(initial, failPutAt) {
       setTimeout(() => {
         if (failPutAt && pending.some(op => op.putNo === failPutAt)) {
           tx.error = new Error('injected-idb-write-failure');
+          tx.error.name = failureName || 'Error';
           if (tx.onabort) tx.onabort({ target: { error: tx.error } });
           return;
         }
@@ -133,6 +139,62 @@ function makeContext(indexedDB, localStorage) {
   check(rejected && failingIdb.stores.get('saves').get('autosave').gameState === 'old-auto' && failingIdb.stores.get('saves').get('slot_0').gameState === 'old-slot',
     'an injected second-slot failure aborts the complete IndexedDB batch');
 
+  const quotaInitial = {
+    saves: {
+      autosave: { id: 'autosave', type: 'auto', gameState: 'old-auto' },
+      slot_0: { id: 'slot_0', type: 'auto', gameState: 'old-slot' },
+      older_auto_1: { id: 'older_auto_1', type: 'auto', gameState: 'disposable' }
+    },
+    saveMetadata: {
+      autosave: { id: 'autosave', type: 'auto', turn: 49, timestamp: 20 },
+      slot_0: { id: 'slot_0', type: 'auto', turn: 49, timestamp: 20 },
+      older_auto_1: { id: 'older_auto_1', type: 'auto', turn: 12, timestamp: 1 }
+    }
+  };
+  const quotaIdb = makeIndexedDB(quotaInitial, 1, 'QuotaExceededError');
+  const quotaCtx = makeContext(quotaIdb, makeLocalStorage());
+  await quotaCtx.TM_SaveDB.open();
+  const quotaSaved = await quotaCtx.TM_SaveDB.saveManyAtomic([
+    { id: 'autosave', gameState: state, meta: { type: 'auto', turn: 50 } },
+    { id: 'slot_0', gameState: state, meta: { type: 'auto', turn: 50 } }
+  ]);
+  check(quotaSaved === true && !quotaIdb.stores.get('saves').has('older_auto_1'),
+    'quota failure aborts the batch, deletes one disposable old auto save, then retries once');
+  check(JSON.parse(quotaIdb.stores.get('saves').get('autosave').gameState).GM.turn === 50
+    && JSON.parse(quotaIdb.stores.get('saves').get('slot_0').gameState).GM.turn === 50,
+  'quota recovery still advances both canonical slots together');
+
+  const noDisposableIdb = makeIndexedDB({ saves: { autosave: oldAuto, slot_0: oldSlot }, saveMetadata: {
+    autosave: { id: 'autosave', type: 'auto', turn: 49, timestamp: 1 },
+    slot_0: { id: 'slot_0', type: 'auto', turn: 49, timestamp: 1 }
+  } }, 1, 'QuotaExceededError');
+  const noDisposableCtx = makeContext(noDisposableIdb, makeLocalStorage());
+  await noDisposableCtx.TM_SaveDB.open();
+  const noDisposableSaved = await noDisposableCtx.TM_SaveDB.saveManyAtomic([
+    { id: 'autosave', gameState: state, meta: { type: 'auto', turn: 50 } },
+    { id: 'slot_0', gameState: state, meta: { type: 'auto', turn: 50 } }
+  ]);
+  check(noDisposableSaved === false
+    && noDisposableIdb.stores.get('saves').get('autosave').gameState === 'old-auto'
+    && noDisposableIdb.stores.get('saves').get('slot_0').gameState === 'old-slot',
+  'quota recovery never deletes either canonical slot when no disposable auto save exists');
+
+  const marker = { transactionId: 'turn-marker-12345678', campaignId: 'campaign-1', turn: 50 };
+  const markerState = { GM: { turn: 51, _pendingTurnDataPublish: marker }, P: {} };
+  const markerIdb = makeIndexedDB({ saves: {
+    autosave: { id: 'autosave', type: 'auto', turn: 51, gameState: JSON.stringify(markerState), _compressed: false },
+    slot_0: { id: 'slot_0', type: 'auto', turn: 51, gameState: JSON.stringify(markerState), _compressed: false }
+  }, saveMetadata: {
+    autosave: { id: 'autosave', type: 'auto', turn: 51 }, slot_0: { id: 'slot_0', type: 'auto', turn: 51 }
+  } });
+  const markerCtx = makeContext(markerIdb, makeLocalStorage());
+  await markerCtx.TM_SaveDB.open();
+  const markerCleared = await markerCtx.TM_SaveDB.clearPendingTurnDataPublishAtomic(['autosave', 'slot_0'], marker.transactionId);
+  const clearedAuto = await markerCtx.TM_SaveDB.load('autosave');
+  const clearedSlot = await markerCtx.TM_SaveDB.load('slot_0');
+  check(markerCleared === true && !clearedAuto.gameState.GM._pendingTurnDataPublish && !clearedSlot.gameState.GM._pendingTurnDataPublish,
+    'successful turn-data publish checkpoint clears both canonical markers atomically');
+
   const keys = {
     auto: 'tm_idb_saves_autosave', autoMeta: 'tm_idb_saveMetadata_autosave',
     slot: 'tm_idb_saves_slot_0', slotMeta: 'tm_idb_saveMetadata_slot_0'
@@ -150,6 +212,29 @@ function makeContext(indexedDB, localStorage) {
   } catch (_) { rejected = true; }
   check(rejected && Object.entries(initial).every(([k, v]) => local.getItem(k) === v), 'localStorage failure restores all four prior values');
   check(local.getItem('tm_save_batch_journal_v1') === null, 'successful rollback removes the local batch journal');
+
+  const localQuotaInitial = {
+    [keys.auto]: JSON.stringify({ id: 'autosave', type: 'auto', name: 'old auto', timestamp: 20, turn: 49, gameState: JSON.stringify({ GM: { turn: 49 }, P: {} }) }),
+    [keys.autoMeta]: JSON.stringify({ id: 'autosave', type: 'auto', name: 'old auto', turn: 49, timestamp: 20 }),
+    [keys.slot]: JSON.stringify({ id: 'slot_0', type: 'auto', name: 'old slot', timestamp: 20, turn: 49, gameState: JSON.stringify({ GM: { turn: 49 }, P: {} }) }),
+    [keys.slotMeta]: JSON.stringify({ id: 'slot_0', type: 'auto', name: 'old slot', turn: 49, timestamp: 20 }),
+    tm_idb_saves_older_auto_1: JSON.stringify({ id: 'older_auto_1', type: 'auto', gameState: '{}' }),
+    tm_idb_saveMetadata_older_auto_1: JSON.stringify({ id: 'older_auto_1', type: 'auto', turn: 12, timestamp: 1 })
+  };
+  const localQuota = makeLocalStorage(localQuotaInitial, keys.slotMeta, 'QuotaExceededError');
+  const localQuotaCtx = makeContext(null, localQuota);
+  await localQuotaCtx.TM_SaveDB.open();
+  const localQuotaSaved = await localQuotaCtx.TM_SaveDB.saveManyAtomic([
+    { id: 'autosave', gameState: state, meta: { type: 'auto', turn: 50 } },
+    { id: 'slot_0', gameState: state, meta: { type: 'auto', turn: 50 } }
+  ]);
+  check(localQuotaSaved === true
+    && localQuota.getItem('tm_idb_saves_older_auto_1') === null
+    && localQuota.getItem('tm_idb_saveMetadata_older_auto_1') === null,
+  'localStorage quota recovery restores the batch, removes one disposable auto save, and retries once');
+  check(JSON.parse(JSON.parse(localQuota.getItem(keys.auto)).gameState).GM.turn === 50
+    && JSON.parse(JSON.parse(localQuota.getItem(keys.slot)).gameState).GM.turn === 50,
+  'localStorage quota recovery still advances both canonical slots together');
 
   const preparedItems = Object.entries(initial).map(([key, previous]) => ({ key, previous }));
   const crashLocal = makeLocalStorage(Object.assign({}, initial, {

--- a/web/tm-chronicle-system.js
+++ b/web/tm-chronicle-system.js
@@ -3,7 +3,7 @@
 // ============================================================
 // tm-chronicle-system.js — 编年史系统
 //
-// R89 从 tm-endturn.js 抽出·单一对象字面量
+// R89 从 tm-endturn.js 抽出·战役状态随 GM 持久化，对象本身只提供操作服务
 //   原位置 L3282-3486 (205 行)
 //
 // 依赖外部：_getDaysPerTurn / callAI / extractJSON / _dbg / addEB （均为 window 全局）
@@ -12,72 +12,179 @@
 // 加载顺序：必须在 tm-endturn.js 之前（index.html 顺序已调整）
 // ============================================================
 
+function _chronicleEmptyState() {
+  return { version: 2, monthDrafts: {}, yearChronicles: {} };
+}
+
+var _chronicleDetachedState = _chronicleEmptyState();
+
+function _chronicleState(targetGM, create) {
+  var owner = targetGM || ((typeof GM !== 'undefined' && GM) ? GM : null);
+  if (!owner) return _chronicleDetachedState;
+  var state = owner._chronicleSysState;
+  if (!state || typeof state !== 'object' || Array.isArray(state)) {
+    if (!create) return null;
+    state = _chronicleEmptyState();
+    owner._chronicleSysState = state;
+  }
+  if (!state.monthDrafts || typeof state.monthDrafts !== 'object' || Array.isArray(state.monthDrafts)) state.monthDrafts = {};
+  if (!state.yearChronicles || typeof state.yearChronicles !== 'object' || Array.isArray(state.yearChronicles)) state.yearChronicles = {};
+  state.version = 2;
+  return state;
+}
+
+function _chronicleCloneState(data) {
+  var source = data && typeof data === 'object' ? data : _chronicleEmptyState();
+  try {
+    var cloned = JSON.parse(JSON.stringify(source));
+    if (!cloned || typeof cloned !== 'object') return _chronicleEmptyState();
+    if (!cloned.monthDrafts || typeof cloned.monthDrafts !== 'object' || Array.isArray(cloned.monthDrafts)) cloned.monthDrafts = {};
+    if (!cloned.yearChronicles || typeof cloned.yearChronicles !== 'object' || Array.isArray(cloned.yearChronicles)) cloned.yearChronicles = {};
+    cloned.version = 2;
+    return cloned;
+  } catch (_) {
+    return _chronicleEmptyState();
+  }
+}
+
+function _chronicleDateForTurn(turn) {
+  if (typeof TimeUtils !== 'undefined' && TimeUtils && typeof TimeUtils.turnToDate === 'function') {
+    var canonical = TimeUtils.turnToDate(turn);
+    return {
+      year: Number(canonical.year), month: Number(canonical.month), day: Number(canonical.day),
+      season: canonical.season || '', monthLabel: canonical.monthLabel || String(canonical.month || '')
+    };
+  }
+  if (typeof calcDateFromTurn === 'function') {
+    var legacy = calcDateFromTurn(turn);
+    return {
+      year: Number(legacy.adYear), month: Number(legacy.solarMonth), day: Number(legacy.solarDay),
+      season: legacy.season || '', monthLabel: String(legacy.solarMonth || '')
+    };
+  }
+  return null;
+}
+
+function _chronicleDraftLimit() {
+  var keepYears = Number(P && P.conf && P.conf.chronicleKeep);
+  if (!isFinite(keepYears) || keepYears <= 0) keepYears = 10;
+  var daysPerTurn = Number(typeof _getDaysPerTurn === 'function' ? _getDaysPerTurn() : 30);
+  if (!isFinite(daysPerTurn) || daysPerTurn <= 0) daysPerTurn = 30;
+  return Math.max(12, Math.ceil(366 / daysPerTurn)) * Math.floor(keepYears);
+}
+
+function _chronicleRequestId() {
+  ChronicleSystem._requestSeq = (ChronicleSystem._requestSeq || 0) + 1;
+  return 'chronicle-' + Date.now() + '-' + ChronicleSystem._requestSeq;
+}
+
 var ChronicleSystem = {
-  monthDrafts: {},  // key: 'year-month', value: {summary, events}
-  yearChronicles: {},  // key: 'year', value: {content, afterword, read}
+  _inFlight: [],
+  _requestSeq: 0,
+
+  // 兼容旧消费者的属性访问；真正数据始终落在当前 GM._chronicleSysState。
+  get monthDrafts() { return _chronicleState(null, true).monthDrafts; },
+  set monthDrafts(value) { _chronicleState(null, true).monthDrafts = (value && typeof value === 'object' && !Array.isArray(value)) ? value : {}; },
+  get yearChronicles() { return _chronicleState(null, true).yearChronicles; },
+  set yearChronicles(value) { _chronicleState(null, true).yearChronicles = (value && typeof value === 'object' && !Array.isArray(value)) ? value : {}; },
 
   /** 记录本回合摘要（每回合末调用） */
   addMonthDraft: function(turn, shizhengji, zhengwen) {
-    if (!P.time) return;
-    var t = P.time;
-    var _dpv = _getDaysPerTurn();
-    var totalDays = (turn - 1) * _dpv;
-    var yo = Math.floor(totalDays / 365);
-    var year = (t.year||0) + yo;
-    var seasonIdx = Math.floor((totalDays % 365) / 91.25); // 0-3
-    var season = Math.min(seasonIdx, (t.seasons||[]).length - 1);
-    var key = year + '-' + season;
+    if (!P || !P.time) return null;
+    turn = Number(turn);
+    if (!Number.isSafeInteger(turn) || turn < 1) return null;
+    var date = _chronicleDateForTurn(turn);
+    if (!date || !isFinite(date.year)) return null;
+    var state = _chronicleState(null, true);
+    var key = String(turn);
 
-    ChronicleSystem.monthDrafts[key] = {
+    state.monthDrafts[key] = {
       turn: turn,
-      year: year,
-      season: season,
+      year: date.year,
+      month: date.month,
+      day: date.day,
+      season: date.season,
+      monthLabel: date.monthLabel,
       summary: (shizhengji || '').substring(0, 300),
       narrative: (zhengwen || '').substring(0, 200),
       timestamp: Date.now()
     };
 
-    // 限制月度摘要数量（保留最近 N 个月，N = chronicleKeep * 12）
-    var draftKeys = Object.keys(ChronicleSystem.monthDrafts);
-    var maxDrafts = ((P.conf && P.conf.chronicleKeep) || 10) * 12;
+    // 每回合一份、同一回合幂等覆盖；按回合号裁剪，不能再以季度键吞掉同季多回合。
+    var draftKeys = Object.keys(state.monthDrafts);
+    var maxDrafts = _chronicleDraftLimit();
     if (draftKeys.length > maxDrafts) {
-      draftKeys.sort();
+      draftKeys.sort(function(a, b) {
+        return Number(state.monthDrafts[a] && state.monthDrafts[a].turn || 0) - Number(state.monthDrafts[b] && state.monthDrafts[b].turn || 0);
+      });
       var toRemove = draftKeys.slice(0, draftKeys.length - maxDrafts);
-      toRemove.forEach(function(k) { delete ChronicleSystem.monthDrafts[k]; });
+      toRemove.forEach(function(k) { delete state.monthDrafts[k]; });
     }
 
-    // 检查是否年末（累计天数跨年）
-    if (typeof isYearBoundary === 'function' && isYearBoundary()) {
-      ChronicleSystem._tryGenerateYearChronicle(year);
+    // 使用统一历法判断“本回合结束后跨年”，不复制固定 365/91.25 天公式。
+    var nextDate = _chronicleDateForTurn(turn + 1);
+    if (nextDate && nextDate.year > date.year) {
+      ChronicleSystem._tryGenerateYearChronicle(date.year);
     }
+    return state.monthDrafts[key];
   },
 
   /** 尝试生成年度正史（异步，不阻塞游戏） */
   _tryGenerateYearChronicle: function(year) {
-    if (ChronicleSystem.yearChronicles[year]) return; // 已生成
-    if (!P.ai.key) return; // 无 AI 跳过
+    year = Number(year);
+    if (!isFinite(year)) return Promise.resolve({ ok: false, reason: 'invalid-year' });
+    var targetGM = (typeof GM !== 'undefined') ? GM : null;
+    var targetP = (typeof P !== 'undefined') ? P : null;
+    var targetState = _chronicleState(targetGM, true);
+    if (!targetGM || !targetP || !targetState) return Promise.resolve({ ok: false, reason: 'missing-world' });
+    if (targetState.yearChronicles[year]) return Promise.resolve({ ok: true, existing: true });
+    if (!(targetP.ai && targetP.ai.key)) return Promise.resolve({ ok: false, reason: 'missing-ai' });
+
+    var existing = ChronicleSystem._inFlight.find(function(item) {
+      return item && item.stateRef === targetState && item.year === year;
+    });
+    if (existing) return existing.promise;
 
     // 收集该年所有月度摘要
     var drafts = [];
-    Object.keys(ChronicleSystem.monthDrafts).forEach(function(key) {
-      var d = ChronicleSystem.monthDrafts[key];
+    Object.keys(targetState.monthDrafts).forEach(function(key) {
+      var d = targetState.monthDrafts[key];
       if (d.year === year) drafts.push(d);
     });
-    if (drafts.length === 0) return;
+    if (drafts.length === 0) return Promise.resolve({ ok: false, reason: 'missing-drafts' });
 
     drafts.sort(function(a, b) { return a.turn - b.turn; });
 
+    var lease = {
+      requestId: _chronicleRequestId(),
+      gmRef: targetGM,
+      pRef: targetP,
+      stateRef: targetState,
+      campaignId: String(targetGM._campaignId || ''),
+      loadGen: (typeof window !== 'undefined' && window._tmLoadGen) || 0,
+      year: year,
+      promise: null
+    };
+    function leaseIsCurrent() {
+      return typeof GM !== 'undefined' && typeof P !== 'undefined' &&
+        GM === lease.gmRef && P === lease.pRef &&
+        (((typeof window !== 'undefined' && window._tmLoadGen) || 0) === lease.loadGen) &&
+        String((GM && GM._campaignId) || '') === lease.campaignId &&
+        _chronicleState(lease.gmRef, false) === lease.stateRef &&
+        ChronicleSystem._inFlight.some(function(item) { return item && item.requestId === lease.requestId; });
+    }
+
     // 构建 AI prompt（不硬编码朝代，从 P 中读取）
-    var sc = findScenarioById(GM.sid);
+    var sc = findScenarioById(targetGM.sid);
     var dynasty = sc ? sc.dynasty || sc.era || '' : '';
     var emperor = sc ? sc.emperor || sc.role || '' : '';
     var prevAfterword = '';
-    if (ChronicleSystem.yearChronicles[year - 1]) {
-      prevAfterword = ChronicleSystem.yearChronicles[year - 1].afterword || '';
+    if (targetState.yearChronicles[year - 1]) {
+      prevAfterword = targetState.yearChronicles[year - 1].afterword || '';
     }
 
     // 编年史风格（从chronicleConfig读取）
-    var _ccfg = P.chronicleConfig || {};
+    var _ccfg = targetP.chronicleConfig || {};
     var _style = _ccfg.style || 'biannian';
     var _styleGuide = {
       biannian: '编年体（仿《资治通鉴》），以时间为纲，逐月叙事，客观冷静。',
@@ -100,8 +207,8 @@ var ChronicleSystem = {
     if (emperor) prompt += '当朝天子/主角：' + emperor + '\n';
     if (prevAfterword) prompt += '上年史评：' + prevAfterword + '\n';
     // 6.1联动：注入该年回收的伏笔因果链
-    if (GM._foreshadowings) {
-      var _yearResolved = GM._foreshadowings.filter(function(f) {
+    if (targetGM._foreshadowings) {
+      var _yearResolved = targetGM._foreshadowings.filter(function(f) {
         return f.resolved && f.resolveTurn && (typeof calcDateFromTurn === 'function') &&
           calcDateFromTurn(f.resolveTurn) && calcDateFromTurn(f.resolveTurn).adYear === year;
       });
@@ -113,13 +220,13 @@ var ChronicleSystem = {
       }
     }
     // 6.5联动：注入每回合一句话摘要
-    if (GM._yearlyDigest && GM._yearlyDigest.length > 0) {
+    if (targetGM._yearlyDigest && targetGM._yearlyDigest.length > 0) {
       prompt += '\n\u672C\u5E74\u5404\u56DE\u5408\u4E00\u53E5\u8BDD\u6458\u8981\uFF1A\n';
-      GM._yearlyDigest.forEach(function(d) { prompt += 'T' + d.turn + ': ' + d.summary + '\n'; });
+      targetGM._yearlyDigest.forEach(function(d) { prompt += 'T' + d.turn + ': ' + d.summary + '\n'; });
     }
     // 6.7联动：本年度下达诏令+其后续影响（colorEdicts + _chainEffects）
-    if (GM._edictTracker && GM._edictTracker.length > 0) {
-      var _yearEdicts = GM._edictTracker.filter(function(e) {
+    if (targetGM._edictTracker && targetGM._edictTracker.length > 0) {
+      var _yearEdicts = targetGM._edictTracker.filter(function(e) {
         if (!e || !e.turn) return false;
         var _d = (typeof calcDateFromTurn === 'function') ? calcDateFromTurn(e.turn) : null;
         return _d && _d.adYear === year;
@@ -144,10 +251,10 @@ var ChronicleSystem = {
         prompt += '  \u203B \u7F16\u5E74\u4E2D\u8BE5\u4EE5\u300C\u8BCFXX\u300D\u300C\u884C\u81F3X\u6708\u67D0\u65E5\uFF0CXX\u4E8B\u5E94\u300D\u7B49\u53E5\u5F0F\uFF0C\u5C06\u8BCF\u4EE4\u9881\u5E03\u2014\u6267\u884C\u2014\u4F59\u6CE2\u7ED3\u6210\u56E0\u679C\u94FE\uFF0C\u4E0D\u53EF\u53EA\u63D0\u9881\u5E03\u800C\u4E0D\u63D0\u7ED3\u679C\n';
       }
     }
-    prompt += '\n\u5404\u5B63\u6458\u8981\uFF1A\n';
+    prompt += '\n\u5404\u56DE\u5408\u6458\u8981\uFF1A\n';
     drafts.forEach(function(d) {
-      var seasonName = (P.time.seasons || ['\u6625','\u590F','\u79CB','\u51AC'])[d.season] || '';
-      prompt += '\u3010' + seasonName + '\u3011' + d.summary + '\n';
+      var dateLabel = d.year + '\u5E74' + (d.monthLabel || d.month || '') + '\u6708' + (d.day ? d.day + '\u65E5' : '');
+      prompt += '\u3010T' + d.turn + '\u00B7' + dateLabel + '\u3011' + d.summary + '\n';
     });
     prompt += '\n请返回 JSON: {"chronicle":"正史正文' + _charRangeText('chronicle') + '","afterword":"史评/论赞' + _charRangeScaled('comment', 1.0) + '"}';
 
@@ -155,14 +262,22 @@ var ChronicleSystem = {
     if (typeof _buildTemporalConstraint === 'function') { try { prompt += '\n' + _buildTemporalConstraint(null, {}); } catch (_) {} }
 
     // 异步生成，不阻塞；年度编年不应抢占玩家正在等待的主推演通道。
-    callAI(prompt, 1500, null, 'primary', {
-      priority: 'background',
-      timeoutMs: 60000,
-      maxRetries: 1
-    }).then(function(result) {
+    var request;
+    try {
+      request = callAI(prompt, 1500, null, 'primary', {
+        priority: 'background',
+        timeoutMs: 60000,
+        maxRetries: 1
+      });
+    } catch (syncError) {
+      (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(syncError, 'Chronicle') : console.warn('[Chronicle] 年度正史生成失败:', syncError);
+      return Promise.resolve({ ok: false, error: syncError });
+    }
+    lease.promise = Promise.resolve(request).then(function(result) {
+      if (!leaseIsCurrent()) return { ok: false, stale: true };
       var parsed = extractJSON(result);
       if (parsed) {
-        ChronicleSystem.yearChronicles[year] = {
+        targetState.yearChronicles[year] = {
           content: parsed.chronicle || result,
           afterword: parsed.afterword || '',
           read: false,
@@ -172,19 +287,28 @@ var ChronicleSystem = {
         };
 
         // 限制年度正史数量
-        var yearKeys = Object.keys(ChronicleSystem.yearChronicles);
-        var maxYears = ((P.conf && P.conf.chronicleKeep) || 10) * 2;
+        var yearKeys = Object.keys(targetState.yearChronicles);
+        var maxYears = ((targetP.conf && targetP.conf.chronicleKeep) || 10) * 2;
         if (yearKeys.length > maxYears) {
           yearKeys.sort(function(a,b){return a-b;});
           var removeYears = yearKeys.slice(0, yearKeys.length - maxYears);
-          removeYears.forEach(function(k) { delete ChronicleSystem.yearChronicles[k]; });
+          removeYears.forEach(function(k) { delete targetState.yearChronicles[k]; });
         }
 
         _dbg('[Chronicle] 年度正史生成完成:', year);
         if (typeof addEB === 'function') addEB('正史', year + '年编年史已完成');
+        return { ok: true, year: year };
       }
+      return { ok: false, reason: 'invalid-result' };
     }).catch(function(e) {
-      (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'Chronicle') : console.warn('[Chronicle] 年度正史生成失败:', e); });
+      (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'Chronicle') : console.warn('[Chronicle] 年度正史生成失败:', e);
+      return { ok: false, error: e };
+    }).then(function(outcome) {
+      ChronicleSystem._inFlight = ChronicleSystem._inFlight.filter(function(item) { return item && item.requestId !== lease.requestId; });
+      return outcome;
+    });
+    ChronicleSystem._inFlight.push(lease);
+    return lease.promise;
   },
 
   /** 获取年度正史（UI 用） */
@@ -205,23 +329,21 @@ var ChronicleSystem = {
   },
 
   /** 序列化（存档用） */
-  serialize: function() {
-    return {
-      monthDrafts: ChronicleSystem.monthDrafts,
-      yearChronicles: ChronicleSystem.yearChronicles
-    };
+  serialize: function(targetGM) {
+    return _chronicleCloneState(_chronicleState(targetGM, false));
   },
 
   /** 反序列化（读档用） */
-  deserialize: function(data) {
-    if (!data) return;
-    ChronicleSystem.monthDrafts = data.monthDrafts || {};
-    ChronicleSystem.yearChronicles = data.yearChronicles || {};
+  deserialize: function(data, targetGM) {
+    var owner = targetGM || ((typeof GM !== 'undefined' && GM) ? GM : null);
+    var next = _chronicleCloneState(data);
+    if (owner) owner._chronicleSysState = next;
+    else _chronicleDetachedState = next;
+    return next;
   },
 
   /** 重置 */
-  reset: function() {
-    ChronicleSystem.monthDrafts = {};
-    ChronicleSystem.yearChronicles = {};
+  reset: function(targetGM) {
+    return ChronicleSystem.deserialize(null, targetGM);
   }
 };

--- a/web/tm-endturn-render.js
+++ b/web/tm-endturn-render.js
@@ -93,9 +93,27 @@ async function _endTurn_publishStagedTurnData(ctx) {
   var marker = ctx && ctx.meta && ctx.meta.stagedTurnData;
   if (!marker) return true;
   if (!(window.tianming && typeof window.tianming.publishTurnData === 'function')) throw new Error('桌面回合分卷发布接口缺失');
+  var targetGM = GM;
+  var targetP = P;
+  var targetLoadGen = (typeof window !== 'undefined' && window._tmLoadGen) || 0;
+  function publishLeaseCurrent() {
+    return GM === targetGM && P === targetP &&
+      (((typeof window !== 'undefined' && window._tmLoadGen) || 0) === targetLoadGen) &&
+      String((GM && GM._campaignId) || '') === String(marker.campaignId || '');
+  }
   var result = await window.tianming.publishTurnData(marker);
   if (!(result && result.success === true)) throw new Error('回合分卷发布失败' + (result && result.error ? '：' + result.error : ''));
-  if (GM && GM._pendingTurnDataPublish && GM._pendingTurnDataPublish.transactionId === marker.transactionId) delete GM._pendingTurnDataPublish; // arch-ok: publish owns its committed marker cleanup
+  if (!publishLeaseCurrent()) throw new Error('回合分卷发布完成时世界身份已变化');
+  if (targetGM._pendingTurnDataPublish && targetGM._pendingTurnDataPublish.transactionId === marker.transactionId) delete targetGM._pendingTurnDataPublish; // arch-ok: publish owns its committed marker cleanup
+  if (!(typeof TM_SaveDB !== 'undefined' && typeof TM_SaveDB.clearPendingTurnDataPublishAtomic === 'function')) {
+    targetGM._pendingTurnDataPublish = deepClone(marker); // arch-ok: keep recoverable receipt when durable checkpoint is unavailable
+    throw new Error('回合分卷发布标记 checkpoint 接口缺失');
+  }
+  var cleared = await TM_SaveDB.clearPendingTurnDataPublishAtomic(['autosave', 'slot_0'], marker.transactionId, { writeGuard: publishLeaseCurrent });
+  if (cleared !== true) {
+    if (publishLeaseCurrent()) targetGM._pendingTurnDataPublish = deepClone(marker); // arch-ok: failed checkpoint remains idempotently recoverable
+    throw new Error('回合分卷已发布，但 canonical 标记清理失败');
+  }
   ctx.meta.stagedTurnData = null;
   return true;
 }

--- a/web/tm-endturn-render.js
+++ b/web/tm-endturn-render.js
@@ -589,8 +589,23 @@ function _endTurn_finalizeRecords(shizhengji, zhengwen, playerStatus, playerInne
 
 // 玩家输入必须在世界与 canonical 存档都提交以后才清空；失败回滚无需重建 DOM 草稿。
 function _endTurn_clearCommittedInputs() {
-  ["edict-pol","edict-mil","edict-dip","edict-eco","edict-oth","xinglu","xinglu-pub","xinglu-prv"].forEach(function(id){var el=typeof _$ === 'function' ? _$(id) : null;if(el)el.value="";});
-  if (window.TMPhase8FormalBridge && typeof window.TMPhase8FormalBridge.clearEdictDrafts === 'function') window.TMPhase8FormalBridge.clearEdictDrafts();
+  var errors = [];
+  ["edict-pol","edict-mil","edict-dip","edict-eco","edict-oth","xinglu","xinglu-pub","xinglu-prv"].forEach(function(id){
+    try { var el=typeof _$ === 'function' ? _$(id) : null;if(el)el.value=""; }
+    catch (error) { errors.push(error); }
+  });
+  try {
+    if (window.TMPhase8FormalBridge && typeof window.TMPhase8FormalBridge.clearEdictDrafts === 'function') {
+      var result = window.TMPhase8FormalBridge.clearEdictDrafts();
+      if (result && result.ok === false) errors = errors.concat(result.errors || [new Error('正式诏令草稿持久层清理失败')]);
+    }
+  } catch (error) { errors.push(error); }
+  if (errors.length) {
+    try { if (window.TM && TM.errors && TM.errors.capture) TM.errors.capture(errors[0], 'endTurn] clear committed drafts'); } catch (_) {}
+    try { if (typeof toast === 'function') toast('本回合诏令已经生效；界面草稿清理不完整，已阻止其再次提交。'); } catch (_) {}
+    return false;
+  }
+  return true;
 }
 
 // 纯展示阶段：只在事务 commit 后调用。这里的异常可降级，不能反向回滚已提交世界。

--- a/web/tm-save-lifecycle.js
+++ b/web/tm-save-lifecycle.js
@@ -868,10 +868,23 @@ var PREF_CONF_KEYS = [
 function _recoverPendingTurnDataPublish() {
   if (!(GM && GM._pendingTurnDataPublish && window.tianming && typeof window.tianming.recoverTurnData === 'function')) return;
   var targetGM = GM;
+  var targetP = P;
+  var targetLoadGen = (typeof window !== 'undefined' && window._tmLoadGen) || 0;
   var marker = deepClone(GM._pendingTurnDataPublish);
-  window.tianming.recoverTurnData(marker).then(function(result) {
-    if (GM !== targetGM || !GM._pendingTurnDataPublish || GM._pendingTurnDataPublish.transactionId !== marker.transactionId) return;
+  function recoveryLeaseCurrent() {
+    return GM === targetGM && P === targetP &&
+      (((typeof window !== 'undefined' && window._tmLoadGen) || 0) === targetLoadGen) &&
+      String((GM && GM._campaignId) || '') === String(marker.campaignId || '') &&
+      !!GM._pendingTurnDataPublish && GM._pendingTurnDataPublish.transactionId === marker.transactionId;
+  }
+  window.tianming.recoverTurnData(marker).then(async function(result) {
+    if (!recoveryLeaseCurrent()) return;
     if (!(result && result.success === true)) throw new Error(result && result.error || '回合分卷恢复失败');
+    if (!(typeof TM_SaveDB !== 'undefined' && typeof TM_SaveDB.clearPendingTurnDataPublishAtomic === 'function')) {
+      throw new Error('回合分卷恢复标记 checkpoint 接口缺失');
+    }
+    var cleared = await TM_SaveDB.clearPendingTurnDataPublishAtomic(['autosave', 'slot_0'], marker.transactionId, { writeGuard: recoveryLeaseCurrent });
+    if (cleared !== true || !recoveryLeaseCurrent()) throw new Error('回合分卷已恢复，但 canonical 标记清理失败');
     delete GM._pendingTurnDataPublish;
   }).catch(function(error) {
     if (GM !== targetGM) return;

--- a/web/tm-save-lifecycle.js
+++ b/web/tm-save-lifecycle.js
@@ -368,7 +368,8 @@ function _prepareGMForSave(GM, P) {
   }
   // 系统序列化
   // 注意：GM._chronicle是编年事件数组，不可与ChronicleSystem的月/年摘要对象混用——分开存
-  GM._chronicleSysState = typeof ChronicleSystem !== 'undefined' ? ChronicleSystem.serialize() : null;
+  // 编年状态已经属于传入的 GM 快照；不得从当前全局世界重新读取后覆盖跨档快照。
+  GM._chronicleSysState = typeof ChronicleSystem !== 'undefined' ? ChronicleSystem.serialize(GM) : null;
   GM._warTruces = typeof WarWeightSystem !== 'undefined' ? WarWeightSystem.serialize() : null;
   GM._rngState = typeof getRngState === 'function' ? getRngState() : null;
   // 亲疏/得罪/反弹/观感
@@ -953,7 +954,8 @@ function fullLoadGame(data, loadOptions){
       if (!GM._chronicleSysState) GM._chronicleSysState = GM._chronicle;
       GM._chronicle = [];
     }
-    if(GM._chronicleSysState && typeof ChronicleSystem !== 'undefined') ChronicleSystem.deserialize(GM._chronicleSysState);
+    // 每次读档都绑定（包括没有旧字段的空档），避免沿用上一战役的进程级单例残留。
+    if(typeof ChronicleSystem !== 'undefined') ChronicleSystem.deserialize(GM._chronicleSysState || null, GM);
     if(GM._warTruces && typeof WarWeightSystem !== 'undefined') WarWeightSystem.deserialize(GM._warTruces);
 
     // 恢复所有_saved*字段

--- a/web/tm-storage.js
+++ b/web/tm-storage.js
@@ -189,12 +189,13 @@ var TM_SaveDB = (function() {
     };
   }
 
-  function _dropOldestAutoSave(writeGuard) {
+  function _dropOldestAutoSave(writeGuard, excludedIds) {
     if (!_writeGuardAllows(writeGuard)) return Promise.resolve(false);
+    excludedIds = excludedIds || {};
     return _listSaveMetadata().then(function(records) {
       // 列表读取本身是异步的；失效请求不得为了一个已取消的写入删除仍可恢复的旧 autosave。
       if (!_writeGuardAllows(writeGuard)) return false;
-      var autos = (records || []).filter(function(r){ return r.type === 'auto'; })
+      var autos = (records || []).filter(function(r){ return r.type === 'auto' && !excludedIds[String(r.id)]; })
                                  .sort(function(a,b){ return (a.timestamp||0) - (b.timestamp||0); });
       if (autos.length === 0) return false; // 没 auto 可清
       var victim = autos[0];
@@ -257,7 +258,7 @@ var TM_SaveDB = (function() {
     });
   }
 
-  function _putSaveRecordsAtomic(records, writeGuard) {
+  function _putSaveRecordsAtomic(records, writeGuard, _retryCount) {
     records = Array.isArray(records) ? records : [];
     if (!records.length) return Promise.resolve(false);
     if (!_writeGuardAllows(writeGuard)) return Promise.resolve(false);
@@ -281,11 +282,24 @@ var TM_SaveDB = (function() {
         localStorage.removeItem(LOCAL_SAVE_BATCH_JOURNAL);
         return Promise.resolve(true);
       } catch (error) {
+        var restored = false;
         try {
           _restoreLocalSaveBatchItems(items);
           localStorage.removeItem(LOCAL_SAVE_BATCH_JOURNAL);
+          restored = true;
         } catch (_) {
           // 保留 prepared journal；下次 open() 会继续恢复旧值。
+        }
+        if (restored && error && error.name === 'QuotaExceededError' && !_retryCount) {
+          var excludedLocal = Object.create(null);
+          records.forEach(function(record) { excludedLocal[String(record.id)] = true; });
+          if (!_writeGuardAllows(writeGuard)) return Promise.resolve(false);
+          return _dropOldestAutoSave(writeGuard, excludedLocal).then(function(dropped) {
+            if (!_writeGuardAllows(writeGuard)) return false;
+            if (dropped) return _putSaveRecordsAtomic(records, writeGuard, 1);
+            if (typeof window.toast === 'function') window.toast('❌ 存档空间满·请手动删除旧存档后重试');
+            return false;
+          });
         }
         return Promise.reject(error);
       }
@@ -305,7 +319,23 @@ var TM_SaveDB = (function() {
         function fail(e) {
           if (settled) return;
           settled = true;
-          reject(e && e.target && e.target.error || tx.error || new Error('IndexedDB 批量存档事务失败'));
+          var error = e && e.target && e.target.error || tx.error || new Error('IndexedDB 批量存档事务失败');
+          if (error && error.name === 'QuotaExceededError' && !_retryCount) {
+            var excluded = Object.create(null);
+            records.forEach(function(record) { excluded[String(record.id)] = true; });
+            if (!_writeGuardAllows(writeGuard)) { resolve(false); return; }
+            console.warn('[SaveDB] canonical 批量存档配额已满·整批回滚后清理旧自动档并重试');
+            _dropOldestAutoSave(writeGuard, excluded).then(function(dropped) {
+              if (!_writeGuardAllows(writeGuard)) { resolve(false); return; }
+              if (dropped) _putSaveRecordsAtomic(records, writeGuard, 1).then(resolve, reject);
+              else {
+                if (typeof window.toast === 'function') window.toast('❌ 存档空间满·请手动删除旧存档后重试');
+                resolve(false);
+              }
+            }).catch(reject);
+            return;
+          }
+          reject(error);
         }
         tx.onerror = fail;
         tx.onabort = fail;
@@ -645,6 +675,38 @@ var TM_SaveDB = (function() {
     });
   }
 
+  /** 分卷发布成功后，以同一批量事务清除 canonical 槽位中的 durable publish marker。 */
+  function clearPendingTurnDataPublishAtomic(ids, transactionId, options) {
+    ids = Array.isArray(ids) ? ids.map(String) : [];
+    transactionId = String(transactionId || '');
+    options = options || {};
+    if (!ids.length || !transactionId) return Promise.resolve(false);
+    function stillAllowed() {
+      if (typeof options.writeGuard !== 'function') return true;
+      try { return options.writeGuard() === true; }
+      catch (_) { return false; }
+    }
+    if (!stillAllowed()) return Promise.resolve(false);
+    return Promise.all(ids.map(function(id) { return load(id); })).then(function(records) {
+      if (!stillAllowed() || records.some(function(record) { return !record || !record.gameState; })) return false;
+      var changed = false;
+      var entries = [];
+      for (var i = 0; i < records.length; i++) {
+        var record = records[i];
+        var state = record.gameState;
+        var marker = state && state.GM && state.GM._pendingTurnDataPublish;
+        if (marker && String(marker.transactionId || '') !== transactionId) return false;
+        if (marker) {
+          delete state.GM._pendingTurnDataPublish;
+          changed = true;
+        }
+        entries.push({ id: record.id, gameState: state, meta: _toSaveMetadata(record) });
+      }
+      if (!changed) return true;
+      return saveManyAtomic(entries, { writeGuard: stillAllowed });
+    });
+  }
+
   /** 读取游戏存档（7.1: 支持gzip解压，兼容旧存档） */
   function load(id) {
     return _ensureOpen().then(function() {
@@ -928,6 +990,7 @@ var TM_SaveDB = (function() {
     open: open,
     save: save,
     saveManyAtomic: saveManyAtomic,
+    clearPendingTurnDataPublishAtomic: clearPendingTurnDataPublishAtomic,
     load: load,
     list: list,
     delete: deleteSave,


### PR DESCRIPTION
## 修复内容

- 将编年史状态纳入 `GM` 战役状态与回合事务，年度异步生成增加战役/读档代际/状态引用租约与同年去重
- 月稿改为逐回合保留，并统一使用 `TimeUtils.turnToDate()` 处理开局年月日与闰年
- 生产热更新 ZIP 改为中央目录预检 + 有界流式解压，移除主进程 `adm-zip` 路径；升级 `adm-zip`、`electron-updater` 与安全补丁依赖
- 原子双槽存档增加配额回收整批重试，回合分卷发布后原子清除两个 canonical 槽位的 durable marker
- 已提交诏令草稿先清运行时真值，DOM/持久层清理失败会显式诊断且不重复提交
- CI 新增生产依赖 high 级漏洞门禁

## 本地验证

- `npm ci --ignore-scripts`
- `npm audit --omit=dev --audit-level=high --registry=https://registry.npmjs.org`：0 vulnerabilities
- `node web/scripts/ci-smokes.js`：847 项，845 PASS + 2 项既有缺资产白名单豁免
- `node web/scripts/lint-arch-all.js`：8/8 PASS
- `node web/scripts/verify-official-scenario-parity.js`：PASS
- `node scripts/verify-release-contract.js`：166 assertions PASS
- `node web/scripts/verify-hot-builder-gates.js`：27 assertions PASS
- 完整资产热更基线：1081 files PASS

未打包、未发版、未部署 Pages；Windows `E:` 输出目录按现行仓主发版契约保留。