### PR TITLE
fix: close seventh-round audit storage and chronicle gaps

### DIFF
--- a/main-turn-data-commit.js
+++ b/main-turn-data-commit.js
@@ -2,8 +2,8 @@
 
 // Desktop turn bundles use a two-phase protocol:
 //   renderer finalizes records -> stage files -> canonical saves commit -> publish directory.
-// A committed save keeps the transaction descriptor, so an interrupted publish is idempotently
-// recoverable on the next load without exposing an uncommitted turn directory.
+// The canonical save transaction commits a lightweight receipt alongside the world payload, so an
+// interrupted publish is idempotently recoverable on the next load without rewriting either save.
 function createTurnDataCommitter(deps) {
   const fs = deps.fs;
   const path = deps.path;

--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-19T15:25:31.053Z",
+  "generatedAt": "2026-08-19T17:05:09.255Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -3691,8 +3691,8 @@
     },
     {
       "path": "tm-chronicle-system.js",
-      "sha256": "839b0456f1af48c1f8259b4ab29f7d9eccde4ae6b35cc45eab24249fdde6c9d4",
-      "size": 16890
+      "sha256": "352b90b47dbcbb7716ccfdbd334cd216de7c7b90c118c4ef738a3032040625a7",
+      "size": 22102
     },
     {
       "path": "tm-chronicle-tracker.js",
@@ -4006,8 +4006,8 @@
     },
     {
       "path": "tm-endturn-render.js",
-      "sha256": "30feded52da0199f11713d5d51af2b34de90feedbe0290e41ec1b752cccd9710",
-      "size": 34639
+      "sha256": "c9c7b78e4032cca769b7bb6ce5c054267e9a531c0d415982d160faa1aadda911",
+      "size": 34663
     },
     {
       "path": "tm-endturn-shiji-compose.js",
@@ -5096,8 +5096,8 @@
     },
     {
       "path": "tm-save-lifecycle.js",
-      "sha256": "d030e54ce7abed09ef3920e82b3ad133062d1ac9b9f0e807d601c8e1f9510222",
-      "size": 108231
+      "sha256": "de663ab673976e9665a99e31f49e0d81c04df2f603a98455d5767639be877102",
+      "size": 110108
     },
     {
       "path": "tm-save-manager.js",
@@ -5156,8 +5156,8 @@
     },
     {
       "path": "tm-storage.js",
-      "sha256": "f056046c3ea4ecb573cc1aaf7fd5f0aec40e351dc002dc3cd2be508c3e971ad7",
-      "size": 45985
+      "sha256": "87fe0d59f940acf5e238e17900cdcd676649a6eccc69a56dbafcfac78fd8d242",
+      "size": 53932
     },
     {
       "path": "tm-talent-backlash.js",

--- a/web/scripts/smoke-chronicle-world-lease.js
+++ b/web/scripts/smoke-chronicle-world-lease.js
@@ -30,6 +30,8 @@ function deferred() {
 let daysPerTurn = 30;
 let aiCalls = 0;
 let aiQueue = [];
+let aiPrompts = [];
+const durableChronicles = new Map();
 const ctx = {
   console,
   Date,
@@ -52,11 +54,22 @@ const ctx = {
   _charRangeScaled: () => '50-100字',
   _buildTemporalConstraint: () => '',
   extractJSON: value => typeof value === 'string' ? JSON.parse(value) : value,
-  callAI() {
+  callAI(prompt) {
     aiCalls++;
+    aiPrompts.push(String(prompt || ''));
     const task = deferred();
     aiQueue.push(task);
     return task.promise;
+  },
+  TM_SaveDB: {
+    async saveChronicleRecord(record, options) {
+      if (options && typeof options.writeGuard === 'function' && options.writeGuard() !== true) return false;
+      durableChronicles.set(record.campaignId + ':' + record.year, clone(record));
+      return true;
+    },
+    async listChronicleRecords(campaignId) {
+      return Array.from(durableChronicles.values()).filter(record => record.campaignId === campaignId).map(clone);
+    }
   },
   _dbg() {},
   addEB() {},
@@ -108,6 +121,48 @@ function setWorld(id, time) {
   check(leapDrafts['2'].year === 2024 && leapDrafts['2'].month === 2 && leapDrafts['2'].day === 29,
     'leap-year February matches canonical calendar');
   check(leapDrafts['3'].month === 3 && leapDrafts['3'].day === 1, 'day after leap day advances to March 1');
+
+  setWorld('annual-filter', { year: 2024, startYear: 2024, startMonth: 1, startDay: 1 });
+  daysPerTurn = 30;
+  let first2025Turn = 1;
+  while (ctx.TimeUtils.turnToDate(first2025Turn).year < 2025) first2025Turn++;
+  ctx.ChronicleSystem.addMonthDraft(first2025Turn, '二年正史素材', '');
+  ctx.GM._yearlyDigest = [
+    { turn: 1, year: 2024, summary: '上一年摘要不得出现' },
+    { turn: first2025Turn, year: 2025, summary: '本年显式摘要' },
+    { turn: first2025Turn + 1, summary: '本年旧格式摘要' }
+  ];
+  ctx.GM._foreshadowings = [{ resolved: true, plantTurn: 1, resolveTurn: first2025Turn, content: '伏笔', resolveContent: '回收' }];
+  ctx.GM._edictTracker = [{ turn: first2025Turn, category: '诏令', content: '本年诏令', status: 'done' }];
+  ctx.GM._endTurnCommitPending = true;
+  aiQueue = [];
+  aiPrompts = [];
+  const filteredRequest = ctx.ChronicleSystem._tryGenerateYearChronicle(2025);
+  check(aiPrompts.length === 1 && !aiPrompts[0].includes('上一年摘要不得出现')
+    && aiPrompts[0].includes('本年显式摘要') && aiPrompts[0].includes('本年旧格式摘要'),
+  'annual prompt includes only digests belonging to the canonical target year');
+  check(aiPrompts[0].includes('本年诏令') && aiPrompts[0].includes('伏笔'),
+    'edict and foreshadowing year filters share the canonical calendar');
+  aiQueue.shift().resolve(JSON.stringify({ chronicle: '二年正史', afterword: '二年史评' }));
+  await new Promise(resolve => setTimeout(resolve, 5));
+  check(!durableChronicles.has('annual-filter:2025') && !ctx.ChronicleSystem.yearChronicles[2025],
+    'annual result waits for the world commit barrier before becoming durable');
+  ctx.GM._endTurnCommitPending = false;
+  const filteredGenerated = await filteredRequest;
+  check(filteredGenerated && filteredGenerated.ok === true && filteredGenerated.durable === true
+    && durableChronicles.has('annual-filter:2025'),
+  'annual result checkpoints durably before it is exposed in campaign memory');
+
+  ctx._tmLoadGen++;
+  setWorld('annual-filter', { year: 2024, startYear: 2024, startMonth: 1, startDay: 1 });
+  check(!ctx.ChronicleSystem.yearChronicles[2025], 'canonical world snapshot may predate the completed background chronicle');
+  const hydrated = await ctx.ChronicleSystem.hydrateDurableRecords(ctx.GM, ctx.P);
+  check(hydrated && hydrated.ok === true && hydrated.merged === 1
+    && ctx.ChronicleSystem.yearChronicles[2025].content === '二年正史',
+  'immediate reload restores a background chronicle from the lightweight checkpoint');
+
+  ctx.ChronicleSystem.yearChronicles = { 100: { content: '百年' }, 9: { content: '九年' }, 10: { content: '十年' } };
+  check(ctx.ChronicleSystem.getAvailableYears().join(',') === '9,10,100', 'chronicle years sort numerically');
 
   setWorld('campaign-A', { year: 2024, startYear: 2024 });
   daysPerTurn = 30;

--- a/web/scripts/smoke-endturn-transaction-failures.js
+++ b/web/scripts/smoke-endturn-transaction-failures.js
@@ -278,7 +278,7 @@ async function main() {
     'canonical save failure aborts before commit');
   ok(clearDraftCalls === 0 && txn.committed === false, 'player input drafts remain untouched when final save fails');
 
-  resetWorld({ _pendingTurnDataPublish: { transactionId: 'turn-publish-retry' } });
+  resetWorld();
   txn = ctx._tmCaptureEndTurnTransaction();
   clearDraftCalls = 0;
   ctx._endTurn_finalizeRecords = function() { return { shijiHtml: 'committed' }; };
@@ -288,10 +288,12 @@ async function main() {
   ctx._endTurn_render = function() {};
   const publishCtx = buildStepCtx();
   publishCtx.meta.turnRenderArgs = [];
+  publishCtx.meta.stagedTurnData = { transactionId: 'turn-publish-retry' };
   ok(await ctx._tmFinalizeEndTurnTransaction(publishCtx, txn) === true && txn.committed === true,
     'turn-data publish failure cannot roll back an already committed world');
-  ok(clearDraftCalls === 1 && ctx.GM._pendingTurnDataPublish.transactionId === 'turn-publish-retry' && publishCtx.results.turnDataPublishError,
-    'publish failure keeps its recovery marker while post-commit input cleanup proceeds');
+  ok(clearDraftCalls === 1 && publishCtx.meta.stagedTurnData.transactionId === 'turn-publish-retry'
+    && !ctx.GM._pendingTurnDataPublish && publishCtx.results.turnDataPublishError,
+    'publish failure leaves the independent recovery receipt intact while post-commit input cleanup proceeds');
 
   resetWorld({ _pendingShijiModal: { courtDone: false, aiReady: false, payload: null } });
   ctx.P.keju = { currentExam: true };

--- a/web/scripts/smoke-runtime-save-consistency.js
+++ b/web/scripts/smoke-runtime-save-consistency.js
@@ -102,9 +102,13 @@ ok(/auto-save-session-rotate/.test(mainImpl) && /autoSaveSessionMatches\(request
 ok(/rotateAutoSaveSession/.test(preloadImpl) && /_tmRotateDesktopAutoSaveSession\('full-load'/.test(lifecycle)
   && /_tmRotateDesktopAutoSaveSession\('new-game'/.test(startPatch), 'preload + 读档 + 新局共同切换 auto-save session');
 ok(/stageTurnData\([\s\S]*?result\.success === true[\s\S]*?回合分卷暂存失败/.test(render)
-  && /_tmCommitEndTurnTransaction[\s\S]*?await _endTurn_publishStagedTurnData/.test(core), '回合分卷先暂存并仅在世界 commit 后发布');
-ok(/function _recoverPendingTurnDataPublish\(\)[\s\S]*?function recoveryLeaseCurrent\(\)[\s\S]*?_tmLoadGen[\s\S]*?transactionId === marker\.transactionId[\s\S]*?recoverTurnData\(marker\)[\s\S]*?clearPendingTurnDataPublishAtomic\(\['autosave', 'slot_0'\][\s\S]*?delete GM\._pendingTurnDataPublish/.test(lifecycle),
-  '读档按世界身份和 transactionId 租约补发，并在双槽 checkpoint 后清除 durable marker');
+  && /turnPublishReceipt:\s*ctx\.meta\.stagedTurnData/.test(render)
+  && /_tmCommitEndTurnTransaction[\s\S]*?await _endTurn_publishStagedTurnData/.test(core), '回合分卷先暂存·receipt 与世界同事务提交·仅在 commit 后发布');
+ok(/function _recoverPendingTurnDataPublish\(\)[\s\S]*?baseRecoveryLeaseCurrent[\s\S]*?listTurnPublishReceipts\(campaignId, 'world-committed'\)[\s\S]*?recoverTurnData\(marker\)[\s\S]*?deleteTurnPublishReceipt\(marker/.test(lifecycle),
+  '读档按世界身份租约补发独立 receipt，并只删除轻量事务记录');
+ok(/function _endTurn_publishStagedTurnData\([\s\S]*?deleteTurnPublishReceipt\(marker[\s\S]*?ctx\.meta\.stagedTurnData = null/.test(render)
+  && !/function _endTurn_publishStagedTurnData\([\s\S]*?clearPendingTurnDataPublishAtomic/.test(render),
+  '正常分卷发布不再解压、重压并重写两个 canonical 世界');
 {
   const finalizerFn = sliceFn(render, 'function _endTurn_finalizeRecords(');
   const uiRenderFn = sliceFn(render, 'function _endTurn_render(');
@@ -201,6 +205,76 @@ async function runDynamicLeaseSmokes() {
     ok(saved === true && order.indexOf('phase5') < order.indexOf('snapshot:after') && writes.length === 2 && writes.every(w => w[1] === 'after'), '真实 save helper 只快照 Phase5 后状态并同时写 autosave/slot_0');
   }
   {
+    let staged = 0, published = 0, deleted = 0, capturedOptions = null;
+    const ctx = {
+      GM: { turn: 50, sid: 's1', saveName: 'desktop-save', _campaignId: 'campaign-receipt', eraName: '某年号' }, P: {},
+      window: {
+        _tmLoadGen: 2,
+        _tmActivePreEndturnSnapshotId: 'pre-50',
+        TM: { errors: { capture() {}, captureSilent() {} } },
+        tianming: {
+          isDesktop: true,
+          async stageTurnData() { staged++; return { success: true }; },
+          async publishTurnData() { published++; return { success: true }; }
+        }
+      },
+      TM: { errors: { capture() {}, captureSilent() {} } }, console, Promise, Date, JSON, Math, Error, setTimeout,
+      deepClone: value => JSON.parse(JSON.stringify(value)),
+      localStorage: { getItem: () => null, setItem() {}, removeItem() {} },
+      _awaitPostTurnJobsForSave: async () => {}, _prepareGMForSave() {},
+      _buildSaveState: opts => ({ GM: JSON.parse(JSON.stringify(opts.gm)), P: opts.p }),
+      findScenarioById: () => ({ name: '测试剧本' }), getTSText: () => '某日',
+      TM_SaveDB: {
+        async saveManyAtomic(entries, options) { capturedOptions = options; return entries.length === 2; },
+        async deleteTurnPublishReceipt() { deleted++; return true; }
+      }
+    };
+    ctx.window.window = ctx.window;
+    vm.createContext(ctx); vm.runInContext(render, ctx);
+    const saveCtx = { meta: { transactionId: 'turn-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee', turnPresentation: { turnData: { context: { turn: 49 } } } } };
+    const saved = await ctx._endTurn_saveSnapshot(saveCtx);
+    const publishedOk = await ctx._endTurn_publishStagedTurnData(saveCtx);
+    ok(saved === true && publishedOk === true && staged === 1 && published === 1 && deleted === 1
+      && capturedOptions.turnPublishReceipt.transactionId === 'turn-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+      && !ctx.GM._pendingTurnDataPublish,
+    'desktop receipt commits with canonical worlds and publish cleanup never mutates the world payload');
+  }
+  {
+    const receipt = {
+      id: 'turn-publish:campaign-recover:turn-recover-1', campaignId: 'campaign-recover',
+      transactionId: 'turn-recover-1', saveName: '测试档', turn: 50,
+      stateChecksum: 'checksum-recover-1', status: 'world-committed'
+    };
+    let recovered = 0, deleted = 0;
+    const ctx = {
+      GM: { _campaignId: 'campaign-recover' }, P: { id: 'p-recover' },
+      window: {
+        _tmLoadGen: 4,
+        tianming: { async recoverTurnData(marker) { recovered++; return { success: marker.transactionId === receipt.transactionId }; } },
+        TM: { errors: { capture() {} } }
+      },
+      TM: { errors: { capture() {} } }, Promise, JSON, Error, console,
+      deepClone: value => JSON.parse(JSON.stringify(value)),
+      TM_SaveDB: {
+        async listTurnPublishReceipts(campaignId, status) {
+          return campaignId === receipt.campaignId && status === 'world-committed' ? [receipt] : [];
+        },
+        async deleteTurnPublishReceipt(marker, options) {
+          if (options.writeGuard() !== true) return false;
+          deleted++;
+          return marker.transactionId === receipt.transactionId;
+        }
+      },
+      toast() {}
+    };
+    ctx.window.window = ctx.window;
+    vm.createContext(ctx); vm.runInContext(sliceFn(lifecycle, 'function _recoverPendingTurnDataPublish('), ctx);
+    ctx._recoverPendingTurnDataPublish();
+    await new Promise(resolve => setTimeout(resolve, 10));
+    ok(recovered === 1 && deleted === 1 && !ctx.GM._pendingTurnDataPublish,
+      'load recovery publishes and removes an independent receipt without touching the canonical world');
+  }
+  {
     let staged = 0, discarded = 0;
     const ctx = {
       GM: { turn: 50, sid: 's1', saveName: 'desktop-save', _campaignId: 'campaign-a', eraName: '某年号' }, P: {},
@@ -228,6 +302,42 @@ async function runDynamicLeaseSmokes() {
     const saved = await ctx._endTurn_saveSnapshot(saveCtx);
     ok(saved === false && staged === 1 && discarded === 1 && !ctx.GM._pendingTurnDataPublish,
       'canonical batch failure discards desktop staging and leaves no formal publish marker');
+  }
+  {
+    let staged = 0, discarded = 0, committedReceipt = null;
+    const ctx = {
+      GM: { turn: 50, sid: 's1', saveName: 'desktop-save', _campaignId: 'campaign-cross-load', eraName: '某年号' }, P: {},
+      window: {
+        _tmLoadGen: 2,
+        _tmActivePreEndturnSnapshotId: 'pre-50',
+        TM: { errors: { capture() {}, captureSilent() {} } },
+        tianming: {
+          isDesktop: true,
+          async stageTurnData() { staged++; return { success: true }; },
+          async discardTurnData() { discarded++; return { success: true }; }
+        }
+      },
+      TM: { errors: { capture() {}, captureSilent() {} } }, console, Promise, Date, JSON, Math, Error, setTimeout,
+      deepClone: value => JSON.parse(JSON.stringify(value)),
+      localStorage: { getItem: () => null, setItem() {}, removeItem() {} },
+      _awaitPostTurnJobsForSave: async () => {}, _prepareGMForSave() {},
+      _buildSaveState: opts => ({ GM: JSON.parse(JSON.stringify(opts.gm)), P: opts.p }),
+      findScenarioById: () => ({ name: '测试剧本' }), getTSText: () => '某日',
+      TM_SaveDB: {
+        async saveManyAtomic(entries, options) {
+          committedReceipt = options.turnPublishReceipt;
+          ctx.window._tmLoadGen++;
+          return entries.length === 2;
+        },
+        async deleteTurnPublishReceipt() { throw new Error('committed receipt must remain'); }
+      }
+    };
+    ctx.window.window = ctx.window;
+    vm.createContext(ctx); vm.runInContext(render, ctx);
+    const saveCtx = { meta: { transactionId: 'turn-cross-load-12345678', turnPresentation: { turnData: { context: { turn: 49 } } } } };
+    const saved = await ctx._endTurn_saveSnapshot(saveCtx);
+    ok(saved === false && staged === 1 && discarded === 0 && committedReceipt.transactionId === 'turn-cross-load-12345678',
+      'a post-commit load switch preserves staging and its durable receipt for the original campaign');
   }
   {
     let src = storage;

--- a/web/scripts/smoke-storage-atomic-batch.js
+++ b/web/scripts/smoke-storage-atomic-batch.js
@@ -179,6 +179,37 @@ function makeContext(indexedDB, localStorage) {
     && noDisposableIdb.stores.get('saves').get('slot_0').gameState === 'old-slot',
   'quota recovery never deletes either canonical slot when no disposable auto save exists');
 
+  const singleOnlySlotIdb = makeIndexedDB({ saves: { slot_0: oldSlot }, saveMetadata: {
+    slot_0: { id: 'slot_0', type: 'auto', turn: 49, timestamp: 1 }
+  } }, 1, 'QuotaExceededError');
+  const singleOnlySlotCtx = makeContext(singleOnlySlotIdb, makeLocalStorage());
+  await singleOnlySlotCtx.TM_SaveDB.open();
+  const singleOnlySlotSaved = await singleOnlySlotCtx.TM_SaveDB.save('slot_0', state, { type: 'auto', turn: 50 });
+  check(singleOnlySlotSaved === false && singleOnlySlotIdb.stores.get('saves').get('slot_0').gameState === 'old-slot',
+    'single-slot quota recovery never deletes the old target when no disposable save exists');
+
+  const singleCanonicalIdb = makeIndexedDB({ saves: { autosave: oldAuto, slot_0: oldSlot }, saveMetadata: {
+    autosave: { id: 'autosave', type: 'auto', turn: 49, timestamp: 1 },
+    slot_0: { id: 'slot_0', type: 'auto', turn: 49, timestamp: 2 }
+  } }, 1, 'QuotaExceededError');
+  const singleCanonicalCtx = makeContext(singleCanonicalIdb, makeLocalStorage());
+  await singleCanonicalCtx.TM_SaveDB.open();
+  const singleCanonicalSaved = await singleCanonicalCtx.TM_SaveDB.save('slot_0', state, { type: 'auto', turn: 50 });
+  check(singleCanonicalSaved === false
+    && singleCanonicalIdb.stores.get('saves').get('autosave').gameState === 'old-auto'
+    && singleCanonicalIdb.stores.get('saves').get('slot_0').gameState === 'old-slot',
+  'single-slot quota recovery protects every canonical recovery slot');
+
+  const singleDisposableIdb = makeIndexedDB(quotaInitial, 1, 'QuotaExceededError');
+  const singleDisposableCtx = makeContext(singleDisposableIdb, makeLocalStorage());
+  await singleDisposableCtx.TM_SaveDB.open();
+  const singleDisposableSaved = await singleDisposableCtx.TM_SaveDB.save('slot_0', state, { type: 'auto', turn: 50 });
+  check(singleDisposableSaved === true
+    && !singleDisposableIdb.stores.get('saves').has('older_auto_1')
+    && singleDisposableIdb.stores.get('saves').get('autosave').gameState === 'old-auto'
+    && JSON.parse(singleDisposableIdb.stores.get('saves').get('slot_0').gameState).GM.turn === 50,
+  'single-slot quota recovery removes only a disposable auto save before retrying the target');
+
   const marker = { transactionId: 'turn-marker-12345678', campaignId: 'campaign-1', turn: 50 };
   const markerState = { GM: { turn: 51, _pendingTurnDataPublish: marker }, P: {} };
   const markerIdb = makeIndexedDB({ saves: {
@@ -235,6 +266,16 @@ function makeContext(indexedDB, localStorage) {
   check(JSON.parse(JSON.parse(localQuota.getItem(keys.auto)).gameState).GM.turn === 50
     && JSON.parse(JSON.parse(localQuota.getItem(keys.slot)).gameState).GM.turn === 50,
   'localStorage quota recovery still advances both canonical slots together');
+
+  const localSingleQuota = makeLocalStorage(localQuotaInitial, keys.slotMeta, 'QuotaExceededError');
+  const localSingleQuotaCtx = makeContext(null, localSingleQuota);
+  await localSingleQuotaCtx.TM_SaveDB.open();
+  const localSingleSaved = await localSingleQuotaCtx.TM_SaveDB.save('slot_0', state, { type: 'auto', turn: 50 });
+  check(localSingleSaved === true
+    && localSingleQuota.getItem('tm_idb_saves_older_auto_1') === null
+    && JSON.parse(localSingleQuota.getItem(keys.auto)).gameState === JSON.parse(localQuotaInitial[keys.auto]).gameState
+    && JSON.parse(JSON.parse(localSingleQuota.getItem(keys.slot)).gameState).GM.turn === 50,
+  'localStorage single-slot quota recovery preserves canonical slots and removes only disposable autos');
 
   const preparedItems = Object.entries(initial).map(([key, previous]) => ({ key, previous }));
   const crashLocal = makeLocalStorage(Object.assign({}, initial, {

--- a/web/scripts/smoke-storage-atomic-batch.js
+++ b/web/scripts/smoke-storage-atomic-batch.js
@@ -41,7 +41,9 @@ function makeIndexedDB(initial, failPutAt, failureName) {
   const stores = new Map([
     ['saves', new Map(Object.entries(initial && initial.saves || {}).map(([k, v]) => [k, clone(v)]))],
     ['saveMetadata', new Map(Object.entries(initial && initial.saveMetadata || {}).map(([k, v]) => [k, clone(v)]))],
-    ['projects', new Map()]
+    ['projects', new Map()],
+    ['chronicleRecords', new Map(Object.entries(initial && initial.chronicleRecords || {}).map(([k, v]) => [k, clone(v)]))],
+    ['turnPublishReceipts', new Map(Object.entries(initial && initial.turnPublishReceipts || {}).map(([k, v]) => [k, clone(v)]))]
   ]);
   const stats = { readwriteTransactions: 0, puts: 0 };
   const db = {
@@ -113,6 +115,26 @@ function makeContext(indexedDB, localStorage) {
   ]);
   check(ok === true && idb.stats.readwriteTransactions === 1, 'both canonical slots use one IndexedDB readwrite transaction');
   check(idb.stores.get('saves').size === 2 && idb.stores.get('saveMetadata').size === 2, 'payloads and metadata commit together');
+
+  const batchReceiptMarker = {
+    campaignId: 'campaign-batch-receipt', transactionId: 'turn-batch-receipt-12345678', saveName: '测试档',
+    turn: 50, stateChecksum: 'checksum-batch-12345678'
+  };
+  const receiptBatchIdb = makeIndexedDB();
+  const receiptBatchCtx = makeContext(receiptBatchIdb, makeLocalStorage());
+  await receiptBatchCtx.TM_SaveDB.open();
+  const receiptBatchSaved = await receiptBatchCtx.TM_SaveDB.saveManyAtomic([
+    { id: 'autosave', gameState: state, meta: { type: 'auto', turn: 50 } },
+    { id: 'slot_0', gameState: state, meta: { type: 'auto', turn: 50 } }
+  ], { turnPublishReceipt: batchReceiptMarker });
+  check(receiptBatchSaved === true && receiptBatchIdb.stats.readwriteTransactions === 1
+    && receiptBatchIdb.stores.get('saves').size === 2 && receiptBatchIdb.stores.get('turnPublishReceipts').size === 1,
+  'canonical worlds and the world-committed turn receipt commit in one IndexedDB transaction');
+  const receiptBatchPuts = receiptBatchIdb.stats.puts;
+  const receiptBatchDeleted = await receiptBatchCtx.TM_SaveDB.deleteTurnPublishReceipt(batchReceiptMarker);
+  check(receiptBatchDeleted === true && receiptBatchIdb.stats.puts === receiptBatchPuts
+    && receiptBatchIdb.stores.get('saves').size === 2 && receiptBatchIdb.stores.get('turnPublishReceipts').size === 0,
+  'publishing clears only the lightweight receipt and never rewrites either world payload');
   let duplicateRejected = false;
   try {
     await ctx.TM_SaveDB.saveManyAtomic([
@@ -210,6 +232,26 @@ function makeContext(indexedDB, localStorage) {
     && JSON.parse(singleDisposableIdb.stores.get('saves').get('slot_0').gameState).GM.turn === 50,
   'single-slot quota recovery removes only a disposable auto save before retrying the target');
 
+  const chronicleSaved = await ctx.TM_SaveDB.saveChronicleRecord({
+    campaignId: 'campaign-chronicle', year: 2025, requestId: 'req-1', loadGeneration: 3,
+    generatedAt: 123, chronicle: { content: '年度正史', afterword: '史评', read: false }
+  });
+  const chronicleRows = await ctx.TM_SaveDB.listChronicleRecords('campaign-chronicle');
+  check(chronicleSaved === true && chronicleRows.length === 1
+    && chronicleRows[0].chronicle.content === '年度正史' && idb.stores.get('saves').size === 2,
+  'annual chronicles checkpoint in a lightweight store without rewriting world saves');
+
+  const receiptMarker = {
+    campaignId: 'campaign-receipt', transactionId: 'turn-receipt-12345678', saveName: '测试档',
+    turn: 50, stateChecksum: 'checksum-12345678'
+  };
+  const receiptSaved = await ctx.TM_SaveDB.saveTurnPublishReceipt(receiptMarker, 'world-committed');
+  const receiptRows = await ctx.TM_SaveDB.listTurnPublishReceipts('campaign-receipt', 'world-committed');
+  const receiptDeleted = await ctx.TM_SaveDB.deleteTurnPublishReceipt(receiptMarker);
+  check(receiptSaved === true && receiptRows.length === 1 && receiptRows[0].transactionId === receiptMarker.transactionId
+    && receiptDeleted === true && idb.stores.get('turnPublishReceipts').size === 0,
+  'turn bundle receipts use an independent lightweight store with explicit lifecycle');
+
   const marker = { transactionId: 'turn-marker-12345678', campaignId: 'campaign-1', turn: 50 };
   const markerState = { GM: { turn: 51, _pendingTurnDataPublish: marker }, P: {} };
   const markerIdb = makeIndexedDB({ saves: {
@@ -243,6 +285,17 @@ function makeContext(indexedDB, localStorage) {
   } catch (_) { rejected = true; }
   check(rejected && Object.entries(initial).every(([k, v]) => local.getItem(k) === v), 'localStorage failure restores all four prior values');
   check(local.getItem('tm_save_batch_journal_v1') === null, 'successful rollback removes the local batch journal');
+
+  const localReceipt = makeLocalStorage();
+  const localReceiptCtx = makeContext(null, localReceipt);
+  await localReceiptCtx.TM_SaveDB.open();
+  const localReceiptSaved = await localReceiptCtx.TM_SaveDB.saveManyAtomic([
+    { id: 'autosave', gameState: state, meta: { type: 'auto', turn: 50 } },
+    { id: 'slot_0', gameState: state, meta: { type: 'auto', turn: 50 } }
+  ], { turnPublishReceipt: batchReceiptMarker });
+  const localReceiptKey = Array.from(localReceipt.rows.keys()).find(key => key.indexOf('tm_idb_turnPublishReceipts_') === 0);
+  check(localReceiptSaved === true && !!localReceiptKey && localReceipt.getItem('tm_save_batch_journal_v1') === null,
+    'localStorage journal commits canonical worlds and the lightweight receipt as one recoverable batch');
 
   const localQuotaInitial = {
     [keys.auto]: JSON.stringify({ id: 'autosave', type: 'auto', name: 'old auto', timestamp: 20, turn: 49, gameState: JSON.stringify({ GM: { turn: 49 }, P: {} }) }),

--- a/web/scripts/smoke-storage-metadata-index.js
+++ b/web/scripts/smoke-storage-metadata-index.js
@@ -144,7 +144,9 @@ function makeLocalStorage() {
   context.SaveCompression.compress = (text) => Promise.resolve(text);
 
   await context.TM_SaveDB.open();
-  check(indexedDB.counters.openedVersion === 3, 'storage schema must open IndexedDB version 3');
+  check(indexedDB.counters.openedVersion === 4, 'storage schema must open IndexedDB version 4');
+  check(indexedDB.stores.has('chronicleRecords') && indexedDB.stores.has('turnPublishReceipts'),
+    'v4 upgrade creates lightweight chronicle and turn receipt stores');
 
   const payload = 'x'.repeat(64 * 1024);
   await Promise.all(Array.from({ length: 100 }, (_, index) => context.TM_SaveDB.save(

--- a/web/tm-chronicle-system.js
+++ b/web/tm-chronicle-system.js
@@ -78,6 +78,34 @@ function _chronicleRequestId() {
   return 'chronicle-' + Date.now() + '-' + ChronicleSystem._requestSeq;
 }
 
+function _chronicleTrimYears(state, targetP) {
+  if (!state || !state.yearChronicles) return;
+  var keepYears = Number(targetP && targetP.conf && targetP.conf.chronicleKeep);
+  if (!isFinite(keepYears) || keepYears <= 0) keepYears = 10;
+  var maxYears = Math.max(1, Math.floor(keepYears)) * 2;
+  var yearKeys = Object.keys(state.yearChronicles).map(Number).filter(function(year) {
+    return Number.isSafeInteger(year);
+  }).sort(function(a, b) { return a - b; });
+  if (yearKeys.length <= maxYears) return;
+  yearKeys.slice(0, yearKeys.length - maxYears).forEach(function(year) {
+    delete state.yearChronicles[year];
+  });
+}
+
+function _chronicleWaitForWorldCommit(targetGM, leaseIsCurrent) {
+  if (!targetGM || !targetGM._endTurnCommitPending) return Promise.resolve(true);
+  var startedAt = Date.now();
+  return new Promise(function(resolve) {
+    function poll() {
+      if (!leaseIsCurrent()) { resolve(false); return; }
+      if (!targetGM._endTurnCommitPending) { resolve(true); return; }
+      if (Date.now() - startedAt > 90000) { resolve(false); return; }
+      setTimeout(poll, 25);
+    }
+    poll();
+  });
+}
+
 var ChronicleSystem = {
   _inFlight: [],
   _requestSeq: 0,
@@ -209,8 +237,9 @@ var ChronicleSystem = {
     // 6.1联动：注入该年回收的伏笔因果链
     if (targetGM._foreshadowings) {
       var _yearResolved = targetGM._foreshadowings.filter(function(f) {
-        return f.resolved && f.resolveTurn && (typeof calcDateFromTurn === 'function') &&
-          calcDateFromTurn(f.resolveTurn) && calcDateFromTurn(f.resolveTurn).adYear === year;
+        if (!(f && f.resolved && f.resolveTurn)) return false;
+        var resolvedDate = _chronicleDateForTurn(f.resolveTurn);
+        return resolvedDate && resolvedDate.year === year;
       });
       if (_yearResolved.length > 0) {
         prompt += '\n\u672C\u5E74\u56DE\u6536\u7684\u4F0F\u7B14\u56E0\u679C\u94FE\uFF08\u7F16\u5E74\u4E2D\u5E94\u81EA\u7136\u5448\u73B0\u8FD9\u4E9B\u524D\u56E0\u540E\u679C\uFF09\uFF1A\n';
@@ -221,15 +250,26 @@ var ChronicleSystem = {
     }
     // 6.5联动：注入每回合一句话摘要
     if (targetGM._yearlyDigest && targetGM._yearlyDigest.length > 0) {
-      prompt += '\n\u672C\u5E74\u5404\u56DE\u5408\u4E00\u53E5\u8BDD\u6458\u8981\uFF1A\n';
-      targetGM._yearlyDigest.forEach(function(d) { prompt += 'T' + d.turn + ': ' + d.summary + '\n'; });
+      var yearDigests = targetGM._yearlyDigest.filter(function(d) {
+        if (!d) return false;
+        var digestYear = (d.year != null && d.year !== '') ? Number(d.year) : NaN;
+        if (!Number.isSafeInteger(digestYear)) {
+          var digestDate = _chronicleDateForTurn(d.turn);
+          digestYear = digestDate && digestDate.year;
+        }
+        return digestYear === year;
+      });
+      if (yearDigests.length > 0) {
+        prompt += '\n\u672C\u5E74\u5404\u56DE\u5408\u4E00\u53E5\u8BDD\u6458\u8981\uFF1A\n';
+        yearDigests.forEach(function(d) { prompt += 'T' + d.turn + ': ' + d.summary + '\n'; });
+      }
     }
     // 6.7联动：本年度下达诏令+其后续影响（colorEdicts + _chainEffects）
     if (targetGM._edictTracker && targetGM._edictTracker.length > 0) {
       var _yearEdicts = targetGM._edictTracker.filter(function(e) {
         if (!e || !e.turn) return false;
-        var _d = (typeof calcDateFromTurn === 'function') ? calcDateFromTurn(e.turn) : null;
-        return _d && _d.adYear === year;
+        var _d = _chronicleDateForTurn(e.turn);
+        return _d && _d.year === year;
       });
       if (_yearEdicts.length > 0) {
         prompt += '\n\u3010\u672C\u5E74\u9881\u4E0B\u8BCF\u4EE4\u00B7\u7F16\u5E74\u4E2D\u5FC5\u987B\u8BB0\u5176\u9881\u5E03\u00B7\u6267\u884C\u00B7\u4F59\u6CE2\u3011\n';
@@ -277,27 +317,42 @@ var ChronicleSystem = {
       if (!leaseIsCurrent()) return { ok: false, stale: true };
       var parsed = extractJSON(result);
       if (parsed) {
-        targetState.yearChronicles[year] = {
-          content: parsed.chronicle || result,
-          afterword: parsed.afterword || '',
+        var chronicleText = (parsed && typeof parsed === 'object') ? parsed.chronicle : '';
+        if (typeof chronicleText !== 'string' || !chronicleText.trim()) {
+          chronicleText = typeof result === 'string' ? result : '';
+        }
+        if (!chronicleText.trim()) return { ok: false, reason: 'invalid-result' };
+        var afterwordText = (parsed && typeof parsed === 'object' && typeof parsed.afterword === 'string') ? parsed.afterword : '';
+        var chronicleEntry = {
+          content: chronicleText.slice(0, 20000),
+          afterword: afterwordText.slice(0, 5000),
           read: false,
           generatedAt: Date.now(),
           authorityLevel: 'official_record',
           confidence: 0.8
         };
-
-        // 限制年度正史数量
-        var yearKeys = Object.keys(targetState.yearChronicles);
-        var maxYears = ((targetP.conf && targetP.conf.chronicleKeep) || 10) * 2;
-        if (yearKeys.length > maxYears) {
-          yearKeys.sort(function(a,b){return a-b;});
-          var removeYears = yearKeys.slice(0, yearKeys.length - maxYears);
-          removeYears.forEach(function(k) { delete targetState.yearChronicles[k]; });
-        }
-
-        _dbg('[Chronicle] 年度正史生成完成:', year);
-        if (typeof addEB === 'function') addEB('正史', year + '年编年史已完成');
-        return { ok: true, year: year };
+        return _chronicleWaitForWorldCommit(targetGM, leaseIsCurrent).then(function(worldCommitted) {
+          if (!worldCommitted || !leaseIsCurrent()) return { ok: false, stale: true };
+          if (!(typeof TM_SaveDB !== 'undefined' && TM_SaveDB && typeof TM_SaveDB.saveChronicleRecord === 'function')) {
+            throw new Error('年度正史轻量持久化接口缺失');
+          }
+          return TM_SaveDB.saveChronicleRecord({
+            campaignId: lease.campaignId,
+            year: year,
+            requestId: lease.requestId,
+            loadGeneration: lease.loadGen,
+            generatedAt: chronicleEntry.generatedAt,
+            chronicle: chronicleEntry
+          }, { writeGuard: leaseIsCurrent }).then(function(saved) {
+            if (saved !== true) throw new Error('年度正史轻量 checkpoint 未提交');
+            if (!leaseIsCurrent()) return { ok: false, stale: true };
+            targetState.yearChronicles[year] = chronicleEntry;
+            _chronicleTrimYears(targetState, targetP);
+            _dbg('[Chronicle] 年度正史生成完成:', year);
+            if (typeof addEB === 'function') addEB('正史', year + '年编年史已完成');
+            return { ok: true, year: year, durable: true };
+          });
+        });
       }
       return { ok: false, reason: 'invalid-result' };
     }).catch(function(e) {
@@ -318,7 +373,53 @@ var ChronicleSystem = {
 
   /** 获取所有已生成年份 */
   getAvailableYears: function() {
-    return Object.keys(ChronicleSystem.yearChronicles).map(Number).sort();
+    return Object.keys(ChronicleSystem.yearChronicles).map(Number).filter(function(year) {
+      return Number.isSafeInteger(year);
+    }).sort(function(a, b) { return a - b; });
+  },
+
+  /** 从独立轻量 store 合并当前战役已完成的年度正史。 */
+  hydrateDurableRecords: function(targetGM, targetP) {
+    targetGM = targetGM || ((typeof GM !== 'undefined' && GM) ? GM : null);
+    targetP = targetP || ((typeof P !== 'undefined' && P) ? P : null);
+    if (!targetGM || !targetP) return Promise.resolve({ ok: false, reason: 'missing-world' });
+    if (!(typeof TM_SaveDB !== 'undefined' && TM_SaveDB && typeof TM_SaveDB.listChronicleRecords === 'function')) {
+      return Promise.resolve({ ok: false, reason: 'storage-unavailable' });
+    }
+    var targetState = _chronicleState(targetGM, true);
+    var campaignId = String(targetGM._campaignId || '');
+    var loadGen = (typeof window !== 'undefined' && window._tmLoadGen) || 0;
+    function leaseIsCurrent() {
+      return typeof GM !== 'undefined' && typeof P !== 'undefined' &&
+        GM === targetGM && P === targetP &&
+        (((typeof window !== 'undefined' && window._tmLoadGen) || 0) === loadGen) &&
+        String((GM && GM._campaignId) || '') === campaignId &&
+        _chronicleState(targetGM, false) === targetState;
+    }
+    return TM_SaveDB.listChronicleRecords(campaignId).then(function(records) {
+      if (!leaseIsCurrent()) return { ok: false, stale: true };
+      var merged = 0;
+      (records || []).sort(function(a, b) { return Number(a && a.generatedAt || 0) - Number(b && b.generatedAt || 0); }).forEach(function(record) {
+        if (!record || String(record.campaignId || '') !== campaignId) return;
+        var year = Number(record.year);
+        var incoming = record.chronicle;
+        if (!Number.isSafeInteger(year) || !incoming || typeof incoming !== 'object' || Array.isArray(incoming)) return;
+        if (typeof incoming.content !== 'string' || !incoming.content) return;
+        var current = targetState.yearChronicles[year];
+        if (current && Number(current.generatedAt || 0) >= Number(record.generatedAt || incoming.generatedAt || 0)) return;
+        var cloned = null;
+        try { cloned = JSON.parse(JSON.stringify(incoming)); } catch (_) { cloned = null; }
+        if (!cloned) return;
+        if (current && current.read === true) cloned.read = true;
+        targetState.yearChronicles[year] = cloned;
+        merged++;
+      });
+      _chronicleTrimYears(targetState, targetP);
+      if (merged && leaseIsCurrent() && typeof renderBiannian === 'function') {
+        try { renderBiannian(); } catch (_) {}
+      }
+      return { ok: true, merged: merged };
+    });
   },
 
   /** 标记已读 */

--- a/web/tm-endturn-render.js
+++ b/web/tm-endturn-render.js
@@ -72,8 +72,6 @@ async function _endTurn_stageTurnData(ctx, snapshot) {
   var result = await window.tianming.stageTurnData(Object.assign({ data: presentation.turnData }, marker));
   if (!(result && result.success === true)) throw new Error('回合分卷暂存失败' + (result && result.error ? '：' + result.error : ''));
   ctx.meta.stagedTurnData = marker;
-  GM._pendingTurnDataPublish = deepClone(marker); // arch-ok: end-turn commit coordinator owns durable desktop publish marker
-  snapshot.GM._pendingTurnDataPublish = deepClone(marker);
   return true;
 }
 
@@ -83,7 +81,9 @@ async function _endTurn_discardStagedTurnData(ctx) {
   try {
     if (window.tianming && typeof window.tianming.discardTurnData === 'function') await window.tianming.discardTurnData(marker);
   } finally {
-    if (GM && GM._pendingTurnDataPublish && GM._pendingTurnDataPublish.transactionId === marker.transactionId) delete GM._pendingTurnDataPublish; // arch-ok: discard owns its staged marker cleanup
+    if (typeof TM_SaveDB !== 'undefined' && TM_SaveDB && typeof TM_SaveDB.deleteTurnPublishReceipt === 'function') {
+      try { await TM_SaveDB.deleteTurnPublishReceipt(marker); } catch (_) {}
+    }
     ctx.meta.stagedTurnData = null;
   }
   return true;
@@ -104,15 +104,12 @@ async function _endTurn_publishStagedTurnData(ctx) {
   var result = await window.tianming.publishTurnData(marker);
   if (!(result && result.success === true)) throw new Error('回合分卷发布失败' + (result && result.error ? '：' + result.error : ''));
   if (!publishLeaseCurrent()) throw new Error('回合分卷发布完成时世界身份已变化');
-  if (targetGM._pendingTurnDataPublish && targetGM._pendingTurnDataPublish.transactionId === marker.transactionId) delete targetGM._pendingTurnDataPublish; // arch-ok: publish owns its committed marker cleanup
-  if (!(typeof TM_SaveDB !== 'undefined' && typeof TM_SaveDB.clearPendingTurnDataPublishAtomic === 'function')) {
-    targetGM._pendingTurnDataPublish = deepClone(marker); // arch-ok: keep recoverable receipt when durable checkpoint is unavailable
-    throw new Error('回合分卷发布标记 checkpoint 接口缺失');
+  if (!(typeof TM_SaveDB !== 'undefined' && TM_SaveDB && typeof TM_SaveDB.deleteTurnPublishReceipt === 'function')) {
+    throw new Error('回合分卷 receipt 清理接口缺失');
   }
-  var cleared = await TM_SaveDB.clearPendingTurnDataPublishAtomic(['autosave', 'slot_0'], marker.transactionId, { writeGuard: publishLeaseCurrent });
+  var cleared = await TM_SaveDB.deleteTurnPublishReceipt(marker, { writeGuard: publishLeaseCurrent });
   if (cleared !== true) {
-    if (publishLeaseCurrent()) targetGM._pendingTurnDataPublish = deepClone(marker); // arch-ok: failed checkpoint remains idempotently recoverable
-    throw new Error('回合分卷已发布，但 canonical 标记清理失败');
+    throw new Error('回合分卷已发布，但 receipt 清理失败');
   }
   ctx.meta.stagedTurnData = null;
   return true;
@@ -138,6 +135,7 @@ function _endTurn_saveSnapshot(ctx) {
       && (!_livePreId || _livePreId === _endturnSavePreId);
   };
   return (async function() {
+    var _canonicalCommitted = false;
     try {
       if (typeof _awaitPostTurnJobsForSave === 'function') {
         await _awaitPostTurnJobsForSave(typeof _postTurnSaveRequiredIds === 'function' ? _postTurnSaveRequiredIds() : ['sc25', 'sc25c']);
@@ -156,12 +154,17 @@ function _endTurn_saveSnapshot(ctx) {
         type: 'auto', turn: _endturnSaveTurn,
         scenarioName: _sc3 ? _sc3.name : '', eraName: _endturnSaveGM.eraName || ''
       };
-      var _autoWriteOptions = { writeGuard: _endturnSaveStillCurrent };
+      var _autoWriteOptions = {
+        writeGuard: _endturnSaveStillCurrent,
+        turnPublishReceipt: ctx.meta.stagedTurnData || null
+      };
       var _writeOk = await TM_SaveDB.saveManyAtomic([
         { id: 'autosave', gameState: _autoState, meta: _autoMeta },
         { id: 'slot_0', gameState: _autoState, meta: _autoMeta }
       ], _autoWriteOptions);
-      if (_writeOk !== true || !_endturnSaveStillCurrent()) throw new Error('canonical 回合存档未原子落库');
+      if (_writeOk !== true) throw new Error('canonical 回合存档未原子落库');
+      _canonicalCommitted = true;
+      if (!_endturnSaveStillCurrent()) throw new Error('canonical 回合存档完成时世界身份已变化');
       // 两个 canonical 槽位都提交后，才清恢复点并发布“已安全保存”标志。
       try { _clearPreEndturnMarkerAfterSave(_endturnSavePreId); } catch (_) {}
       try { if (typeof _updateSaveIndex === 'function') _updateSaveIndex(0, _autoMeta); } catch (_) {}
@@ -176,7 +179,12 @@ function _endTurn_saveSnapshot(ctx) {
       return true;
     } catch(e) {
       console.warn('[AutoSave] post-turn save failed:', e);
-      try { await _endTurn_discardStagedTurnData(ctx); } catch (_discardE) { console.warn('[AutoSave] discard staged turn-data failed:', _discardE); }
+      if (!_canonicalCommitted) {
+        try { await _endTurn_discardStagedTurnData(ctx); } catch (_discardE) { console.warn('[AutoSave] discard staged turn-data failed:', _discardE); }
+      } else {
+        // 世界已与 receipt 同事务落库；若此刻恰好跨档，只保留 staging 供该战役下次加载补发。
+        ctx.meta.stagedTurnData = null;
+      }
       return false;
     }
   })();
@@ -433,10 +441,16 @@ function _endTurn_finalizeRecords(shizhengji, zhengwen, playerStatus, playerInne
   if (GM.shijiHistory.length > 200) GM.shijiHistory.splice(0, GM.shijiHistory.length - 200); // arch-ok·史记封顶防长局存档膨胀·生成式 cap（同文件 _factionHistory/_metricHistory）
   // 6.5: 每回合一句话摘要存入年度素材
   if (!GM._yearlyDigest) GM._yearlyDigest = [];
-  GM._yearlyDigest.push({turn: GM.turn-1, summary: _summaryText || (shizhengji||'').split(/[\u3002\n]/)[0] || ''});
-  // 按年度清理（只保留当年）
+  var _digestTurn = GM.turn - 1;
+  var _digestDate = (typeof _chronicleDateForTurn === 'function') ? _chronicleDateForTurn(_digestTurn) : null;
+  GM._yearlyDigest.push({
+    turn: _digestTurn,
+    year: _digestDate && Number.isSafeInteger(_digestDate.year) ? _digestDate.year : undefined,
+    summary: _summaryText || (shizhengji||'').split(/[\u3002\n]/)[0] || ''
+  });
+  // 保留两年重试素材；年度 prompt 会再次按 canonical year 精确过滤。
   var _yTurns = (typeof turnsForDuration === 'function') ? turnsForDuration('year') : 12;
-  if (GM._yearlyDigest.length > _yTurns * 2) GM._yearlyDigest = GM._yearlyDigest.slice(-_yTurns);
+  if (GM._yearlyDigest.length > _yTurns * 2) GM._yearlyDigest = GM._yearlyDigest.slice(-_yTurns * 2);
   // 纪传体：记录月度摘要
   // 编年史草稿：优先使用实录(正式体)+时政记；后人戏说作为辅助材料
   // 实录本就是正史体，最适合喂给编年体系统；否则回落到shizhengji+zhengwen

--- a/web/tm-save-lifecycle.js
+++ b/web/tm-save-lifecycle.js
@@ -866,26 +866,52 @@ var PREF_CONF_KEYS = [
 ];
 
 function _recoverPendingTurnDataPublish() {
-  if (!(GM && GM._pendingTurnDataPublish && window.tianming && typeof window.tianming.recoverTurnData === 'function')) return;
+  if (!(GM && window.tianming && typeof window.tianming.recoverTurnData === 'function')) return;
   var targetGM = GM;
   var targetP = P;
   var targetLoadGen = (typeof window !== 'undefined' && window._tmLoadGen) || 0;
-  var marker = deepClone(GM._pendingTurnDataPublish);
-  function recoveryLeaseCurrent() {
+  var campaignId = String((GM && GM._campaignId) || '');
+  function baseRecoveryLeaseCurrent() {
     return GM === targetGM && P === targetP &&
       (((typeof window !== 'undefined' && window._tmLoadGen) || 0) === targetLoadGen) &&
-      String((GM && GM._campaignId) || '') === String(marker.campaignId || '') &&
-      !!GM._pendingTurnDataPublish && GM._pendingTurnDataPublish.transactionId === marker.transactionId;
+      String((GM && GM._campaignId) || '') === campaignId;
   }
-  window.tianming.recoverTurnData(marker).then(async function(result) {
-    if (!recoveryLeaseCurrent()) return;
-    if (!(result && result.success === true)) throw new Error(result && result.error || '回合分卷恢复失败');
-    if (!(typeof TM_SaveDB !== 'undefined' && typeof TM_SaveDB.clearPendingTurnDataPublishAtomic === 'function')) {
-      throw new Error('回合分卷恢复标记 checkpoint 接口缺失');
+
+  Promise.resolve().then(async function() {
+    // v4 以前的存档把 marker 烘进两个大世界正文；仅在兼容迁移时做一次全量清理。
+    if (targetGM._pendingTurnDataPublish) {
+      var legacyMarker = deepClone(targetGM._pendingTurnDataPublish);
+      function legacyLeaseCurrent() {
+        return baseRecoveryLeaseCurrent() && !!targetGM._pendingTurnDataPublish &&
+          targetGM._pendingTurnDataPublish.transactionId === legacyMarker.transactionId;
+      }
+      var legacyResult = await window.tianming.recoverTurnData(legacyMarker);
+      if (!legacyLeaseCurrent()) return;
+      if (!(legacyResult && legacyResult.success === true)) throw new Error(legacyResult && legacyResult.error || '旧回合分卷恢复失败');
+      if (!(typeof TM_SaveDB !== 'undefined' && typeof TM_SaveDB.clearPendingTurnDataPublishAtomic === 'function')) {
+        throw new Error('旧回合分卷 marker 迁移接口缺失');
+      }
+      var legacyCleared = await TM_SaveDB.clearPendingTurnDataPublishAtomic(['autosave', 'slot_0'], legacyMarker.transactionId, { writeGuard: legacyLeaseCurrent });
+      if (legacyCleared !== true || !legacyLeaseCurrent()) throw new Error('旧回合分卷已恢复，但 canonical marker 清理失败');
+      delete targetGM._pendingTurnDataPublish;
     }
-    var cleared = await TM_SaveDB.clearPendingTurnDataPublishAtomic(['autosave', 'slot_0'], marker.transactionId, { writeGuard: recoveryLeaseCurrent });
-    if (cleared !== true || !recoveryLeaseCurrent()) throw new Error('回合分卷已恢复，但 canonical 标记清理失败');
-    delete GM._pendingTurnDataPublish;
+
+    if (!baseRecoveryLeaseCurrent()) return;
+    if (!(typeof TM_SaveDB !== 'undefined' && TM_SaveDB &&
+      typeof TM_SaveDB.listTurnPublishReceipts === 'function' && typeof TM_SaveDB.deleteTurnPublishReceipt === 'function')) return;
+    var receipts = await TM_SaveDB.listTurnPublishReceipts(campaignId, 'world-committed');
+    receipts = (receipts || []).slice().sort(function(a, b) {
+      return Number(a && a.turn || 0) - Number(b && b.turn || 0) || Number(a && a.createdAt || 0) - Number(b && b.createdAt || 0);
+    });
+    for (var i = 0; i < receipts.length; i++) {
+      if (!baseRecoveryLeaseCurrent()) return;
+      var marker = receipts[i];
+      var result = await window.tianming.recoverTurnData(marker);
+      if (!baseRecoveryLeaseCurrent()) return;
+      if (!(result && result.success === true)) throw new Error(result && result.error || '回合分卷恢复失败');
+      var deleted = await TM_SaveDB.deleteTurnPublishReceipt(marker, { writeGuard: baseRecoveryLeaseCurrent });
+      if (deleted !== true || !baseRecoveryLeaseCurrent()) throw new Error('回合分卷已恢复，但 receipt 清理失败');
+    }
   }).catch(function(error) {
     if (GM !== targetGM) return;
     try { if (window.TM && TM.errors && TM.errors.capture) TM.errors.capture(error, 'fullLoadGame] recover turn-data'); } catch (_) {}
@@ -968,7 +994,14 @@ function fullLoadGame(data, loadOptions){
       GM._chronicle = [];
     }
     // 每次读档都绑定（包括没有旧字段的空档），避免沿用上一战役的进程级单例残留。
-    if(typeof ChronicleSystem !== 'undefined') ChronicleSystem.deserialize(GM._chronicleSysState || null, GM);
+    if(typeof ChronicleSystem !== 'undefined') {
+      ChronicleSystem.deserialize(GM._chronicleSysState || null, GM);
+      if (typeof ChronicleSystem.hydrateDurableRecords === 'function') {
+        ChronicleSystem.hydrateDurableRecords(GM, P).catch(function(error) {
+          try { if (window.TM && TM.errors && TM.errors.captureSilent) TM.errors.captureSilent(error, 'fullLoadGame·chronicle hydrate'); } catch (_) {}
+        });
+      }
+    }
     if(GM._warTruces && typeof WarWeightSystem !== 'undefined') WarWeightSystem.deserialize(GM._warTruces);
 
     // 恢复所有_saved*字段

--- a/web/tm-storage.js
+++ b/web/tm-storage.js
@@ -61,6 +61,11 @@ var TM_SaveDB = (function() {
   var _openPromise = null; // 防止重复打开
   var _migrationTail = Promise.resolve(); // 两类旧源必须串行探测/占用目标 ID
   var LOCAL_SAVE_BATCH_JOURNAL = 'tm_save_batch_journal_v1';
+  var PROTECTED_SAVE_IDS = Object.freeze({
+    autosave: true,
+    slot_0: true,
+    pre_endturn: true
+  });
 
   function _restoreLocalSaveBatchItems(items) {
     items = Array.isArray(items) ? items : [];
@@ -191,11 +196,13 @@ var TM_SaveDB = (function() {
 
   function _dropOldestAutoSave(writeGuard, excludedIds) {
     if (!_writeGuardAllows(writeGuard)) return Promise.resolve(false);
-    excludedIds = excludedIds || {};
+    var protectedIds = Object.create(null);
+    Object.keys(PROTECTED_SAVE_IDS).forEach(function(id) { protectedIds[id] = true; });
+    Object.keys(excludedIds || {}).forEach(function(id) { protectedIds[String(id)] = true; });
     return _listSaveMetadata().then(function(records) {
       // 列表读取本身是异步的；失效请求不得为了一个已取消的写入删除仍可恢复的旧 autosave。
       if (!_writeGuardAllows(writeGuard)) return false;
-      var autos = (records || []).filter(function(r){ return r.type === 'auto' && !excludedIds[String(r.id)]; })
+      var autos = (records || []).filter(function(r){ return r.type === 'auto' && !protectedIds[String(r.id)]; })
                                  .sort(function(a,b){ return (a.timestamp||0) - (b.timestamp||0); });
       if (autos.length === 0) return false; // 没 auto 可清
       var victim = autos[0];
@@ -223,6 +230,17 @@ var TM_SaveDB = (function() {
           if (previousMetadata == null) localStorage.removeItem(metadataKey);
           else localStorage.setItem(metadataKey, previousMetadata);
         } catch (_) {}
+        if (e && e.name === 'QuotaExceededError' && !_retryCount) {
+          var excludedLocal = Object.create(null);
+          excludedLocal[String(record.id)] = true;
+          if (!_writeGuardAllows(writeGuard)) return Promise.resolve(false);
+          return _dropOldestAutoSave(writeGuard, excludedLocal).then(function(dropped) {
+            if (!_writeGuardAllows(writeGuard)) return false;
+            if (dropped) return _putSaveRecord(record, 1, writeGuard);
+            if (typeof window.toast === 'function') window.toast('❌ 存档空间满·请手动删除旧存档后重试');
+            return false;
+          });
+        }
         return Promise.reject(e);
       }
     }
@@ -240,7 +258,9 @@ var TM_SaveDB = (function() {
           var isQuota = err && err.name === 'QuotaExceededError';
           if (isQuota && !_retryCount) {
             if (!_writeGuardAllows(writeGuard)) { resolve(false); return; }
-            _dropOldestAutoSave(writeGuard).then(function(dropped) {
+            var excluded = Object.create(null);
+            excluded[String(record.id)] = true;
+            _dropOldestAutoSave(writeGuard, excluded).then(function(dropped) {
               if (!_writeGuardAllows(writeGuard)) { resolve(false); return; }
               if (dropped) _putSaveRecord(record, 1, writeGuard).then(resolve, reject);
               else {
@@ -355,6 +375,17 @@ var TM_SaveDB = (function() {
         return Promise.resolve(true);
       } catch(e) {
         console.error('[SaveDB] localStorage写入失败:', e.message);
+        if (e && e.name === 'QuotaExceededError' && storeName === SAVE_STORE && !_retryCount) {
+          var excludedLocal = Object.create(null);
+          excludedLocal[String(record.id)] = true;
+          if (!_writeGuardAllows(writeGuard)) return Promise.resolve(false);
+          return _dropOldestAutoSave(writeGuard, excludedLocal).then(function(dropped) {
+            if (!_writeGuardAllows(writeGuard)) return false;
+            if (dropped) return _put(storeName, record, 1, writeGuard);
+            if (typeof window.toast === 'function') window.toast('❌ 存档空间满·请手动删除旧存档后重试');
+            return false;
+          });
+        }
         return Promise.reject(e);
       }
     }
@@ -372,7 +403,9 @@ var TM_SaveDB = (function() {
           if (isQuota && storeName === SAVE_STORE && !_retryCount) {
             if (!_writeGuardAllows(writeGuard)) { resolve(false); return; }
             console.warn('[SaveDB] 配额已满·尝试清最老自动存档后重试');
-            _dropOldestAutoSave(writeGuard).then(function(dropped) {
+            var excluded = Object.create(null);
+            excluded[String(record.id)] = true;
+            _dropOldestAutoSave(writeGuard, excluded).then(function(dropped) {
               if (!_writeGuardAllows(writeGuard)) { resolve(false); return; }
               if (dropped) {
                 // 重试（带 flag 防止无限递归）

--- a/web/tm-storage.js
+++ b/web/tm-storage.js
@@ -2,7 +2,7 @@
 /// <reference path="types.d.ts" />
 // ============================================================
 // IndexedDB 存储层 — 替代 localStorage 的 5MB 限制
-// 两个 store：saves（游戏存档）+ projects（剧本项目P）
+// 分层 store：大型存档、轻量元数据、剧本项目、年度编年与回合分卷 receipt
 // 带 localStorage 回退
 // ============================================================
 
@@ -52,10 +52,12 @@ var TM_SaveDB = (function() {
   'use strict';
 
   var DB_NAME = 'tianming_db'; // 统一数据库名
-  var DB_VERSION = 3; // v3: 存档 payload 与列表 metadata 分离
+  var DB_VERSION = 4; // v4: 年度编年与回合分卷 receipt 独立轻量持久化
   var SAVE_STORE = 'saves';
   var SAVE_META_STORE = 'saveMetadata';
   var PROJECT_STORE = 'projects';
+  var CHRONICLE_RECORD_STORE = 'chronicleRecords';
+  var TURN_PUBLISH_RECEIPT_STORE = 'turnPublishReceipts';
   var _db = null;
   var _available = false;
   var _openPromise = null; // 防止重复打开
@@ -126,6 +128,12 @@ var TM_SaveDB = (function() {
         }
         if (!db.objectStoreNames.contains(PROJECT_STORE)) {
           db.createObjectStore(PROJECT_STORE, { keyPath: 'id' });
+        }
+        if (!db.objectStoreNames.contains(CHRONICLE_RECORD_STORE)) {
+          db.createObjectStore(CHRONICLE_RECORD_STORE, { keyPath: 'id' });
+        }
+        if (!db.objectStoreNames.contains(TURN_PUBLISH_RECEIPT_STORE)) {
+          db.createObjectStore(TURN_PUBLISH_RECEIPT_STORE, { keyPath: 'id' });
         }
         // v2→v3 只在升级事务中遍历一次旧 payload，之后列表永远只读轻量 metadata。
         if (e.oldVersion > 0 && e.oldVersion < 3 && saveStore && metadataStore) {
@@ -278,7 +286,7 @@ var TM_SaveDB = (function() {
     });
   }
 
-  function _putSaveRecordsAtomic(records, writeGuard, _retryCount) {
+  function _putSaveRecordsAtomic(records, writeGuard, _retryCount, turnPublishReceipt) {
     records = Array.isArray(records) ? records : [];
     if (!records.length) return Promise.resolve(false);
     if (!_writeGuardAllows(writeGuard)) return Promise.resolve(false);
@@ -290,6 +298,11 @@ var TM_SaveDB = (function() {
         items.push({ key: payloadKey, previous: localStorage.getItem(payloadKey) });
         items.push({ key: metadataKey, previous: localStorage.getItem(metadataKey) });
       });
+      var receiptKey = '';
+      if (turnPublishReceipt) {
+        receiptKey = 'tm_idb_' + TURN_PUBLISH_RECEIPT_STORE + '_' + turnPublishReceipt.id;
+        items.push({ key: receiptKey, previous: localStorage.getItem(receiptKey) });
+      }
       var journal = { version: 1, phase: 'prepared', createdAt: Date.now(), items: items };
       try {
         localStorage.setItem(LOCAL_SAVE_BATCH_JOURNAL, JSON.stringify(journal));
@@ -297,6 +310,7 @@ var TM_SaveDB = (function() {
           localStorage.setItem('tm_idb_' + SAVE_STORE + '_' + record.id, JSON.stringify(record));
           localStorage.setItem('tm_idb_' + SAVE_META_STORE + '_' + record.id, JSON.stringify(_toSaveMetadata(record)));
         });
+        if (turnPublishReceipt) localStorage.setItem(receiptKey, JSON.stringify(turnPublishReceipt));
         journal.phase = 'committed';
         localStorage.setItem(LOCAL_SAVE_BATCH_JOURNAL, JSON.stringify(journal));
         localStorage.removeItem(LOCAL_SAVE_BATCH_JOURNAL);
@@ -316,7 +330,7 @@ var TM_SaveDB = (function() {
           if (!_writeGuardAllows(writeGuard)) return Promise.resolve(false);
           return _dropOldestAutoSave(writeGuard, excludedLocal).then(function(dropped) {
             if (!_writeGuardAllows(writeGuard)) return false;
-            if (dropped) return _putSaveRecordsAtomic(records, writeGuard, 1);
+            if (dropped) return _putSaveRecordsAtomic(records, writeGuard, 1, turnPublishReceipt);
             if (typeof window.toast === 'function') window.toast('❌ 存档空间满·请手动删除旧存档后重试');
             return false;
           });
@@ -327,7 +341,9 @@ var TM_SaveDB = (function() {
     return new Promise(function(resolve, reject) {
       try {
         if (!_writeGuardAllows(writeGuard)) { resolve(false); return; }
-        var tx = _db.transaction([SAVE_STORE, SAVE_META_STORE], 'readwrite');
+        var txStores = [SAVE_STORE, SAVE_META_STORE];
+        if (turnPublishReceipt) txStores.push(TURN_PUBLISH_RECEIPT_STORE);
+        var tx = _db.transaction(txStores, 'readwrite');
         var payloadStore = tx.objectStore(SAVE_STORE);
         var metadataStore = tx.objectStore(SAVE_META_STORE);
         var settled = false;
@@ -335,6 +351,7 @@ var TM_SaveDB = (function() {
           payloadStore.put(record);
           metadataStore.put(_toSaveMetadata(record));
         });
+        if (turnPublishReceipt) tx.objectStore(TURN_PUBLISH_RECEIPT_STORE).put(turnPublishReceipt);
         tx.oncomplete = function() { if (!settled) { settled = true; resolve(true); } };
         function fail(e) {
           if (settled) return;
@@ -347,7 +364,7 @@ var TM_SaveDB = (function() {
             console.warn('[SaveDB] canonical 批量存档配额已满·整批回滚后清理旧自动档并重试');
             _dropOldestAutoSave(writeGuard, excluded).then(function(dropped) {
               if (!_writeGuardAllows(writeGuard)) { resolve(false); return; }
-              if (dropped) _putSaveRecordsAtomic(records, writeGuard, 1).then(resolve, reject);
+              if (dropped) _putSaveRecordsAtomic(records, writeGuard, 1, turnPublishReceipt).then(resolve, reject);
               else {
                 if (typeof window.toast === 'function') window.toast('❌ 存档空间满·请手动删除旧存档后重试');
                 resolve(false);
@@ -496,7 +513,8 @@ var TM_SaveDB = (function() {
   }
 
   // ── 通用删除 ──
-  function _del(storeName, id) {
+  function _del(storeName, id, writeGuard) {
+    if (!_writeGuardAllows(writeGuard)) return Promise.resolve(false);
     if (!_available || !_db) {
       try { localStorage.removeItem('tm_idb_' + storeName + '_' + id); } catch(e) { return Promise.reject(e); }
       return Promise.resolve(true);
@@ -667,6 +685,7 @@ var TM_SaveDB = (function() {
       catch (_) { return false; }
     }
     var frozen;
+    var frozenTurnPublishReceipt = null;
     try {
       var seenIds = Object.create(null);
       frozen = entries.map(function(entry) {
@@ -678,6 +697,9 @@ var TM_SaveDB = (function() {
         if (typeof json !== 'string') throw new Error('批量存档正文不可序列化：' + id);
         return { id: id, json: json, meta: Object.assign({}, entry.meta || {}) };
       });
+      if (options.turnPublishReceipt) {
+        frozenTurnPublishReceipt = _normalizeTurnPublishReceipt(options.turnPublishReceipt, 'world-committed');
+      }
     } catch (error) { return Promise.reject(error); }
     if (!_writeStillAllowed()) return Promise.resolve(false);
     return _ensureOpen().then(async function() {
@@ -704,11 +726,11 @@ var TM_SaveDB = (function() {
         });
       }
       if (!_writeStillAllowed()) return false;
-      return _putSaveRecordsAtomic(records, _writeStillAllowed);
+      return _putSaveRecordsAtomic(records, _writeStillAllowed, 0, frozenTurnPublishReceipt);
     });
   }
 
-  /** 分卷发布成功后，以同一批量事务清除 canonical 槽位中的 durable publish marker。 */
+  /** v4 以前的兼容迁移：清除烘在 canonical 槽位正文中的旧 publish marker。 */
   function clearPendingTurnDataPublishAtomic(ids, transactionId, options) {
     ids = Array.isArray(ids) ? ids.map(String) : [];
     transactionId = String(transactionId || '');
@@ -737,6 +759,110 @@ var TM_SaveDB = (function() {
       }
       if (!changed) return true;
       return saveManyAtomic(entries, { writeGuard: stillAllowed });
+    });
+  }
+
+  function _auxRecordId(prefix, campaignId, suffix) {
+    campaignId = String(campaignId || '');
+    suffix = String(suffix == null ? '' : suffix);
+    if (!campaignId || campaignId.length > 128 || !/^[A-Za-z0-9_-]+$/.test(campaignId)) {
+      throw new Error('轻量记录缺少合法 campaignId');
+    }
+    if (!suffix || suffix.length > 160) throw new Error('轻量记录缺少合法键');
+    return prefix + ':' + campaignId + ':' + suffix;
+  }
+
+  /** 年度正史独立 checkpoint；AI 成功结果不必等待下一次大型世界存档。 */
+  function saveChronicleRecord(input, options) {
+    input = input || {};
+    options = options || {};
+    var campaignId = String(input.campaignId || '');
+    var year = Number(input.year);
+    if (!Number.isSafeInteger(year)) return Promise.reject(new Error('年度正史缺少合法年份'));
+    var chronicle;
+    try { chronicle = JSON.parse(JSON.stringify(input.chronicle)); }
+    catch (error) { return Promise.reject(error); }
+    if (!chronicle || typeof chronicle !== 'object' || Array.isArray(chronicle)) {
+      return Promise.reject(new Error('年度正史内容不可持久化'));
+    }
+    var record;
+    try {
+      record = {
+        id: _auxRecordId('chronicle', campaignId, year),
+        campaignId: campaignId,
+        year: year,
+        requestId: String(input.requestId || ''),
+        loadGeneration: Number(input.loadGeneration) || 0,
+        generatedAt: Number(input.generatedAt) || Date.now(),
+        chronicle: chronicle
+      };
+    } catch (error) { return Promise.reject(error); }
+    return _ensureOpen().then(function() {
+      return _put(CHRONICLE_RECORD_STORE, record, 0, options.writeGuard);
+    });
+  }
+
+  function listChronicleRecords(campaignId) {
+    campaignId = String(campaignId || '');
+    if (!campaignId) return Promise.resolve([]);
+    return _ensureOpen().then(function() { return _listAll(CHRONICLE_RECORD_STORE); }).then(function(records) {
+      return (records || []).filter(function(record) { return record && String(record.campaignId || '') === campaignId; });
+    });
+  }
+
+  function _normalizeTurnPublishReceipt(marker, status) {
+    marker = marker || {};
+    var campaignId = String(marker.campaignId || '');
+    var transactionId = String(marker.transactionId || '');
+    var normalizedStatus = String(status || marker.status || 'world-committed');
+    if (['staged', 'world-committed', 'published'].indexOf(normalizedStatus) < 0) {
+      throw new Error('回合分卷 receipt 状态无效');
+    }
+    var record = {
+      id: _auxRecordId('turn-publish', campaignId, transactionId),
+      campaignId: campaignId,
+      transactionId: transactionId,
+      saveName: String(marker.saveName || ''),
+      turn: Number(marker.turn),
+      stateChecksum: String(marker.stateChecksum || ''),
+      status: normalizedStatus,
+      createdAt: Number(marker.createdAt) || Date.now(),
+      updatedAt: Date.now()
+    };
+    if (!Number.isSafeInteger(record.turn) || record.turn < 0) throw new Error('回合分卷 receipt 回合号无效');
+    if (!record.stateChecksum || record.stateChecksum.length > 128) throw new Error('回合分卷 receipt checksum 无效');
+    return record;
+  }
+
+  function saveTurnPublishReceipt(marker, status, options) {
+    options = options || {};
+    var record;
+    try { record = _normalizeTurnPublishReceipt(marker, status); }
+    catch (error) { return Promise.reject(error); }
+    return _ensureOpen().then(function() {
+      return _put(TURN_PUBLISH_RECEIPT_STORE, record, 0, options.writeGuard);
+    });
+  }
+
+  function listTurnPublishReceipts(campaignId, status) {
+    campaignId = String(campaignId || '');
+    status = status == null ? '' : String(status);
+    if (!campaignId) return Promise.resolve([]);
+    return _ensureOpen().then(function() { return _listAll(TURN_PUBLISH_RECEIPT_STORE); }).then(function(records) {
+      return (records || []).filter(function(record) {
+        return record && String(record.campaignId || '') === campaignId && (!status || String(record.status || '') === status);
+      });
+    });
+  }
+
+  function deleteTurnPublishReceipt(marker, options) {
+    marker = marker || {};
+    options = options || {};
+    var id;
+    try { id = _auxRecordId('turn-publish', marker.campaignId, marker.transactionId); }
+    catch (error) { return Promise.reject(error); }
+    return _ensureOpen().then(function() {
+      return _del(TURN_PUBLISH_RECEIPT_STORE, String(id), options.writeGuard);
     });
   }
 
@@ -1024,6 +1150,11 @@ var TM_SaveDB = (function() {
     save: save,
     saveManyAtomic: saveManyAtomic,
     clearPendingTurnDataPublishAtomic: clearPendingTurnDataPublishAtomic,
+    saveChronicleRecord: saveChronicleRecord,
+    listChronicleRecords: listChronicleRecords,
+    saveTurnPublishReceipt: saveTurnPublishReceipt,
+    listTurnPublishReceipts: listTurnPublishReceipts,
+    deleteTurnPublishReceipt: deleteTurnPublishReceipt,
     load: load,
     list: list,
     delete: deleteSave,


### PR DESCRIPTION
## Summary

- protect the current target and canonical recovery slots during single-save quota cleanup
- isolate annual chronicle inputs by the canonical calendar, sort years numerically, and checkpoint completed background chronicles in a lightweight store
- commit desktop turn-publish receipts alongside canonical saves, then clear only the receipt after publish instead of rewriting both large worlds
- retain one-time compatibility recovery for legacy saves with embedded publish markers

## Regression coverage

- single-slot quota recovery cannot delete `autosave`, `slot_0`, `pre_endturn`, or the target being overwritten
- second-year prompts exclude prior-year digests; edicts and foreshadowings use `TimeUtils`
- annual generation waits for world commit, persists before memory exposure, and survives immediate reload
- canonical worlds and turn receipt share one transaction; receipt cleanup does not rewrite world payloads
- post-commit load switches preserve the durable receipt for later recovery

## Local gates

- `npm ci --ignore-scripts`
- official scenario sync + clean diff
- official scenario parity: PASS (27 assertions)
- release contract: PASS (166 files / 37 assertions)
- hot builder gates: PASS (27 assertions)
- architecture guards: PASS (8/8)
- production dependency audit: 0 vulnerabilities (official npm registry)
- full smoke runner: PASS (847 total; 845 direct passes + 2 existing missing-asset whitelist exemptions)
- full-asset hot baseline: PASS (1081 files, version 1.3.4.11)

No package, release, Pages deployment, or version bump is included.