### PR TITLE
fix: close ninth-round audit migration and load gaps

### DIFF
--- a/main-impl.js
+++ b/main-impl.js
@@ -258,7 +258,12 @@ function desktopSaveMetadataPath(storageKey) {
   return path.join(SAVE_METADATA_DIR, storageKey + '.json');
 }
 
-function desktopSaveMetadataFromData(data, storageKey) {
+function desktopSavePayloadStamp(stats) {
+  if (!stats || !Number.isFinite(Number(stats.size)) || !Number.isFinite(Number(stats.mtimeMs))) return null;
+  return { size: Number(stats.size), mtimeMs: Number(stats.mtimeMs) };
+}
+
+function desktopSaveMetadataFromData(data, storageKey, payloadStats) {
   const envelope = data && data.__tmAutoSaveEnvelope === 1 ? data.data : data;
   const meta = envelope && envelope._saveMeta && typeof envelope._saveMeta === 'object' ? envelope._saveMeta : {};
   const state = envelope && envelope.gameState;
@@ -270,7 +275,7 @@ function desktopSaveMetadataFromData(data, storageKey) {
     ? '__autosave__'
     : clean(meta.name || meta.saveName || (gm && gm.saveName) || storageKey, 200);
   return {
-    version: 1,
+    version: 2,
     storageKey: String(storageKey),
     name: canonicalName,
     meta: {
@@ -282,12 +287,15 @@ function desktopSaveMetadataFromData(data, storageKey) {
       campaignId: clean(gm && gm._campaignId, 128),
       timelineId: clean(gm && gm._timelineId, 128)
     },
+    payload: desktopSavePayloadStamp(payloadStats),
+    metadataGeneration: crypto.randomUUID(),
     updatedAt: Date.now()
   };
 }
 
-function writeDesktopSaveMetadata(storageKey, data) {
-  const record = desktopSaveMetadataFromData(data, storageKey);
+function writeDesktopSaveMetadata(storageKey, data, payloadStats) {
+  const record = desktopSaveMetadataFromData(data, storageKey, payloadStats);
+  if (!record.payload) throw new Error('存档 sidecar 缺少正文版本戳');
   writeJsonAtomic(desktopSaveMetadataPath(storageKey), record);
   return record;
 }
@@ -296,11 +304,15 @@ function fallbackDesktopSaveName(storageKey) {
   return String(storageKey || '').replace(/--[0-9a-f]{16}$/i, '') || '未命名存档';
 }
 
-async function readDesktopSaveMetadata(storageKey) {
+async function readDesktopSaveMetadata(storageKey, payloadStats) {
   try {
     const raw = await fs.promises.readFile(desktopSaveMetadataPath(storageKey), 'utf-8');
     const parsed = JSON.parse(raw);
-    if (!parsed || parsed.version !== 1 || String(parsed.storageKey || '') !== String(storageKey)) return null;
+    if (!parsed || (parsed.version !== 1 && parsed.version !== 2) || String(parsed.storageKey || '') !== String(storageKey)) return null;
+    const current = desktopSavePayloadStamp(payloadStats);
+    const recorded = desktopSavePayloadStamp(parsed.payload);
+    parsed._payloadCurrent = !!(parsed.version === 2 && current && recorded
+      && recorded.size === current.size && recorded.mtimeMs === current.mtimeMs);
     return parsed;
   } catch (error) {
     if (error && error.code === 'ENOENT') return null;
@@ -2847,7 +2859,7 @@ ipcMain.handle('save-project', async (event, { filename, data }) => {
     // 2026-06-10·紧凑写盘:同 auto-save·缩进占体积 55%·手动存档同步砍半
     writeFileAtomic(filepath, JSON.stringify(data), 'utf-8');
     let metadataWarning = '';
-    try { writeDesktopSaveMetadata(key, data); }
+    try { writeDesktopSaveMetadata(key, data, fs.statSync(filepath)); }
     catch (metadataError) {
       metadataWarning = String(metadataError && metadataError.message || metadataError);
       console.warn('[save-project] 正文已保存，sidecar 写入失败:', metadataWarning);
@@ -2864,7 +2876,7 @@ ipcMain.handle('load-project', async (event, filename) => {
     const ref = saveFileRef(filename);
     if (!fs.existsSync(ref.path)) return { success: false, error: '文件不存在' };
     const data = JSON.parse(fs.readFileSync(ref.path, 'utf-8'));
-    try { writeDesktopSaveMetadata(ref.key, data); } catch (metadataError) {
+    try { writeDesktopSaveMetadata(ref.key, data, fs.statSync(ref.path)); } catch (metadataError) {
       console.warn('[load-project] sidecar 回填失败:', metadataError && metadataError.message || metadataError);
     }
     return { success: true, data, storageKey: ref.key };
@@ -2885,17 +2897,18 @@ ipcMain.handle('list-saves', async () => {
         const fp = path.join(SAVE_DIR, f);
         const stats = await fs.promises.stat(fp);
         const storageKey = f.replace(/\.json$/i, '');
-        const sidecar = await readDesktopSaveMetadata(storageKey);
-        const _saveMeta = sidecar && sidecar.meta || null;
+        const sidecar = await readDesktopSaveMetadata(storageKey, stats);
+        const sidecarCurrent = !!(sidecar && sidecar._payloadCurrent === true);
+        const _saveMeta = sidecarCurrent && sidecar.meta || null;
         return {
-          name: (sidecar && typeof sidecar.name === 'string' && sidecar.name) || fallbackDesktopSaveName(storageKey),
+          name: (sidecarCurrent && typeof sidecar.name === 'string' && sidecar.name) || fallbackDesktopSaveName(storageKey),
           storageKey,
           size: stats.size,
           modified: stats.mtimeMs,
           modifiedStr: new Date(stats.mtimeMs).toLocaleString('zh-CN'),
           _saveMeta,
           meta: _saveMeta,
-          metadataPending: !sidecar,
+          metadataPending: !sidecarCurrent,
           corrupt: false,
           error: ''
         };
@@ -2904,6 +2917,38 @@ ipcMain.handle('list-saves', async () => {
     return { success: true, files };
   } catch (e) {
     return { success: false, error: e.message };
+  }
+});
+
+// renderer 的 IndexedDB GC 必须同时计算桌面文件存档引用。任何 sidecar 缺失/陈旧时
+// 返回 complete=false，让 renderer fail closed，绝不因看不见桌面引用而误删编年或 receipt。
+ipcMain.handle('list-save-timeline-refs', async () => {
+  try {
+    ensureSaveDir();
+    const entries = await fs.promises.readdir(SAVE_DIR, { withFileTypes: true });
+    const refs = [];
+    let complete = true;
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+      const storageKey = entry.name.replace(/\.json$/i, '');
+      const payloadPath = path.join(SAVE_DIR, entry.name);
+      const stats = await fs.promises.stat(payloadPath);
+      const sidecar = await readDesktopSaveMetadata(storageKey, stats);
+      if (!(sidecar && sidecar._payloadCurrent === true && sidecar.meta)) {
+        complete = false;
+        continue;
+      }
+      const campaignId = String(sidecar.meta.campaignId || '');
+      const timelineId = String(sidecar.meta.timelineId || '');
+      if (!campaignId || !timelineId) {
+        complete = false;
+        continue;
+      }
+      refs.push({ storageKey, campaignId, timelineId });
+    }
+    return { success: true, complete, refs };
+  } catch (e) {
+    return { success: false, complete: false, refs: [], error: e.message };
   }
 });
 
@@ -3010,7 +3055,7 @@ ipcMain.handle('auto-save', (event, payload) => {
       if (requestToken && !autoSaveSessionMatches(requestToken)) {
         return { success: false, stale: true, error: '自动存档提交期间已跨档失效', sessionToken: getAutoSaveSessionToken() };
       }
-      try { writeDesktopSaveMetadata('__autosave__', diskPayload); }
+      try { writeDesktopSaveMetadata('__autosave__', diskPayload, await fs.promises.stat(AUTO_SAVE_FILE)); }
       catch (metadataError) { console.warn('[auto-save] sidecar 写入失败:', metadataError && metadataError.message || metadataError); }
       return { success: true, sessionToken: requestToken || '' };
     } catch (e) {
@@ -3033,10 +3078,14 @@ ipcMain.handle('load-auto-save', async () => {
       if (!fileToken || fileToken !== currentToken) {
         return { success: false, stale: true, error: '自动存档属于已失效的旧局' };
       }
+      try { writeDesktopSaveMetadata('__autosave__', parsed, fs.statSync(AUTO_SAVE_FILE)); }
+      catch (metadataError) { console.warn('[load-auto-save] sidecar 回填失败:', metadataError && metadataError.message || metadataError); }
       return { success: true, data: parsed.data, sessionToken: fileToken };
     }
     // 首次升级前的无 envelope 旧档仅在 sidecar 尚不存在时兼容读取。
     if (getAutoSaveSessionToken()) return { success: false, stale: true, error: '旧自动存档已被新局失效' };
+    try { writeDesktopSaveMetadata('__autosave__', parsed, fs.statSync(AUTO_SAVE_FILE)); }
+    catch (metadataError) { console.warn('[load-auto-save] legacy sidecar 回填失败:', metadataError && metadataError.message || metadataError); }
     return { success: true, data: parsed, sessionToken: '' };
   } catch (e) {
     return { success: false, error: e.message };

--- a/preload-impl.js
+++ b/preload-impl.js
@@ -93,6 +93,9 @@ contextBridge.exposeInMainWorld('tianming', {
   listSaves: () =>
     ipcRenderer.invoke('list-saves'),
 
+  listSaveTimelineRefs: () =>
+    ipcRenderer.invoke('list-save-timeline-refs'),
+
   deleteSave: (filename) =>
     ipcRenderer.invoke('delete-save', filename),
 

--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-19T18:38:20.892Z",
+  "generatedAt": "2026-08-20T02:08:49.075Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -2161,8 +2161,8 @@
     },
     {
       "path": "index.html",
-      "sha256": "e3a2baff35fdd0ad14923d0a40965ef9aeb13d306073ee43fbccb36ee064ba4e",
-      "size": 68582
+      "sha256": "4d6cee867ed96d514ca6b47c4cb3900148fce95ad740ae4c14a2b0944c0dc982",
+      "size": 68606
     },
     {
       "path": "INDEX.md",
@@ -3691,8 +3691,8 @@
     },
     {
       "path": "tm-chronicle-system.js",
-      "sha256": "36052327b81fa3cddf3928a2ba7d313a4d230589b6595a7ea96252743c1192a6",
-      "size": 27104
+      "sha256": "11d211ccd52e0f4313d62ef42413a59523faf9f718ae2cdb392a1968264dc1bf",
+      "size": 27657
     },
     {
       "path": "tm-chronicle-tracker.js",
@@ -5096,8 +5096,8 @@
     },
     {
       "path": "tm-save-lifecycle.js",
-      "sha256": "ec8c206dec82d3d3552b2fbd72b6ea9a23b403b49b2fbbf2288c51fb4aebbe52",
-      "size": 114559
+      "sha256": "651c8146813e0f704cb2a28a8a8e19a1d0d225d4b83b4608330805b9856a6a0e",
+      "size": 120027
     },
     {
       "path": "tm-save-manager.js",
@@ -5146,8 +5146,8 @@
     },
     {
       "path": "tm-state-snapshot.js",
-      "sha256": "9be9918575e045a7ad1e525f3e61033581e4884c0ccd23f88088c1600452b6b3",
-      "size": 19785
+      "sha256": "c31cca7a535b650e39ceb7abdb2d38662c8624692256edde28b704b89036520f",
+      "size": 25261
     },
     {
       "path": "tm-state.js",
@@ -5156,8 +5156,8 @@
     },
     {
       "path": "tm-storage.js",
-      "sha256": "0b30aad1ae7e809d66a60094c8f2b70cf1813c1ed37dac5faa910d9873820d5b",
-      "size": 63398
+      "sha256": "80b5b08a10f2cecabb8c589337ca930ca1972621d577b035effd90ea0e4104db",
+      "size": 68691
     },
     {
       "path": "tm-talent-backlash.js",
@@ -5311,8 +5311,8 @@
     },
     {
       "path": "tm-world-identity.js",
-      "sha256": "d6d3076b81a64703c251424dd58bfd015e69015dce6b51c8480e96cf1d21f9b3",
-      "size": 2122
+      "sha256": "399479d213b0fa4677ba9b545811f0faf6cbe8f321013a32b7554bbe7dc1ed70",
+      "size": 2959
     },
     {
       "path": "tm-world-reactors.js",

--- a/web/index.html
+++ b/web/index.html
@@ -556,8 +556,8 @@ console.log('天命游戏脚本开始加载...');
 <!-- 2026-04-30 12 表结构化记忆（Phase 1）·须在 endturn 之前加载 -->
 <script src="tm-memory-tables.js?v=2026050101"></script>
 <!-- 2026-04-30 Phase 2.1 Swipe 快照与 timeTravel 回溯 -->
-<script src="tm-state-snapshot.js?v=2026050101"></script>
-<script src="tm-world-identity.js?v=20260820-auditfix8"></script>
+<script src="tm-world-identity.js?v=20260820-auditfix9"></script>
+<script src="tm-state-snapshot.js?v=20260820-auditfix9"></script>
 <!-- 2026-04-30 Phase 2.2 本地语义检索（bge-small-zh-v1.5） -->
 <script src="tm-semantic-recall.js?v=20260811-auditfix1"></script>
 <!-- 2026-04-30 P10.4A 召回节流门控（KokoroMemo retrieval_gate 范式） -->
@@ -633,7 +633,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-feudal.js?v=20260707-deadcode"></script>
 <script src="tm-feudal-warfare.js?v=20260707-deadcode"></script>
 <script src="tm-event-system.js?v=20260709"></script>
-<script src="tm-storage.js?v=2026042714"></script>
+<script src="tm-storage.js?v=20260820-auditfix9"></script>
 <script src="tm-endturn-helpers.js?v=2026050701"></script>
 <script src="tm-border-risk.js?v=2026062002"></script><!-- P1-A1a 边境风险结算·激活死字段 borderRisk·A4 消费 defenseBonus -->
 <script src="tm-border-invasion.js?v=20260721"></script><!-- 批二刀2·威胁→侵攻确定性接点·flag borderInvasionEnabled 默认OFF·高压3回合具象化入侵军 -->
@@ -665,7 +665,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-post-turn-jobs.js?v=2026052201"></script>
 <script src="tm-arcs.js?v=2026042714"></script>
 <script src="tm-memory-anchors.js?v=2026042714"></script>
-<script src="tm-chronicle-system.js?v=2026042714"></script>
+<script src="tm-chronicle-system.js?v=20260820-auditfix9"></script>
 <script src="tm-endturn-edict.js?v=20260622-movefix"></script>
 <!-- R110 (2026-04-25) 拆分 tm-endturn.js → prep + ai-infer + core -->
 <!-- R138 (2026-04-25) endturn-prep 再拆·启动 AI 规划独立成 tm-ai-planning -->
@@ -838,7 +838,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-bgm-config.js?v=2026051201"></script>
 <!-- R131 (2026-04-25) tm-audio-theme.js 拆分 → audio-theme + save-lifecycle + office-editor -->
 <script src="tm-audio-theme.js?v=20260710-fontscale"></script>
-<script src="tm-save-lifecycle.js?v=20260811-auditfix1"></script>
+<script src="tm-save-lifecycle.js?v=20260820-auditfix9"></script>
 <script src="tm-office-editor.js?v=20260707-nestflat2"></script>
 <script src="tm-topbar-vars.js?v=20260514-phase8-vars-2"></script>
 <!-- R137 (2026-04-25) 拆 shell-extras → shell UI + 时政面板 -->

--- a/web/scripts/smoke-chronicle-world-lease.js
+++ b/web/scripts/smoke-chronicle-world-lease.js
@@ -175,6 +175,22 @@ function setWorld(id, time, timelineId) {
   check(branchHydrated.merged === 0 && !ctx.ChronicleSystem.yearChronicles[2025],
     'same-campaign durable chronicle never crosses into a different timeline');
 
+  const legacyChronicleTimeline = 'tml_legacy_claim_12345678';
+  setWorld('legacy-chronicle', { year: 2024, startYear: 2024, startMonth: 1, startDay: 1 }, legacyChronicleTimeline);
+  ctx.GM.turn = 1;
+  ctx.ChronicleSystem.addMonthDraft(1, '旧版年度素材', '旧版月稿');
+  durableChronicles.set('legacy-chronicle:' + legacyChronicleTimeline + ':2024', {
+    id: 'chronicle:legacy-chronicle:' + legacyChronicleTimeline + ':2024',
+    campaignId: 'legacy-chronicle', timelineId: legacyChronicleTimeline, year: 2024,
+    sourceTurn: -1, historyBasisHash: '', migrationState: 'legacy-unassigned', generatedAt: 10,
+    chronicle: { content: '迁移后的旧版正史', afterword: '旧史评', generatedAt: 10 }
+  });
+  const legacyHydrated = await ctx.ChronicleSystem.hydrateDurableRecords(ctx.GM, ctx.P);
+  const preservedLegacy = durableChronicles.get('legacy-chronicle:' + legacyChronicleTimeline + ':2024');
+  check(legacyHydrated.merged === 0 && !ctx.ChronicleSystem.yearChronicles[2024]
+    && preservedLegacy.migrationState === 'legacy-unassigned' && preservedLegacy.chronicle.content === '迁移后的旧版正史',
+  'ambiguous v4 chronicle stays durable but is never silently attached to the first loaded legacy branch');
+
   setWorld('annual-filter', { year: 2024, startYear: 2024, startMonth: 1, startDay: 1 }, annualTimeline);
   ctx.GM.turn = first2025Turn + 1;
   ctx.ChronicleSystem.deserialize(canonicalBeforeBackgroundResult, ctx.GM);

--- a/web/scripts/smoke-runtime-save-consistency.js
+++ b/web/scripts/smoke-runtime-save-consistency.js
@@ -107,18 +107,19 @@ ok(/stageTurnData\([\s\S]*?result\.success === true[\s\S]*?回合分卷暂存失
 ok(/function _recoverPendingTurnDataPublish\(\)[\s\S]*?baseRecoveryLeaseCurrent[\s\S]*?listTurnPublishReceipts\(campaignId, timelineId, 'world-committed'\)[\s\S]*?recoverTurnData\(marker\)[\s\S]*?deleteTurnPublishReceipt\(marker/.test(lifecycle),
   '读档按世界身份租约补发独立 receipt，并只删除轻量事务记录');
 {
-  const loadImpl = sliceFn(lifecycle, 'async function _fullLoadGameImpl(');
+  const loadImpl = sliceFn(lifecycle, 'async function _fullLoadGameApplyImpl(');
   const hydrateAt = loadImpl.indexOf('await ChronicleSystem.hydrateDurableRecords(GM, P)');
   const receiptAt = loadImpl.indexOf('await _recoverPendingTurnDataPublish()');
   const forkAt = loadImpl.indexOf('_tmForkLoadedTimeline(GM');
   const enableAt = loadImpl.indexOf('GM.busy = false');
   const showWorldAt = loadImpl.indexOf('_$("G").style.display="grid"');
   const enterAt = loadImpl.indexOf('enterGame()');
-  ok(/function fullLoadGame\(data, loadOptions\)[\s\S]*?window\._tmLoadBarrier = promise/.test(lifecycle)
+  ok(/function fullLoadGame\(data, loadOptions\)[\s\S]*?window\._tmLoadBarrier = barrier/.test(lifecycle)
     && hydrateAt >= 0 && receiptAt > hydrateAt && forkAt > receiptAt && enableAt > forkAt
     && showWorldAt > enableAt && enterAt > showWorldAt,
   '读档以显式 Promise 屏障等待编年 hydration 和 receipt 恢复后才开放玩法');
   ok(/GM\.busy = true;[\s\S]*?GM\._loadHydrationPending = true;/.test(loadImpl)
+    && /function _tmAwaitLoadBarrier\(\)[\s\S]*?result !== true[\s\S]*?throw new Error/.test(lifecycle)
     && /doSaveGame=async function\(\)\{\s*await _tmAwaitLoadBarrier\(\)/.test(lifecycle)
     && /desktopDoSave=async function\(\)\{\s*await _tmAwaitLoadBarrier\(\)/.test(lifecycle)
     && /saveToSlot:\s*async function[\s\S]*?await _tmAwaitLoadBarrier\(\)/.test(manager),
@@ -215,6 +216,77 @@ async function runDynamicLeaseSmokes() {
     releaseBarrier(true);
     await waiting;
     ok(settled === true, 'hydration 完成后 load barrier 才放行等待中的操作');
+  }
+  {
+    const transactionFns = [
+      sliceFn(lifecycle, 'function _tmAwaitLoadBarrier('),
+      sliceFn(lifecycle, 'function _tmCaptureLoadTransaction('),
+      sliceFn(lifecycle, 'function _tmRestoreLoadTransaction('),
+      sliceFn(lifecycle, 'function fullLoadGame('),
+      sliceFn(lifecycle, 'async function _fullLoadGameImpl(')
+    ].join('\n');
+    function makeLoadContext(rollbackMustFail) {
+      let sessionToken = 'session-old-1234567890';
+      const oldP = { marker: 'old-P' };
+      const oldGM = { marker: 'old-GM', running: true, busy: false, _chronicleSysState: { monthDrafts: {}, yearChronicles: {}, yearBases: {} } };
+      const context = {
+        P: oldP, GM: oldGM, Promise, Date, Math, Error, String, Object, Array,
+        console: { warn() {}, error() {}, log() {} },
+        _tmGetDesktopAutoSaveSessionToken() { return sessionToken; },
+        _tmRotateDesktopAutoSaveSession(_reason, token) { sessionToken = token; return token; },
+        ChronicleSystem: { deserialize() {} },
+        buildIndices: rollbackMustFail ? function() { throw new Error('rollback-index-failure'); } : function() {}
+      };
+      context.window = context;
+      context._tmLoadGen = 7;
+      context.scriptData = { customPresets: { old: true } };
+      context._fullLoadGameApplyImpl = async function() {
+        context.P = { marker: 'incoming-P' };
+        context.GM = { marker: 'incoming-GM', running: true, busy: true };
+        context.window.P = context.P;
+        context.window.GM = context.GM;
+        context._tmLoadGen++;
+        context._tmRotateDesktopAutoSaveSession('full-load', 'session-incoming-123456');
+        await Promise.resolve();
+        throw new Error('hydrate-injected-failure');
+      };
+      vm.createContext(context);
+      vm.runInContext(transactionFns, context);
+      return { context, oldP, oldGM, getSession: () => sessionToken };
+    }
+    const restored = makeLoadContext(false);
+    let loadError = null;
+    try { await restored.context.fullLoadGame({}); } catch (error) { loadError = error; }
+    await restored.context._tmAwaitLoadBarrier();
+    ok(loadError && loadError._tmLoadRollbackComplete === true
+      && restored.context.P === restored.oldP && restored.context.GM === restored.oldGM
+      && restored.context._tmLoadGen === 9 && restored.getSession() === 'session-old-1234567890',
+    'hydration 失败恢复原 P/GM 与自动存档 session，并以单调 load generation 失效旧租约');
+
+    const blocked = makeLoadContext(true);
+    let blockedError = null;
+    try { await blocked.context.fullLoadGame({}); } catch (error) { blockedError = error; }
+    let barrierRejected = false;
+    try { await blocked.context._tmAwaitLoadBarrier(); } catch (_) { barrierRejected = true; }
+    ok(blockedError && blockedError._tmLoadRollbackComplete !== true && blockedError._tmLoadRollbackError
+      && barrierRejected === true,
+    '读档回滚自身失败时 barrier 保持 rejected，半恢复世界不能被手动保存入口放行');
+
+    let releaseFirstLoad;
+    const serialized = makeLoadContext(false);
+    serialized.context._fullLoadGameApplyImpl = async function() {
+      await new Promise(resolve => { releaseFirstLoad = resolve; });
+    };
+    const firstLoad = serialized.context.fullLoadGame({ id: 'first' });
+    const firstBarrier = serialized.context._tmLoadBarrier;
+    let overlappingRejected = false;
+    try { await serialized.context.fullLoadGame({ id: 'second' }); } catch (_) { overlappingRejected = true; }
+    ok(overlappingRejected && serialized.context._tmLoadBarrier === firstBarrier
+      && serialized.context._tmActiveLoadTransaction,
+    '重叠读档被同步拒绝且不能替换第一条仍在进行的完成屏障');
+    releaseFirstLoad();
+    await firstLoad;
+    await serialized.context._tmAwaitLoadBarrier();
   }
   {
     const writes = [], order = [];

--- a/web/scripts/smoke-save-integrity-audit.js
+++ b/web/scripts/smoke-save-integrity-audit.js
@@ -35,7 +35,7 @@ console.log('=== save integrity audit ===');
   const b = ctx.stableStorageKey('甲?乙');
   ok(a !== b && a.startsWith('甲_乙--') && b.startsWith('甲_乙--'), 'sanitize 碰撞名使用内容 hash 分离');
   ok(ctx.stableStorageKey('甲:乙') === a, 'storage key 对同一显示名稳定');
-  ok(/readDesktopSaveMetadata\(storageKey\)/.test(main) && /name:\s*\(sidecar/.test(main)
+  ok(/readDesktopSaveMetadata\(storageKey, stats\)/.test(main) && /name:\s*\(sidecarCurrent/.test(main)
     && /name:\s*canonicalName/.test(main), '列表通过轻量 sidecar 返回 display name + canonical storageKey');
 }
 

--- a/web/scripts/smoke-security-trust-boundary.js
+++ b/web/scripts/smoke-security-trust-boundary.js
@@ -184,9 +184,10 @@ async function main() {
   const sidecar = T.desktopSaveMetadataFromData({
     _saveMeta: { name: hostileSaveName, scenario: '<script>owned()</script>', turn: 0 },
     gameState: { turn: 0, _campaignId: 'campaign-sidecar', _timelineId: 'tml_sidecar_12345678', privatePayload: 'must-not-leak' }
-  }, 'manual-save-key');
+  }, 'manual-save-key', { size: 123, mtimeMs: 456 });
   check(sidecar.name === hostileSaveName && sidecar.meta.turn === 0
     && sidecar.meta.campaignId === 'campaign-sidecar' && sidecar.meta.timelineId === 'tml_sidecar_12345678'
+    && sidecar.version === 2 && sidecar.payload.size === 123 && sidecar.payload.mtimeMs === 456
     && !Object.prototype.hasOwnProperty.call(sidecar, 'gameState') && !Object.prototype.hasOwnProperty.call(sidecar.meta, 'privatePayload'),
   'desktop save sidecar preserves display text and identity but never copies world payloads');
   const autoSidecar = T.desktopSaveMetadataFromData({ gameState: { turn: 3, saveName: '玩家档名' } }, '__autosave__');
@@ -241,7 +242,7 @@ async function main() {
   const listSavesEnd = mainSource.indexOf("ipcMain.handle('delete-save'", listSavesStart);
   const listSavesSource = mainSource.slice(listSavesStart, listSavesEnd);
   check(listSavesStart >= 0 && listSavesEnd > listSavesStart
-    && /readDesktopSaveMetadata\(storageKey\)/.test(listSavesSource)
+    && /readDesktopSaveMetadata\(storageKey, stats\)/.test(listSavesSource)
     && !/readFileSync\(fp|JSON\.parse\(raw/.test(listSavesSource),
   'desktop save listing reads lightweight sidecars without parsing every world payload');
   const desktopSaveDir = path.join(TMP, 'userData', 'saves');
@@ -249,12 +250,16 @@ async function main() {
   fs.mkdirSync(desktopMetadataDir, { recursive: true });
   for (let i = 0; i < 100; i++) {
     const storageKey = 'large-save-' + i;
-    fs.writeFileSync(path.join(desktopSaveDir, storageKey + '.json'), '<invalid-json>' + 'x'.repeat(64 * 1024));
+    const payloadPath = path.join(desktopSaveDir, storageKey + '.json');
+    fs.writeFileSync(payloadPath, '<invalid-json>' + 'x'.repeat(64 * 1024));
+    const payloadStats = fs.statSync(payloadPath);
     fs.writeFileSync(path.join(desktopMetadataDir, storageKey + '.json'), JSON.stringify({
-      version: 1,
+      version: 2,
       storageKey,
       name: '大型存档 ' + i,
       meta: { scenario: '测试剧本', turn: i, campaignId: 'campaign-sidecars', timelineId: 'tml_sidecars_12345678' },
+      payload: { size: payloadStats.size, mtimeMs: payloadStats.mtimeMs },
+      metadataGeneration: 'fixture-' + i,
       updatedAt: Date.now()
     }));
   }
@@ -274,6 +279,21 @@ async function main() {
   '100 desktop saves list successfully even when every full payload is deliberately unparsable');
   check(readPaths.length === 100 && readPaths.every(file => path.dirname(file) === path.resolve(desktopMetadataDir)),
     'desktop listing reads only 100 small sidecars and zero world payload files');
+  const refHandler = ipcHandlers.get('list-save-timeline-refs');
+  const refs = await refHandler({ senderFrame: mainFrame, sender: { mainFrame } });
+  check(refs && refs.success === true && refs.complete === true && refs.refs.length === 100
+    && refs.refs.every(ref => ref.campaignId === 'campaign-sidecars' && ref.timelineId === 'tml_sidecars_12345678'),
+  'desktop timeline reference registry is complete when every payload has a current v2 sidecar');
+
+  const stalePayloadPath = path.join(desktopSaveDir, 'large-save-0.json');
+  fs.appendFileSync(stalePayloadPath, 'new-generation');
+  const staleListed = await listHandler({ senderFrame: mainFrame, sender: { mainFrame } });
+  const staleRow = staleListed.files.find(file => file.storageKey === 'large-save-0');
+  const staleRefs = await refHandler({ senderFrame: mainFrame, sender: { mainFrame } });
+  check(staleRow && staleRow.metadataPending === true && staleRow.meta === null && staleRow.name === 'large-save-0',
+    'payload overwrite with a failed sidecar update is shown as metadataPending, never as trusted stale metadata');
+  check(staleRefs && staleRefs.success === true && staleRefs.complete === false,
+    'timeline GC reference registry fails closed while any desktop sidecar is missing or stale');
   check(mainSource.includes("redirect: 'manual'") && mainSource.includes('dns.lookup(hostname, { all: true')
     && mainSource.includes("credentials: 'omit'") && mainSource.includes("referrerPolicy: 'no-referrer'"), 'network proxy revalidates DNS/redirects and omits ambient credentials');
   check(mainSource.includes('WORKSHOP_CATALOG_AUTHORIZATIONS.get(packageUrl)')

--- a/web/scripts/smoke-state-snapshot-integrity.js
+++ b/web/scripts/smoke-state-snapshot-integrity.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
-// StateSnapshot v3：同回合跨战役/时间线隔离、完整状态恢复、异步身份租约与 awaited hook。
+// StateSnapshot v4：旧快照迁移、祖先只读继承、完整状态恢复、异步身份租约与 awaited hook。
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
@@ -12,13 +12,57 @@ let pass = 0;
 function ok(cond, msg) { if (!cond) throw new Error('FAIL: ' + msg); pass++; console.log('  ok - ' + msg); }
 function clone(v) { return JSON.parse(JSON.stringify(v)); }
 
-function fakeIndexedDB() {
+function fakeIndexedDB(options) {
+  options = options || {};
   const stores = new Map();
+  const deletedIndexes = [];
+  if (Array.isArray(options.records)) {
+    stores.set('snapshots_v2', {
+      keyPath: 'id',
+      rows: new Map(options.records.map(record => [String(record.id), clone(record)])),
+      indexes: new Set(options.indexes || ['campaignId', 'campaignTurn'])
+    });
+    stores.set('snapshots', { keyPath: 'turn', rows: new Map(), indexes: new Set() });
+  }
+  function storeFacade(def) {
+    function completeLater(tx) { setTimeout(function() { if (tx && tx.oncomplete) tx.oncomplete(); }, 0); }
+    return {
+      indexNames: { contains(name) { return def.indexes.has(name); } },
+      createIndex(name) { def.indexes.add(name); },
+      deleteIndex(name) { def.indexes.delete(name); deletedIndexes.push(name); },
+      put(record) { def.rows.set(String(record[def.keyPath]), clone(record)); return {}; },
+      get(key) {
+        const req = {};
+        setTimeout(function() { if (req.onsuccess) req.onsuccess({ target: { result: def.rows.has(String(key)) ? clone(def.rows.get(String(key))) : undefined } }); }, 0);
+        return req;
+      },
+      getAll() {
+        const req = {};
+        setTimeout(function() { if (req.onsuccess) req.onsuccess({ target: { result: Array.from(def.rows.values()).map(clone) } }); }, 0);
+        return req;
+      },
+      delete(key) { def.rows.delete(String(key)); return {}; },
+      openCursor() {
+        const req = {};
+        const values = Array.from(def.rows.values()).map(clone);
+        let cursorIndex = 0;
+        function advance() {
+          setTimeout(function() {
+            req.result = cursorIndex < values.length ? { value: values[cursorIndex++], continue: advance } : null;
+            if (req.onsuccess) req.onsuccess({ target: req });
+          }, 0);
+        }
+        advance();
+        return req;
+      },
+      _completeLater: completeLater
+    };
+  }
   const db = {
     objectStoreNames: { contains(name) { return stores.has(name); } },
     createObjectStore(name, options) {
-      if (!stores.has(name)) stores.set(name, { keyPath: options.keyPath, rows: new Map() });
-      return { createIndex() {} };
+      if (!stores.has(name)) stores.set(name, { keyPath: options.keyPath, rows: new Map(), indexes: new Set() });
+      return storeFacade(stores.get(name));
     },
     close() {},
     transaction(name) {
@@ -27,30 +71,24 @@ function fakeIndexedDB() {
       const tx = { error: null, oncomplete: null, onerror: null, onabort: null };
       function completeLater() { setTimeout(function() { if (tx.oncomplete) tx.oncomplete(); }, 0); }
       tx.objectStore = function() {
-        return {
-          put(record) { def.rows.set(record[def.keyPath], clone(record)); completeLater(); return {}; },
-          get(key) {
-            const req = {};
-            setTimeout(function() { if (req.onsuccess) req.onsuccess({ target: { result: def.rows.has(key) ? clone(def.rows.get(key)) : undefined } }); }, 0);
-            return req;
-          },
-          getAll() {
-            const req = {};
-            setTimeout(function() { if (req.onsuccess) req.onsuccess({ target: { result: Array.from(def.rows.values()).map(clone) } }); }, 0);
-            return req;
-          },
-          delete(key) { def.rows.delete(key); completeLater(); return {}; }
-        };
+        const facade = storeFacade(def);
+        const put = facade.put;
+        const del = facade.delete;
+        facade.put = function(record) { const result = put(record); completeLater(); return result; };
+        facade.delete = function(key) { const result = del(key); completeLater(); return result; };
+        return facade;
       };
       return tx;
     }
   };
   return {
     stores,
-    open() {
+    deletedIndexes,
+    open(_name, version) {
       const req = {};
       setTimeout(function() {
-        if (req.onupgradeneeded) req.onupgradeneeded({ target: { result: db } });
+        const upgradeTx = { objectStore(name) { return storeFacade(stores.get(name)); } };
+        if (req.onupgradeneeded) req.onupgradeneeded({ oldVersion: Number(options.oldVersion) || 0, target: { result: db, transaction: upgradeTx } });
         if (req.onsuccess) req.onsuccess({ target: { result: db } });
       }, 0);
       return req;
@@ -93,9 +131,45 @@ function fakeIndexedDB() {
   vm.createContext(ctx);
   vm.runInContext(src, ctx);
 
-  ok(/DB_VERSION = 3/.test(src) && /keyPath: 'id'/.test(src), 'v3 使用 campaign/timeline/turn compound record id');
+  ok(/DB_VERSION = 4/.test(src) && /keyPath: 'id'/.test(src), 'v4 使用 campaign/timeline/turn compound record id');
   ok(/_buildSaveState/.test(src) && /format: 'idb', detach: true/.test(src), '快照复用完整纯存档 builder');
   ok(registeredHook && typeof registeredHook === 'function', 'after hook 已注册');
+
+  function expectedLegacyTimeline(campaignId) {
+    let hash = 2166136261;
+    for (let i = 0; i < campaignId.length; i++) {
+      hash ^= campaignId.charCodeAt(i);
+      hash = Math.imul(hash, 16777619);
+    }
+    return 'tml_legacy_' + (hash >>> 0).toString(16).padStart(8, '0') + '_' + campaignId;
+  }
+  const legacyCampaign = 'campaignLegacy';
+  const legacyTimeline = expectedLegacyTimeline(legacyCampaign);
+  const legacyDb = fakeIndexedDB({
+    oldVersion: 2,
+    records: [{
+      id: legacyCampaign + ':4', campaignId: legacyCampaign, turn: 4, ts: 4, schema: 2,
+      state: { GM: { _campaignId: legacyCampaign, turn: 4, marker: 'legacy-v2' }, P: { conf: { legacy: true } } }
+    }]
+  });
+  const legacyCtx = {
+    console, Promise, Date, Math, JSON, Object, Array, Number,
+    setTimeout, clearTimeout, structuredClone,
+    indexedDB: legacyDb,
+    EndTurnHooks: { register() {} }, addEventListener() {},
+    _buildSaveState(options) { return { GM: clone(options.gm), P: clone(options.p || {}) }; }
+  };
+  legacyCtx.window = legacyCtx;
+  vm.createContext(legacyCtx);
+  vm.runInContext(src, legacyCtx);
+  await legacyCtx.StateSnapshot.list(legacyCampaign, legacyTimeline);
+  await new Promise(resolve => setTimeout(resolve, 20));
+  const migratedLegacy = await legacyCtx.StateSnapshot.load(4, legacyCampaign, legacyTimeline);
+  ok(migratedLegacy && migratedLegacy.state.GM.marker === 'legacy-v2'
+    && migratedLegacy.state.GM._timelineId === legacyTimeline
+    && migratedLegacy.migrationState === 'legacy-v2',
+  'v2 campaign-only snapshot migrates atomically into deterministic legacy timeline');
+  ok(legacyDb.deletedIndexes.includes('campaignTurn'), 'v4 upgrade removes obsolete unique campaignTurn index');
 
   ctx.GM = { _campaignId: 'campA', _timelineId: 'tml_campA_12345678', turn: 1, marker: 'A1', customWorld: { deep: 11 }, shijiHistory: [{ turn: 1, a: 1 }], evtLog: [{ turn: 1 }] };
   ctx.P = { conf: { campaign: 'A' }, mapData: { a: 1 } };
@@ -106,6 +180,23 @@ function fakeIndexedDB() {
   ctx.GM.shijiHistory.push({ turn: 2, a: 2 }); ctx.P.mapData.a = 2;
   r = await ctx.StateSnapshot.save(2);
   ok(r.ok === true && (await ctx.StateSnapshot.list()).length === 2, '同局多回合可列出');
+
+  ctx.GM = {
+    _campaignId: 'campA', _timelineId: 'tml_childA_12345678', _parentTimelineId: 'tml_campA_12345678',
+    _forkTurn: 2, turn: 2, marker: 'A2-child', customWorld: { deep: 23 }, shijiHistory: [], evtLog: []
+  };
+  ctx.P = { conf: { campaign: 'A-child' }, mapData: { a: 23 } };
+  const inheritedList = await ctx.StateSnapshot.list();
+  const inheritedA1 = await ctx.StateSnapshot.load(1);
+  ok(inheritedList.map(item => item.turn).join(',') === '1,2'
+    && inheritedList.every(item => item.inherited === true)
+    && inheritedA1 && inheritedA1.inherited === true && inheritedA1.state.GM.marker === 'A1',
+  '子时间线以父链只读继承 forkTurn 以前的完整快照列表');
+  r = await ctx.StateSnapshot.save(2);
+  const childOverrideList = await ctx.StateSnapshot.list();
+  ok(r.ok === true && childOverrideList[0].inherited === true && childOverrideList[1].inherited === false
+    && (await ctx.StateSnapshot.load(2)).state.GM.marker === 'A2-child',
+  '子时间线同回合快照覆盖父线视图但不复制其他祖先 payload');
 
   ctx.GM = { _campaignId: 'campB', _timelineId: 'tml_campB_12345678', turn: 1, marker: 'B1', customWorld: { deep: 99 }, shijiHistory: [], evtLog: [] };
   ctx.P = { conf: { campaign: 'B' } };

--- a/web/scripts/smoke-storage-atomic-batch.js
+++ b/web/scripts/smoke-storage-atomic-batch.js
@@ -275,6 +275,36 @@ function makeContext(indexedDB, localStorage) {
   check(gcIdb.stores.get('chronicleRecords').size === 0 && gcIdb.stores.get('turnPublishReceipts').size === 0,
     'deleting the final timeline save garbage-collects its chronicle and receipt records');
 
+  const desktopGcIdb = makeIndexedDB();
+  const desktopGcCtx = makeContext(desktopGcIdb, makeLocalStorage());
+  let desktopRefs = [{ storageKey: 'manual-desktop', campaignId: 'campaign-desktop-gc', timelineId: 'tml_desktop_gc_12345678' }];
+  let desktopRefsComplete = true;
+  desktopGcCtx.tianming = {
+    isDesktop: true,
+    async listSaveTimelineRefs() { return { success: true, complete: desktopRefsComplete, refs: desktopRefs }; }
+  };
+  await desktopGcCtx.TM_SaveDB.open();
+  const desktopGcState = { GM: { turn: 8, _campaignId: 'campaign-desktop-gc', _timelineId: 'tml_desktop_gc_12345678' }, P: {} };
+  await desktopGcCtx.TM_SaveDB.save('slot_desktop_gc', desktopGcState, { type: 'manual', turn: 8 });
+  await desktopGcCtx.TM_SaveDB.saveChronicleRecord({
+    campaignId: 'campaign-desktop-gc', timelineId: 'tml_desktop_gc_12345678', year: 2024, sourceTurn: 8,
+    historyBasisHash: 'chb_desktop_gc_12345678', chronicle: { content: '桌面分支正史' }
+  });
+  await desktopGcCtx.TM_SaveDB.delete('slot_desktop_gc');
+  check(desktopGcIdb.stores.get('chronicleRecords').size === 1,
+    'desktop sidecar reference keeps auxiliary records after the final IndexedDB slot is removed');
+  desktopRefs = [];
+  desktopRefsComplete = false;
+  await desktopGcCtx.TM_SaveDB.save('slot_desktop_gc_retry', desktopGcState, { type: 'manual', turn: 8 });
+  await desktopGcCtx.TM_SaveDB.delete('slot_desktop_gc_retry');
+  check(desktopGcIdb.stores.get('chronicleRecords').size === 1,
+    'incomplete desktop reference registry makes auxiliary GC fail closed');
+  desktopRefsComplete = true;
+  await desktopGcCtx.TM_SaveDB.save('slot_desktop_gc_final', desktopGcState, { type: 'manual', turn: 8 });
+  await desktopGcCtx.TM_SaveDB.delete('slot_desktop_gc_final');
+  check(desktopGcIdb.stores.get('chronicleRecords').size === 0,
+    'auxiliary records are collected only after both IndexedDB and complete desktop registries have no references');
+
   const oldBranchState = { GM: { turn: 20, _campaignId: 'campaign-overwrite', _timelineId: 'tml_overwrite_old_12345678' }, P: {} };
   await gcCtx.TM_SaveDB.save('slot_overwrite', oldBranchState, { type: 'manual', turn: 20 });
   await gcCtx.TM_SaveDB.saveChronicleRecord({

--- a/web/scripts/smoke-storage-metadata-index.js
+++ b/web/scripts/smoke-storage-metadata-index.js
@@ -14,13 +14,25 @@ function check(condition, message) {
   assertions += 1;
 }
 
-function makeFakeIndexedDB(legacySaves) {
+function makeFakeIndexedDB(legacySaves, options) {
+  options = options || {};
   const stores = new Map();
   if (Array.isArray(legacySaves)) {
     stores.set('saves', new Map(legacySaves.map((record) => [String(record.id), JSON.parse(JSON.stringify(record))])));
     stores.set('projects', new Map());
   }
-  const oldVersion = Array.isArray(legacySaves) ? 2 : 0;
+  if (options.oldVersion > 0 && !stores.has('saves')) {
+    stores.set('saves', new Map());
+    stores.set('saveMetadata', new Map());
+    stores.set('projects', new Map());
+  }
+  if (Array.isArray(options.chronicles)) {
+    stores.set('chronicleRecords', new Map(options.chronicles.map((record) => [String(record.id), clone(record)])));
+  }
+  if (Array.isArray(options.receipts)) {
+    stores.set('turnPublishReceipts', new Map(options.receipts.map((record) => [String(record.id), clone(record)])));
+  }
+  const oldVersion = Number(options.oldVersion) || (Array.isArray(legacySaves) ? 2 : 0);
   const counters = { openedVersion: 0, openCalls: 0, closed: 0, getAll: Object.create(null), get: Object.create(null) };
 
   function clone(value) {
@@ -31,6 +43,7 @@ function makeFakeIndexedDB(legacySaves) {
     if (!stores.has(name)) throw new Error('missing store ' + name);
     const rows = stores.get(name);
     return {
+      indexNames: { contains() { return false; } },
       createIndex() {},
       put(value) { rows.set(String(value.id), clone(value)); },
       delete(id) { rows.delete(String(id)); },
@@ -144,12 +157,12 @@ function makeLocalStorage() {
   context.SaveCompression.compress = (text) => Promise.resolve(text);
 
   await context.TM_SaveDB.open();
-  check(indexedDB.counters.openedVersion === 5, 'storage schema must open IndexedDB version 5');
+  check(indexedDB.counters.openedVersion === 6, 'storage schema must open IndexedDB version 6');
   check(indexedDB.stores.has('chronicleRecords') && indexedDB.stores.has('turnPublishReceipts'),
-    'v5 upgrade creates lightweight chronicle and turn receipt stores');
+    'v6 upgrade creates lightweight chronicle and turn receipt stores');
   check(source.includes("ensureIndex(chronicleStore, 'campaignTimeline'")
     && source.includes("ensureIndex(receiptStore, 'campaignTimelineStatus'"),
-  'v5 upgrade indexes auxiliary records by campaign and timeline');
+  'v6 upgrade indexes auxiliary records by campaign and timeline');
 
   const payload = 'x'.repeat(64 * 1024);
   await Promise.all(Array.from({ length: 100 }, (_, index) => context.TM_SaveDB.save(
@@ -203,6 +216,52 @@ function makeLocalStorage() {
   check(migratedList.length === 2 && migratedList[0].id === 'legacy-b', 'v2 upgrade must backfill and sort metadata for existing saves');
   check(Array.from(legacyIndexedDB.stores.get('saveMetadata').values()).every((row) => !Object.prototype.hasOwnProperty.call(row, 'gameState')),
     'v2 metadata backfill must not duplicate legacy payloads');
+
+  const oldChronicleId = 'chronicle:campaign-v4:2025';
+  const oldReceiptId = 'turn-publish:campaign-v4:txn-v4';
+  const auxiliaryIndexedDB = makeFakeIndexedDB(null, {
+    oldVersion: 5,
+    chronicles: [{
+      id: oldChronicleId,
+      campaignId: 'campaign-v4',
+      year: 2025,
+      generatedAt: 10,
+      chronicle: { content: '旧版正史', afterword: '旧评' }
+    }],
+    receipts: [{
+      id: oldReceiptId,
+      campaignId: 'campaign-v4',
+      transactionId: 'txn-v4',
+      turn: 12,
+      stateChecksum: 'a'.repeat(64),
+      status: 'world-committed'
+    }]
+  });
+  const auxiliaryContext = {
+    console: { log() {}, warn() {}, error() {}, info() {} },
+    Promise, Math, Date, JSON, Object, Array, Number, String, Boolean, Error,
+    Blob, Response, CompressionStream, DecompressionStream, TextDecoder,
+    setTimeout, clearTimeout,
+    localStorage: makeLocalStorage(), navigator: { storage: null }, indexedDB: auxiliaryIndexedDB
+  };
+  auxiliaryContext.window = auxiliaryContext;
+  auxiliaryContext.globalThis = auxiliaryContext;
+  vm.createContext(auxiliaryContext);
+  vm.runInContext(bootAt > 0 ? source.slice(0, bootAt) : source, auxiliaryContext, { filename: 'tm-storage-v5-aux.js' });
+  await auxiliaryContext.TM_SaveDB.open();
+  await new Promise(resolve => setTimeout(resolve, 30));
+  const migratedChronicles = Array.from(auxiliaryIndexedDB.stores.get('chronicleRecords').values());
+  const migratedReceipts = Array.from(auxiliaryIndexedDB.stores.get('turnPublishReceipts').values());
+  check(migratedChronicles.length === 1 && migratedChronicles[0].id !== oldChronicleId
+    && /^tml_legacy_/.test(migratedChronicles[0].timelineId)
+    && migratedChronicles[0].migrationState === 'legacy-unassigned',
+  'v4/v5 chronicle rows migrate atomically to deterministic legacy timeline keys');
+  check(migratedReceipts.length === 1 && migratedReceipts[0].id !== oldReceiptId
+    && migratedReceipts[0].timelineId === migratedChronicles[0].timelineId
+    && migratedReceipts[0].migrationState === 'legacy-v4',
+  'v4/v5 turn receipts remain recoverable on the same deterministic legacy timeline');
+  check((await auxiliaryContext.TM_SaveDB.listChronicleRecords('campaign-v4', migratedChronicles[0].timelineId)).length === 1,
+    'migrated chronicle is visible through the timeline-scoped query');
 
   console.log('[smoke-storage-metadata-index] PASS assertions=' + assertions);
 })().catch((error) => {

--- a/web/tm-chronicle-system.js
+++ b/web/tm-chronicle-system.js
@@ -483,26 +483,34 @@ var ChronicleSystem = {
     return TM_SaveDB.listChronicleRecords(campaignId, timelineId).then(function(records) {
       if (!leaseIsCurrent()) return { ok: false, stale: true };
       var merged = 0;
-      (records || []).sort(function(a, b) { return Number(a && a.generatedAt || 0) - Number(b && b.generatedAt || 0); }).forEach(function(record) {
-        if (!record || String(record.campaignId || '') !== campaignId || String(record.timelineId || '') !== timelineId) return;
+      records = (records || []).sort(function(a, b) { return Number(a && a.generatedAt || 0) - Number(b && b.generatedAt || 0); });
+      for (var recordIndex = 0; recordIndex < records.length; recordIndex++) {
+        var record = records[recordIndex];
+        if (!record || String(record.campaignId || '') !== campaignId || String(record.timelineId || '') !== timelineId) continue;
         var year = Number(record.year);
         var incoming = record.chronicle;
-        if (!Number.isSafeInteger(year) || !incoming || typeof incoming !== 'object' || Array.isArray(incoming)) return;
-        if (typeof incoming.content !== 'string' || !incoming.content) return;
-        var sourceTurn = Number(record.sourceTurn);
-        if (!Number.isSafeInteger(sourceTurn) || sourceTurn < 0 || sourceTurn > Number(targetGM.turn || 0)) return;
+        if (!Number.isSafeInteger(year) || !incoming || typeof incoming !== 'object' || Array.isArray(incoming)) continue;
+        if (typeof incoming.content !== 'string' || !incoming.content) continue;
         var currentBasis = targetState.yearBases[year] || _chronicleBuildYearBasis(targetGM, targetState, year);
-        if (!currentBasis || currentBasis.sourceTurn !== sourceTurn || currentBasis.historyBasisHash !== String(record.historyBasisHash || '')) return;
+        if (String(record.migrationState || '') === 'legacy-unassigned') {
+          // v4 checkpoint 没有 sourceTurn/historyBasisHash，无法证明它属于哪个旧存档分支。
+          // 迁移器会完整保留这条记录供显式导入/诊断，但 hydration 绝不把它静默附着到
+          // “第一个被加载的世界”，否则一次升级就会重新制造跨分支串史。
+          continue;
+        }
+        var sourceTurn = Number(record.sourceTurn);
+        if (!Number.isSafeInteger(sourceTurn) || sourceTurn < 0 || sourceTurn > Number(targetGM.turn || 0)) continue;
+        if (!currentBasis || currentBasis.sourceTurn !== sourceTurn || currentBasis.historyBasisHash !== String(record.historyBasisHash || '')) continue;
         targetState.yearBases[year] = currentBasis;
         var current = targetState.yearChronicles[year];
-        if (current && Number(current.generatedAt || 0) >= Number(record.generatedAt || incoming.generatedAt || 0)) return;
+        if (current && Number(current.generatedAt || 0) >= Number(record.generatedAt || incoming.generatedAt || 0)) continue;
         var cloned = null;
         try { cloned = JSON.parse(JSON.stringify(incoming)); } catch (_) { cloned = null; }
-        if (!cloned) return;
+        if (!cloned) continue;
         if (current && current.read === true) cloned.read = true;
         targetState.yearChronicles[year] = cloned;
         merged++;
-      });
+      }
       _chronicleTrimYears(targetState, targetP);
       if (merged && leaseIsCurrent() && typeof renderBiannian === 'function') {
         try { renderBiannian(); } catch (_) {}

--- a/web/tm-save-lifecycle.js
+++ b/web/tm-save-lifecycle.js
@@ -57,7 +57,12 @@ function _tmEnsureTimelineIdentity(gm) {
   } catch (_) {}
   var id = typeof gm._timelineId === 'string' ? gm._timelineId.trim() : '';
   if (!id || id.length > 128 || !/^tml_[A-Za-z0-9_-]+$/.test(id)) {
-    id = 'tml_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 14);
+    try {
+      if (gm._campaignId && typeof window !== 'undefined' && typeof window._tmLegacyTimelineId === 'function') {
+        id = window._tmLegacyTimelineId(gm._campaignId);
+      }
+    } catch (_) {}
+    if (!id) id = 'tml_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 14);
   }
   gm._timelineId = id;
   return id;
@@ -81,7 +86,10 @@ function _tmForkLoadedTimeline(gm, reason) {
 
 function _tmAwaitLoadBarrier() {
   var barrier = (typeof window !== 'undefined') ? window._tmLoadBarrier : null;
-  return barrier && typeof barrier.then === 'function' ? barrier : Promise.resolve(true);
+  return (barrier && typeof barrier.then === 'function' ? barrier : Promise.resolve(true)).then(function(result) {
+    if (result !== true) throw new Error('读档尚未完整完成，保存与过回合已阻止');
+    return true;
+  });
 }
 
 // 确保 GM 所有字段存在默认值（存档前/读档后统一调用）
@@ -1066,15 +1074,93 @@ function _recoverPendingTurnDataPublish() {
   });
 }
 
+function _tmCaptureLoadTransaction() {
+  var oldP = (typeof P !== 'undefined') ? P : null;
+  var oldGM = (typeof GM !== 'undefined') ? GM : null;
+  var presets = null;
+  try {
+    presets = window.scriptData && window.scriptData.customPresets;
+  } catch (_) {}
+  return {
+    id: 'load-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 12),
+    P: oldP,
+    GM: oldGM,
+    gmBusy: oldGM && oldGM.busy,
+    hydrationPending: oldGM && oldGM._loadHydrationPending,
+    autoSaveSessionToken: (typeof _tmGetDesktopAutoSaveSessionToken === 'function') ? _tmGetDesktopAutoSaveSessionToken() : '',
+    customPresets: presets
+  };
+}
+
+function _tmRestoreLoadTransaction(txn) {
+  if (!txn) throw new Error('读档回滚缺少事务快照');
+  P = txn.P;
+  GM = txn.GM;
+  if (typeof window !== 'undefined') {
+    window.P = P;
+    window.GM = GM;
+    // load generation 必须单调增加；倒退会让旧 AI/存储租约重新变成有效。
+    window._tmLoadGen = Number(window._tmLoadGen || 0) + 1;
+  }
+  if (GM) {
+    GM.busy = txn.gmBusy;
+    if (txn.hydrationPending === undefined) delete GM._loadHydrationPending;
+    else GM._loadHydrationPending = txn.hydrationPending;
+  }
+  if (typeof _tmInstallScenarioGetter === 'function') _tmInstallScenarioGetter();
+  if (typeof ChronicleSystem !== 'undefined' && ChronicleSystem && typeof ChronicleSystem.deserialize === 'function') {
+    ChronicleSystem.deserialize(GM && GM._chronicleSysState || null, GM);
+  }
+  if (GM && GM._warTruces && typeof WarWeightSystem !== 'undefined' && WarWeightSystem && typeof WarWeightSystem.deserialize === 'function') {
+    WarWeightSystem.deserialize(GM._warTruces);
+  }
+  if (GM && GM._rngState && typeof restoreRng === 'function') restoreRng(GM._rngState);
+  if (typeof _tmRotateDesktopAutoSaveSession === 'function') {
+    var rollbackSessionToken = txn.autoSaveSessionToken;
+    if (!rollbackSessionToken && typeof _tmNewDesktopAutoSaveSessionToken === 'function') {
+      rollbackSessionToken = _tmNewDesktopAutoSaveSessionToken();
+    }
+    if (rollbackSessionToken) _tmRotateDesktopAutoSaveSession('load-rollback', rollbackSessionToken);
+  }
+  try {
+    if (window.scriptData) window.scriptData.customPresets = txn.customPresets;
+  } catch (_) {}
+  if (typeof buildIndices === 'function') buildIndices();
+  try {
+    if (window.TM && TM.FactionIndex && typeof TM.FactionIndex.rebuild === 'function') TM.FactionIndex.rebuild();
+  } catch (_) {}
+  try {
+    if (window.TMPhase8FormalBridge && typeof window.TMPhase8FormalBridge.restoreDraftsFromGM === 'function') {
+      window.TMPhase8FormalBridge.restoreDraftsFromGM(true);
+    }
+  } catch (_) {}
+  if (GM && GM.running) {
+    ['renderGameState', 'renderOfficeTree', 'renderBiannian', 'renderMemorials', 'renderJishi',
+      'renderShijiList', 'renderGameTech', 'renderGameCivic', 'renderRenwu', 'renderSidePanels'].forEach(function(name) {
+      try { if (typeof window[name] === 'function') window[name](); } catch (_) {}
+    });
+  }
+  return true;
+}
+
 function fullLoadGame(data, loadOptions) {
+  if (typeof window !== 'undefined' && window._tmActiveLoadTransaction) {
+    return Promise.reject(new Error('已有读档正在完成，请稍候再切换存档'));
+  }
   var promise = _fullLoadGameImpl(data, loadOptions);
+  var barrier = promise.then(function() { return true; });
+  barrier.catch(function() {}); // barrier 本身保持 rejected；这里只防止无人等待时产生 unhandled rejection。
   try {
     if (typeof window !== 'undefined') {
-      window._tmLoadBarrier = promise;
+      window._tmLoadBarrier = barrier;
       promise.then(function() {
-        if (window._tmLoadBarrier === promise) window._tmLoadBarrier = Promise.resolve(true);
-      }, function() {
-        if (window._tmLoadBarrier === promise) window._tmLoadBarrier = Promise.resolve(false);
+        if (window._tmLoadBarrier === barrier) window._tmLoadBarrier = Promise.resolve(true);
+      }, function(error) {
+        // 成功恢复旧世界后允许继续保存旧局；回滚失败则保留 rejected barrier，绝不把
+        // 半载入世界伪装成 Promise.resolve(false) 后交给忽略返回值的调用方。
+        if (window._tmLoadBarrier === barrier && error && error._tmLoadRollbackComplete === true) {
+          window._tmLoadBarrier = Promise.resolve(true);
+        }
       });
     }
   } catch (_) {}
@@ -1082,6 +1168,29 @@ function fullLoadGame(data, loadOptions) {
 }
 
 async function _fullLoadGameImpl(data, loadOptions){
+  var _loadTxn = _tmCaptureLoadTransaction();
+  if (typeof window !== 'undefined') window._tmActiveLoadTransaction = _loadTxn;
+  try {
+    await _fullLoadGameApplyImpl(data, loadOptions, _loadTxn);
+    if (typeof window !== 'undefined' && window._tmActiveLoadTransaction === _loadTxn) {
+      window._tmActiveLoadTransaction = null;
+    }
+  } catch (error) {
+    if (!error || (typeof error !== 'object' && typeof error !== 'function')) error = new Error(String(error));
+    if (typeof window !== 'undefined' && window._tmActiveLoadTransaction === _loadTxn) {
+      try {
+        _tmRestoreLoadTransaction(_loadTxn);
+        error._tmLoadRollbackComplete = true;
+      } catch (rollbackError) {
+        error._tmLoadRollbackError = rollbackError;
+      }
+      window._tmActiveLoadTransaction = null;
+    }
+    throw error;
+  }
+}
+
+async function _fullLoadGameApplyImpl(data, loadOptions, _loadTxn){
   loadOptions = loadOptions || {};
   // 跨档保留 API 设置：localStorage 的 tm_api 是用户的"机器"配置·不应被存档覆盖
   var _preservedAi = null;
@@ -1120,6 +1229,14 @@ async function _fullLoadGameImpl(data, loadOptions){
   if (GM) GM._isFreshNewGame = false;
   if (typeof _tmInstallScenarioGetter === 'function') _tmInstallScenarioGetter(); // P 整体重赋值后重装 P.scenario 派生 getter
   try { if (typeof window !== 'undefined') window._tmLoadGen = (window._tmLoadGen || 0) + 1; } catch (_lg) {} // 读档代际++·按GM.turn失效的模块级缓存(officeIndex/memCache)读同turn档曾泄漏旧局数据(2026-07-04 审查定罪)
+  var _loadLeaseP = P;
+  var _loadLeaseGM = GM;
+  var _loadLeaseGen = (typeof window !== 'undefined') ? Number(window._tmLoadGen || 0) : 0;
+  function _assertLoadLeaseCurrent() {
+    var current = (typeof window === 'undefined') || (window._tmActiveLoadTransaction === _loadTxn
+      && window.P === _loadLeaseP && window.GM === _loadLeaseGM && Number(window._tmLoadGen || 0) === _loadLeaseGen);
+    if (!current) throw new Error('读档请求已被更新的世界切换取代');
+  }
   // 同步通知主进程切换 canonical auto-save session。旧 IPC 即使正在 writeFile，rename 前也会因 token 失效被拒；
   // 从 canonical 自动档恢复时沿用其 token，普通案卷/残局读档则创建新 token。
   try {
@@ -1394,8 +1511,10 @@ async function _fullLoadGameImpl(data, loadOptions){
     // 读档完成屏障：先合并当前父时间线的有效辅助记录和可恢复分卷，再开放任何玩法操作。
     if (typeof ChronicleSystem !== 'undefined' && typeof ChronicleSystem.hydrateDurableRecords === 'function') {
       await ChronicleSystem.hydrateDurableRecords(GM, P);
+      _assertLoadLeaseCurrent();
     }
     await _recoverPendingTurnDataPublish();
+    _assertLoadLeaseCurrent();
     // 每次从快照继续都建立子时间线；失败回滚可显式 preserveTimeline 复原原身份。
     if (!loadOptions.preserveTimeline) _tmForkLoadedTimeline(GM, loadOptions.source || 'load');
     GM._loadHydrationPending = false;

--- a/web/tm-state-snapshot.js
+++ b/web/tm-state-snapshot.js
@@ -12,9 +12,23 @@
   var DB_NAME = 'tianming_snapshots';
   var LEGACY_STORE = 'snapshots';
   var STORE = 'snapshots_v2';
-  var DB_VERSION = 3;
+  var DB_VERSION = 4;
   var MAX_SNAPSHOTS = 200;
   var _dbPromise = null;
+
+  function _legacyTimelineId(campaignId) {
+    try {
+      if (typeof global._tmLegacyTimelineId === 'function') return global._tmLegacyTimelineId(campaignId);
+    } catch (_) {}
+    var source = String(campaignId || '').trim();
+    var hash = 2166136261;
+    for (var i = 0; i < source.length; i++) {
+      hash ^= source.charCodeAt(i);
+      hash = Math.imul(hash, 16777619);
+    }
+    var tail = source.replace(/[^A-Za-z0-9_-]/g, '_').slice(-40) || 'campaign';
+    return 'tml_legacy_' + (hash >>> 0).toString(16).padStart(8, '0') + '_' + tail;
+  }
 
   function _newCampaignId() {
     try {
@@ -40,7 +54,9 @@
       if (typeof global._tmEnsureTimelineId === 'function') return global._tmEnsureTimelineId(gm);
     } catch (_) {}
     var id = typeof gm._timelineId === 'string' ? gm._timelineId.trim() : '';
-    if (!/^tml_[A-Za-z0-9_-]{8,124}$/.test(id)) id = 'tml_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 14);
+    if (!/^tml_[A-Za-z0-9_-]{8,124}$/.test(id)) {
+      id = gm._campaignId ? _legacyTimelineId(gm._campaignId) : 'tml_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 14);
+    }
     gm._timelineId = id;
     return id;
   }
@@ -75,10 +91,42 @@
           store.createIndex('campaignId', 'campaignId', { unique: false });
           store.createIndex('campaignTimeline', ['campaignId', 'timelineId'], { unique: false });
           store.createIndex('timelineTurn', ['campaignId', 'timelineId', 'turn'], { unique: true });
-        } else if (e.oldVersion < 3) {
+        } else {
           var existingStore = e.target.transaction.objectStore(STORE);
-          try { existingStore.createIndex('campaignTimeline', ['campaignId', 'timelineId'], { unique: false }); } catch (_) {}
-          try { existingStore.createIndex('timelineTurn', ['campaignId', 'timelineId', 'turn'], { unique: true }); } catch (_) {}
+          try {
+            if (existingStore.indexNames && existingStore.indexNames.contains('campaignTurn')) existingStore.deleteIndex('campaignTurn');
+          } catch (_) {}
+          try {
+            if (!existingStore.indexNames || !existingStore.indexNames.contains('campaignTimeline')) {
+              existingStore.createIndex('campaignTimeline', ['campaignId', 'timelineId'], { unique: false });
+            }
+          } catch (_) {}
+          try {
+            if (!existingStore.indexNames || !existingStore.indexNames.contains('timelineTurn')) {
+              existingStore.createIndex('timelineTurn', ['campaignId', 'timelineId', 'turn'], { unique: true });
+            }
+          } catch (_) {}
+          if (e.oldVersion > 0 && e.oldVersion < 4) {
+            var cursorReq = existingStore.openCursor();
+            cursorReq.onsuccess = function() {
+              var cursor = cursorReq.result;
+              if (!cursor) return;
+              var record = cursor.value;
+              if (record && record.campaignId && !/^tml_[A-Za-z0-9_-]{8,124}$/.test(String(record.timelineId || ''))) {
+                var oldId = String(record.id || '');
+                var timelineId = _legacyTimelineId(record.campaignId);
+                record.timelineId = timelineId;
+                record.id = _recordId(record.campaignId, timelineId, record.turn);
+                record.schema = Math.max(3, Number(record.schema) || 0);
+                record.migrationState = 'legacy-v2';
+                record.legacySourceId = oldId;
+                if (record.state && record.state.GM) record.state.GM._timelineId = timelineId;
+                existingStore.put(record);
+                if (oldId && oldId !== record.id) existingStore.delete(oldId);
+              }
+              cursor.continue();
+            };
+          }
         }
         // v1 的 partial GM 快照不能安全升级成完整 {GM,P}，保留旧 store 只读，
         // 但绝不混入 v2 列表或恢复路径。
@@ -135,6 +183,47 @@
           tx.onabort = function(e) { reject((e.target && e.target.error) || tx.error || new Error('快照读取事务已中止')); };
         } catch (e) { reject(e); }
       });
+    });
+  }
+
+  function _timelineOwnerFromRecords(records, campaignId, timelineId, maxTurn) {
+    var candidates = (records || []).filter(function(record) {
+      return record && record.campaignId === campaignId && record.timelineId === timelineId
+        && (!Number.isFinite(maxTurn) || Number(record.turn) <= maxTurn) && record.state && record.state.GM;
+    }).sort(function(a, b) { return Number(b.turn) - Number(a.turn) || Number(b.ts) - Number(a.ts); });
+    return candidates.length ? candidates[0].state.GM : null;
+  }
+
+  // 子时间线可只读继承 forkTurn 以前的祖先快照。当前线记录优先；祖先 payload 不复制，
+  // 因而长局分叉不会造成成倍存储，同时不会让一次正常读档把 T1..Tn 历史列表清空。
+  function _accessibleSnapshotRecords(records, campaignId, timelineId, currentGM) {
+    var chain = [];
+    var seen = Object.create(null);
+    var cursorTimeline = timelineId;
+    var cursorOwner = currentGM && currentGM._campaignId === campaignId && currentGM._timelineId === timelineId ? currentGM : null;
+    var maxTurn = Infinity;
+    while (cursorTimeline && !seen[cursorTimeline]) {
+      seen[cursorTimeline] = true;
+      chain.push({ timelineId: cursorTimeline, maxTurn: maxTurn });
+      if (!cursorOwner) cursorOwner = _timelineOwnerFromRecords(records, campaignId, cursorTimeline, maxTurn);
+      var parentTimeline = cursorOwner && String(cursorOwner._parentTimelineId || '');
+      var forkTurn = cursorOwner && Number(cursorOwner._forkTurn);
+      if (!parentTimeline || !Number.isSafeInteger(forkTurn) || forkTurn < 0) break;
+      maxTurn = Math.min(maxTurn, forkTurn);
+      cursorTimeline = parentTimeline;
+      cursorOwner = _timelineOwnerFromRecords(records, campaignId, cursorTimeline, maxTurn);
+    }
+    var byTurn = Object.create(null);
+    chain.forEach(function(access, depth) {
+      (records || []).forEach(function(record) {
+        if (!record || record.campaignId !== campaignId || record.timelineId !== access.timelineId) return;
+        var turn = Number(record.turn);
+        if (!Number.isSafeInteger(turn) || turn > access.maxTurn || byTurn[turn]) return;
+        byTurn[turn] = { record: record, inherited: depth > 0, sourceTimelineId: access.timelineId };
+      });
+    });
+    return Object.keys(byTurn).map(function(turn) { return byTurn[turn]; }).sort(function(a, b) {
+      return Number(a.record.turn) - Number(b.record.turn);
     });
   }
 
@@ -217,6 +306,18 @@
             tx.onabort = function(e) { reject((e.target && e.target.error) || tx.error || new Error('快照读取事务已中止')); };
           } catch (e) { reject(e); }
         });
+      }).then(function(exact) {
+        if (exact) return exact;
+        return _getAllRecords().then(function(records) {
+          var currentGM = global.GM || (typeof GM !== 'undefined' ? GM : null);
+          var accessible = _accessibleSnapshotRecords(records, campaignId, timelineId, currentGM);
+          var match = accessible.find(function(item) { return Number(item.record.turn) === _strictTurn(turn); });
+          if (!match) return null;
+          var inherited = _deepClone(match.record);
+          inherited.inherited = true;
+          inherited.sourceTimelineId = match.sourceTimelineId;
+          return inherited;
+        });
       });
     } catch (e) { return Promise.reject(e); }
   }
@@ -227,9 +328,17 @@
     timelineId = timelineId || (gm ? _ensureTimelineId(gm) : '');
     if (!campaignId || !timelineId) return Promise.resolve([]);
     return _getAllRecords().then(function(records) {
-      return records.filter(function(r) { return r && r.campaignId === campaignId && r.timelineId === timelineId; })
-        .sort(function(a, b) { return a.turn - b.turn; })
-        .map(function(r) { return { turn: r.turn, ts: r.ts, campaignId: r.campaignId, timelineId: r.timelineId }; });
+      return _accessibleSnapshotRecords(records, campaignId, timelineId, gm).map(function(item) {
+        var r = item.record;
+        return {
+          turn: r.turn,
+          ts: r.ts,
+          campaignId: r.campaignId,
+          timelineId: timelineId,
+          sourceTimelineId: item.sourceTimelineId,
+          inherited: item.inherited
+        };
+      });
     });
   }
 
@@ -297,7 +406,8 @@
 
     return loadSnapshot(target, campaignId, timelineId).then(function(targetRecord) {
       if (!targetRecord) return { ok: false, reason: 'no snapshot for turn ' + target };
-      if (!targetRecord.state || targetRecord.campaignId !== campaignId || targetRecord.timelineId !== timelineId || targetRecord.turn !== target) {
+      if (!targetRecord.state || targetRecord.campaignId !== campaignId || targetRecord.turn !== target
+          || (!targetRecord.inherited && targetRecord.timelineId !== timelineId)) {
         return { ok: false, reason: 'snapshot identity mismatch' };
       }
       if (!_stillCurrent(sourceGM, sourceP, sourceLoadGen, campaignId, timelineId)) {

--- a/web/tm-storage.js
+++ b/web/tm-storage.js
@@ -52,7 +52,7 @@ var TM_SaveDB = (function() {
   'use strict';
 
   var DB_NAME = 'tianming_db'; // 统一数据库名
-  var DB_VERSION = 5; // v5: 辅助记录按 campaign + timeline 建索引并参与存档生命周期回收
+  var DB_VERSION = 6; // v6: 将 v4/v5 的无 timeline 辅助记录原子迁入确定性 legacy 时间线
   var SAVE_STORE = 'saves';
   var SAVE_META_STORE = 'saveMetadata';
   var PROJECT_STORE = 'projects';
@@ -68,6 +68,58 @@ var TM_SaveDB = (function() {
     slot_0: true,
     pre_endturn: true
   });
+
+  function _legacyTimelineId(campaignId) {
+    try {
+      if (typeof window !== 'undefined' && typeof window._tmLegacyTimelineId === 'function') {
+        return window._tmLegacyTimelineId(campaignId);
+      }
+    } catch (_) {}
+    var source = String(campaignId || '').trim();
+    var hash = 2166136261;
+    for (var i = 0; i < source.length; i++) {
+      hash ^= source.charCodeAt(i);
+      hash = Math.imul(hash, 16777619);
+    }
+    var tail = source.replace(/[^A-Za-z0-9_-]/g, '_').slice(-40) || 'campaign';
+    return 'tml_legacy_' + (hash >>> 0).toString(16).padStart(8, '0') + '_' + tail;
+  }
+
+  function _migrateLocalAuxiliaryRecords() {
+    [CHRONICLE_RECORD_STORE, TURN_PUBLISH_RECEIPT_STORE].forEach(function(storeName) {
+      var prefix = 'tm_idb_' + storeName + '_';
+      var keys = [];
+      for (var i = 0; i < localStorage.length; i++) {
+        var key = localStorage.key(i);
+        if (key && key.indexOf(prefix) === 0) keys.push(key);
+      }
+      keys.forEach(function(oldKey) {
+        var raw = localStorage.getItem(oldKey);
+        if (!raw) return;
+        var record;
+        try { record = JSON.parse(raw); } catch (_) { return; }
+        if (!record || _validTimelineId(record.timelineId) || !record.campaignId) return;
+        var oldId = String(record.id || oldKey.slice(prefix.length));
+        var timelineId = _legacyTimelineId(record.campaignId);
+        record.timelineId = timelineId;
+        record.legacySourceId = oldId;
+        if (storeName === CHRONICLE_RECORD_STORE) {
+          if (!Number.isSafeInteger(Number(record.year))) return;
+          record.id = _auxRecordId('chronicle', record.campaignId, timelineId + ':' + Number(record.year));
+          record.sourceTurn = -1;
+          record.historyBasisHash = '';
+          record.migrationState = 'legacy-unassigned';
+        } else {
+          if (!String(record.transactionId || '')) return;
+          record.id = _auxRecordId('turn-publish', record.campaignId, timelineId + ':' + String(record.transactionId || ''));
+          record.migrationState = 'legacy-v4';
+        }
+        var newKey = prefix + record.id;
+        localStorage.setItem(newKey, JSON.stringify(record));
+        if (newKey !== oldKey) localStorage.removeItem(oldKey);
+      });
+    });
+  }
 
   function _restoreLocalSaveBatchItems(items) {
     items = Array.isArray(items) ? items : [];
@@ -99,6 +151,8 @@ var TM_SaveDB = (function() {
   function open() {
     try { _recoverLocalSaveBatchJournal(); }
     catch (journalError) { return Promise.reject(new Error('localStorage 批量存档恢复失败：' + (journalError && journalError.message || journalError))); }
+    try { _migrateLocalAuxiliaryRecords(); }
+    catch (migrationError) { console.warn('[SaveDB] localStorage 辅助记录迁移延后重试:', migrationError); }
     if (_db) return Promise.resolve(_db);
     if (_openPromise) return _openPromise;
 
@@ -143,6 +197,41 @@ var TM_SaveDB = (function() {
         ensureIndex(chronicleStore, 'campaignTimeline', ['campaignId', 'timelineId']);
         ensureIndex(chronicleStore, 'campaignTimelineYear', ['campaignId', 'timelineId', 'year']);
         ensureIndex(receiptStore, 'campaignTimelineStatus', ['campaignId', 'timelineId', 'status']);
+        // v4 的 key 只有 campaign/year 或 campaign/transactionId；v5 只补了索引，旧行仍不进入
+        // compound index。v6 在同一 upgrade transaction 中先 put 新键、再删旧键；任何异常都会
+        // 由 IndexedDB 原子回滚，旧记录可在下次启动继续迁移。
+        if (e.oldVersion > 0 && e.oldVersion < 6) {
+          function migrateAuxStore(store, kind) {
+            var cursorReq = store.openCursor();
+            cursorReq.onsuccess = function() {
+              var cursor = cursorReq.result;
+              if (!cursor) return;
+              var record = cursor.value;
+              if (record && record.campaignId && !_validTimelineId(record.timelineId)) {
+                var oldId = String(record.id || '');
+                var timelineId = _legacyTimelineId(record.campaignId);
+                record.timelineId = timelineId;
+                record.legacySourceId = oldId;
+                if (kind === 'chronicle') {
+                  if (!Number.isSafeInteger(Number(record.year))) { cursor.continue(); return; }
+                  record.id = _auxRecordId('chronicle', record.campaignId, timelineId + ':' + Number(record.year));
+                  record.sourceTurn = -1;
+                  record.historyBasisHash = '';
+                  record.migrationState = 'legacy-unassigned';
+                } else {
+                  if (!String(record.transactionId || '')) { cursor.continue(); return; }
+                  record.id = _auxRecordId('turn-publish', record.campaignId, timelineId + ':' + String(record.transactionId || ''));
+                  record.migrationState = 'legacy-v4';
+                }
+                store.put(record);
+                if (oldId && oldId !== record.id) store.delete(oldId);
+              }
+              cursor.continue();
+            };
+          }
+          migrateAuxStore(chronicleStore, 'chronicle');
+          migrateAuxStore(receiptStore, 'turn-publish');
+        }
         // v2→v3 只在升级事务中遍历一次旧 payload，之后列表永远只读轻量 metadata。
         if (e.oldVersion > 0 && e.oldVersion < 3 && saveStore && metadataStore) {
           var cursorReq = saveStore.openCursor();
@@ -1050,6 +1139,18 @@ var TM_SaveDB = (function() {
   }
 
   /** 删除游戏存档 */
+  function _desktopTimelineMayBeReferenced(campaignId, timelineId) {
+    var bridge = (typeof window !== 'undefined') ? window.tianming : null;
+    if (!(bridge && bridge.isDesktop)) return Promise.resolve(false);
+    if (typeof bridge.listSaveTimelineRefs !== 'function') return Promise.resolve(true);
+    return Promise.resolve(bridge.listSaveTimelineRefs()).then(function(result) {
+      if (!(result && result.success === true && result.complete === true && Array.isArray(result.refs))) return true;
+      return result.refs.some(function(ref) {
+        return ref && String(ref.campaignId || '') === campaignId && String(ref.timelineId || '') === timelineId;
+      });
+    }).catch(function() { return true; });
+  }
+
   function _gcAuxiliaryTimelineIfUnreferenced(metadata) {
     var campaignId = String(metadata && metadata.campaignId || '');
     var timelineId = String(metadata && metadata.timelineId || '');
@@ -1059,10 +1160,13 @@ var TM_SaveDB = (function() {
         return record && String(record.campaignId || '') === campaignId && String(record.timelineId || '') === timelineId;
       });
       if (referenced) return false;
-      return Promise.all([
-        listChronicleRecords(campaignId, timelineId).then(function(rows) { return _deleteMany(CHRONICLE_RECORD_STORE, rows); }),
-        listTurnPublishReceipts(campaignId, timelineId, '').then(function(rows) { return _deleteMany(TURN_PUBLISH_RECEIPT_STORE, rows); })
-      ]).then(function() { return true; });
+      return _desktopTimelineMayBeReferenced(campaignId, timelineId).then(function(desktopReferenced) {
+        if (desktopReferenced) return false;
+        return Promise.all([
+          listChronicleRecords(campaignId, timelineId).then(function(rows) { return _deleteMany(CHRONICLE_RECORD_STORE, rows); }),
+          listTurnPublishReceipts(campaignId, timelineId, '').then(function(rows) { return _deleteMany(TURN_PUBLISH_RECEIPT_STORE, rows); })
+        ]).then(function() { return true; });
+      });
     });
   }
 

--- a/web/tm-world-identity.js
+++ b/web/tm-world-identity.js
@@ -30,10 +30,26 @@
     return _newId('tml_');
   }
 
+  // v8 以前的存档、编年 checkpoint 与时间快照只有 campaignId。升级时必须
+  // 将它们稳定地汇入同一条 legacy 时间线；若每次读档随机补 timelineId，
+  // 物理上仍在 IndexedDB 的旧记录会永远无法重新关联。
+  function legacyTimelineId(campaignId) {
+    var source = String(campaignId || '').trim();
+    var hash = 2166136261;
+    for (var i = 0; i < source.length; i++) {
+      hash ^= source.charCodeAt(i);
+      hash = Math.imul(hash, 16777619);
+    }
+    var tail = source.replace(/[^A-Za-z0-9_-]/g, '_').slice(-40) || 'campaign';
+    return 'tml_legacy_' + (hash >>> 0).toString(16).padStart(8, '0') + '_' + tail;
+  }
+
   function ensureTimelineId(gm) {
     if (!gm || typeof gm !== 'object') return '';
     var id = gm._timelineId;
-    if (!_validId(id, 'tml_')) id = newTimelineId();
+    if (!_validId(id, 'tml_')) {
+      id = gm._campaignId ? legacyTimelineId(gm._campaignId) : newTimelineId();
+    }
     gm._timelineId = id;
     return id;
   }
@@ -51,11 +67,13 @@
 
   global.TMWorldIdentity = {
     newTimelineId: newTimelineId,
+    legacyTimelineId: legacyTimelineId,
     ensureTimelineId: ensureTimelineId,
     forkTimeline: forkTimeline,
     isValidTimelineId: function(value) { return _validId(value, 'tml_'); }
   };
   global._tmNewTimelineId = newTimelineId;
+  global._tmLegacyTimelineId = legacyTimelineId;
   global._tmEnsureTimelineId = ensureTimelineId;
   global._tmForkTimeline = forkTimeline;
 })(typeof window !== 'undefined' ? window : this);


### PR DESCRIPTION
## Summary

- atomically migrate v4/v5 auxiliary records and v2 state snapshots into deterministic legacy timelines
- preserve ambiguous legacy chronicles as `legacy-unassigned` instead of silently attaching them to the first loaded branch
- make failed world hydration transactional, restore the prior world/session, keep load generations monotonic, and fail closed if rollback itself fails
- expose parent-timeline snapshots read-only up to each fork point without copying world payloads
- include current desktop sidecars in auxiliary-record GC and reject collection when the desktop reference set is incomplete
- validate sidecar metadata against the exact payload generation and show stale metadata as pending

## Verification

- `npm ci --ignore-scripts`
- `node web/scripts/sync-official-scenarios.js`
- `git diff --exit-code`
- `node web/scripts/verify-official-scenario-parity.js`
- `node scripts/verify-release-contract.js`
- `node web/scripts/verify-hot-builder-gates.js`
- `node web/scripts/lint-arch-all.js`
- `node web/scripts/ci-smokes.js` (847 selected; 845 direct pass + 2 existing missing-asset allowlist exemptions)
- full local asset baseline: 1,082 files, version 1.3.4.11
- `npm audit --omit=dev --audit-level=high --registry=https://registry.npmjs.org` (0 vulnerabilities)

No package, release, Pages deployment, or version bump is included.