### PR TITLE
fix: close tenth-round audit load and lineage gaps

### DIFF
--- a/main-impl.js
+++ b/main-impl.js
@@ -258,12 +258,51 @@ function desktopSaveMetadataPath(storageKey) {
   return path.join(SAVE_METADATA_DIR, storageKey + '.json');
 }
 
-function desktopSavePayloadStamp(stats) {
-  if (!stats || !Number.isFinite(Number(stats.size)) || !Number.isFinite(Number(stats.mtimeMs))) return null;
-  return { size: Number(stats.size), mtimeMs: Number(stats.mtimeMs) };
+function desktopSaveGenerationPath(storageKey) {
+  storageKey = String(storageKey == null ? '' : storageKey);
+  if (!storageKey || storageKey.length > 140 || path.basename(storageKey) !== storageKey || /[<>:"/\\|?*]/.test(storageKey)) {
+    throw new Error('存档代际标识非法');
+  }
+  return path.join(SAVE_METADATA_DIR, storageKey + '.generation.json');
 }
 
-function desktopSaveMetadataFromData(data, storageKey, payloadStats) {
+function normalizeDesktopSaveGeneration(value) {
+  value = String(value || '').trim();
+  return value.length >= 16 && value.length <= 160 && /^[A-Za-z0-9._:-]+$/.test(value) ? value : '';
+}
+
+function desktopSaveGenerationFromData(data) {
+  return normalizeDesktopSaveGeneration(data && data.__tmDesktopSaveGeneration);
+}
+
+function prepareDesktopSavePayload(data, requestedGeneration) {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) throw new Error('存档正文必须是对象');
+  // 每次正文提交必须轮换 generation；不得复用 renderer 随存档带回的旧值，
+  // 否则同尺寸快速覆盖且 sidecar 写失败时，旧元数据仍可能被误认作当前。
+  const generation = normalizeDesktopSaveGeneration(requestedGeneration) || crypto.randomUUID();
+  // generation 必须位于 JSON 前缀，列表页只读一个很小的正文头即可将 sidecar/commit marker
+  // 绑定到真实 payload，而不必解析几十至数百 MB 的世界正文。
+  const preparedData = Object.assign({ __tmDesktopSaveGeneration: generation }, data);
+  preparedData.__tmDesktopSaveGeneration = generation;
+  return { data: preparedData, generation, text: JSON.stringify(preparedData) };
+}
+
+function desktopSavePayloadStamp(stats) {
+  if (!stats || !Number.isFinite(Number(stats.size)) || !Number.isFinite(Number(stats.mtimeMs))) return null;
+  const stamp = { size: Number(stats.size), mtimeMs: Number(stats.mtimeMs) };
+  if (Number.isFinite(Number(stats.ctimeMs))) stamp.ctimeMs = Number(stats.ctimeMs);
+  if (Number.isFinite(Number(stats.birthtimeMs))) stamp.birthtimeMs = Number(stats.birthtimeMs);
+  if (Number.isFinite(Number(stats.ino))) stamp.ino = Number(stats.ino);
+  if (Number.isFinite(Number(stats.dev))) stamp.dev = Number(stats.dev);
+  return stamp;
+}
+
+function desktopSavePayloadStampMatches(recorded, current) {
+  if (!recorded || !current || recorded.size !== current.size || recorded.mtimeMs !== current.mtimeMs) return false;
+  return ['ctimeMs', 'birthtimeMs', 'ino', 'dev'].every(key => recorded[key] == null || recorded[key] === current[key]);
+}
+
+function desktopSaveMetadataFromData(data, storageKey, payloadStats, payloadGeneration) {
   const envelope = data && data.__tmAutoSaveEnvelope === 1 ? data.data : data;
   const meta = envelope && envelope._saveMeta && typeof envelope._saveMeta === 'object' ? envelope._saveMeta : {};
   const state = envelope && envelope.gameState;
@@ -275,7 +314,7 @@ function desktopSaveMetadataFromData(data, storageKey, payloadStats) {
     ? '__autosave__'
     : clean(meta.name || meta.saveName || (gm && gm.saveName) || storageKey, 200);
   return {
-    version: 2,
+    version: 3,
     storageKey: String(storageKey),
     name: canonicalName,
     meta: {
@@ -288,14 +327,69 @@ function desktopSaveMetadataFromData(data, storageKey, payloadStats) {
       timelineId: clean(gm && gm._timelineId, 128)
     },
     payload: desktopSavePayloadStamp(payloadStats),
+    payloadGeneration: normalizeDesktopSaveGeneration(payloadGeneration) || desktopSaveGenerationFromData(data),
     metadataGeneration: crypto.randomUUID(),
     updatedAt: Date.now()
   };
 }
 
-function writeDesktopSaveMetadata(storageKey, data, payloadStats) {
-  const record = desktopSaveMetadataFromData(data, storageKey, payloadStats);
-  if (!record.payload) throw new Error('存档 sidecar 缺少正文版本戳');
+function writeDesktopSaveGeneration(storageKey, payloadGeneration) {
+  payloadGeneration = normalizeDesktopSaveGeneration(payloadGeneration);
+  if (!payloadGeneration) throw new Error('存档正文缺少真实代际');
+  writeJsonAtomic(desktopSaveGenerationPath(storageKey), {
+    version: 1,
+    storageKey: String(storageKey),
+    payloadGeneration,
+    updatedAt: Date.now()
+  });
+  return payloadGeneration;
+}
+
+function invalidateDesktopSaveGeneration(storageKey) {
+  try { fs.unlinkSync(desktopSaveGenerationPath(storageKey)); }
+  catch (error) { if (!(error && error.code === 'ENOENT')) throw error; }
+}
+
+async function readDesktopSavePayloadGeneration(payloadPath) {
+  let handle = null;
+  try {
+    handle = await fs.promises.open(payloadPath, 'r');
+    const buffer = Buffer.alloc(512);
+    const result = await handle.read(buffer, 0, buffer.length, 0);
+    const prefix = buffer.subarray(0, result.bytesRead).toString('utf8').replace(/^\uFEFF/, '');
+    const match = /^\s*\{\s*"__tmDesktopSaveGeneration"\s*:\s*"([A-Za-z0-9._:-]{16,160})"/.exec(prefix);
+    return normalizeDesktopSaveGeneration(match && match[1]);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return '';
+    console.warn('[save-metadata] payload generation read failed:', payloadPath, error && error.message || error);
+    return '';
+  } finally {
+    if (handle) {
+      try { await handle.close(); } catch (_) {}
+    }
+  }
+}
+
+async function readDesktopSaveGeneration(storageKey, payloadPath) {
+  try {
+    const raw = await fs.promises.readFile(desktopSaveGenerationPath(storageKey), 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || parsed.version !== 1 || String(parsed.storageKey || '') !== String(storageKey)) return '';
+    const markerGeneration = normalizeDesktopSaveGeneration(parsed.payloadGeneration);
+    const payloadGeneration = await readDesktopSavePayloadGeneration(payloadPath);
+    return markerGeneration && markerGeneration === payloadGeneration ? markerGeneration : '';
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return '';
+    console.warn('[save-metadata] generation read failed:', storageKey, error && error.message || error);
+    return '';
+  }
+}
+
+function writeDesktopSaveMetadata(storageKey, data, payloadStats, payloadGeneration) {
+  payloadGeneration = normalizeDesktopSaveGeneration(payloadGeneration) || desktopSaveGenerationFromData(data);
+  const record = desktopSaveMetadataFromData(data, storageKey, payloadStats, payloadGeneration);
+  if (!record.payload || !record.payloadGeneration) throw new Error('存档 sidecar 缺少正文版本戳或代际');
+  writeDesktopSaveGeneration(storageKey, payloadGeneration);
   writeJsonAtomic(desktopSaveMetadataPath(storageKey), record);
   return record;
 }
@@ -304,15 +398,17 @@ function fallbackDesktopSaveName(storageKey) {
   return String(storageKey || '').replace(/--[0-9a-f]{16}$/i, '') || '未命名存档';
 }
 
-async function readDesktopSaveMetadata(storageKey, payloadStats) {
+async function readDesktopSaveMetadata(storageKey, payloadStats, payloadGeneration) {
   try {
     const raw = await fs.promises.readFile(desktopSaveMetadataPath(storageKey), 'utf-8');
     const parsed = JSON.parse(raw);
-    if (!parsed || (parsed.version !== 1 && parsed.version !== 2) || String(parsed.storageKey || '') !== String(storageKey)) return null;
+    if (!parsed || ![1, 2, 3].includes(parsed.version) || String(parsed.storageKey || '') !== String(storageKey)) return null;
     const current = desktopSavePayloadStamp(payloadStats);
     const recorded = desktopSavePayloadStamp(parsed.payload);
-    parsed._payloadCurrent = !!(parsed.version === 2 && current && recorded
-      && recorded.size === current.size && recorded.mtimeMs === current.mtimeMs);
+    const currentGeneration = normalizeDesktopSaveGeneration(payloadGeneration);
+    parsed._payloadCurrent = !!(parsed.version === 3 && currentGeneration
+      && normalizeDesktopSaveGeneration(parsed.payloadGeneration) === currentGeneration
+      && desktopSavePayloadStampMatches(recorded, current));
     return parsed;
   } catch (error) {
     if (error && error.code === 'ENOENT') return null;
@@ -2856,10 +2952,12 @@ ipcMain.handle('save-project', async (event, { filename, data }) => {
     ensureSaveDir();
     const key = stableStorageKey(filename);
     const filepath = path.join(SAVE_DIR, key + '.json');
+    const prepared = prepareDesktopSavePayload(data);
     // 2026-06-10·紧凑写盘:同 auto-save·缩进占体积 55%·手动存档同步砍半
-    writeFileAtomic(filepath, JSON.stringify(data), 'utf-8');
+    invalidateDesktopSaveGeneration(key);
+    writeFileAtomic(filepath, prepared.text, 'utf-8');
     let metadataWarning = '';
-    try { writeDesktopSaveMetadata(key, data, fs.statSync(filepath)); }
+    try { writeDesktopSaveMetadata(key, prepared.data, fs.statSync(filepath), prepared.generation); }
     catch (metadataError) {
       metadataWarning = String(metadataError && metadataError.message || metadataError);
       console.warn('[save-project] 正文已保存，sidecar 写入失败:', metadataWarning);
@@ -2876,7 +2974,14 @@ ipcMain.handle('load-project', async (event, filename) => {
     const ref = saveFileRef(filename);
     if (!fs.existsSync(ref.path)) return { success: false, error: '文件不存在' };
     const data = JSON.parse(fs.readFileSync(ref.path, 'utf-8'));
-    try { writeDesktopSaveMetadata(ref.key, data, fs.statSync(ref.path)); } catch (metadataError) {
+    let payloadGeneration = desktopSaveGenerationFromData(data);
+    if (!payloadGeneration) {
+      const prepared = prepareDesktopSavePayload(data);
+      payloadGeneration = prepared.generation;
+      invalidateDesktopSaveGeneration(ref.key);
+      writeFileAtomic(ref.path, prepared.text, 'utf-8');
+    }
+    try { writeDesktopSaveMetadata(ref.key, data, fs.statSync(ref.path), payloadGeneration); } catch (metadataError) {
       console.warn('[load-project] sidecar 回填失败:', metadataError && metadataError.message || metadataError);
     }
     return { success: true, data, storageKey: ref.key };
@@ -2897,7 +3002,8 @@ ipcMain.handle('list-saves', async () => {
         const fp = path.join(SAVE_DIR, f);
         const stats = await fs.promises.stat(fp);
         const storageKey = f.replace(/\.json$/i, '');
-        const sidecar = await readDesktopSaveMetadata(storageKey, stats);
+        const payloadGeneration = await readDesktopSaveGeneration(storageKey, fp);
+        const sidecar = await readDesktopSaveMetadata(storageKey, stats, payloadGeneration);
         const sidecarCurrent = !!(sidecar && sidecar._payloadCurrent === true);
         const _saveMeta = sidecarCurrent && sidecar.meta || null;
         return {
@@ -2933,7 +3039,8 @@ ipcMain.handle('list-save-timeline-refs', async () => {
       const storageKey = entry.name.replace(/\.json$/i, '');
       const payloadPath = path.join(SAVE_DIR, entry.name);
       const stats = await fs.promises.stat(payloadPath);
-      const sidecar = await readDesktopSaveMetadata(storageKey, stats);
+      const payloadGeneration = await readDesktopSaveGeneration(storageKey, payloadPath);
+      const sidecar = await readDesktopSaveMetadata(storageKey, stats, payloadGeneration);
       if (!(sidecar && sidecar._payloadCurrent === true && sidecar.meta)) {
         complete = false;
         continue;
@@ -2959,6 +3066,8 @@ ipcMain.handle('delete-save', async (event, filename) => {
     if (fs.existsSync(ref.path)) fs.unlinkSync(ref.path);
     try { fs.unlinkSync(desktopSaveMetadataPath(ref.key)); }
     catch (metadataError) { if (!(metadataError && metadataError.code === 'ENOENT')) throw metadataError; }
+    try { fs.unlinkSync(desktopSaveGenerationPath(ref.key)); }
+    catch (generationError) { if (!(generationError && generationError.code === 'ENOENT')) throw generationError; }
     return { success: true };
   } catch (e) {
     return { success: false, error: e.message };
@@ -3043,19 +3152,21 @@ ipcMain.handle('auto-save', (event, payload) => {
       const diskPayload = requestToken
         ? { __tmAutoSaveEnvelope: 1, sessionToken: requestToken, data: data }
         : data;
+      const prepared = prepareDesktopSavePayload(diskPayload);
       // 2026-06-10·紧凑写盘:pretty-print 缩进占存档体积 55%(实测 113MB→48MB)·机器读写无人看·JSON.parse 两者通吃
-      await fs.promises.writeFile(tmpFile, JSON.stringify(diskPayload), 'utf-8');
+      await fs.promises.writeFile(tmpFile, prepared.text, 'utf-8');
       // writeFile 在途可跨越 renderer 的同步 rotate；rename 前必须按 sidecar 再验。
       if (requestToken && !autoSaveSessionMatches(requestToken)) {
         try { await fs.promises.unlink(tmpFile); } catch (_) {}
         return { success: false, stale: true, error: '自动存档写入期间已跨档失效', sessionToken: getAutoSaveSessionToken() };
       }
+      invalidateDesktopSaveGeneration('__autosave__');
       await fs.promises.rename(tmpFile, AUTO_SAVE_FILE);
       // rotate 可与原子 rename 的系统调用并行完成；即使旧 envelope 已落下，sidecar 不匹配也使其不可恢复。
       if (requestToken && !autoSaveSessionMatches(requestToken)) {
         return { success: false, stale: true, error: '自动存档提交期间已跨档失效', sessionToken: getAutoSaveSessionToken() };
       }
-      try { writeDesktopSaveMetadata('__autosave__', diskPayload, await fs.promises.stat(AUTO_SAVE_FILE)); }
+      try { writeDesktopSaveMetadata('__autosave__', prepared.data, await fs.promises.stat(AUTO_SAVE_FILE), prepared.generation); }
       catch (metadataError) { console.warn('[auto-save] sidecar 写入失败:', metadataError && metadataError.message || metadataError); }
       return { success: true, sessionToken: requestToken || '' };
     } catch (e) {
@@ -3068,6 +3179,7 @@ ipcMain.handle('auto-save', (event, payload) => {
 
 ipcMain.handle('load-auto-save', async () => {
   try {
+    await autoSaveWriteQueue;
     if (!fs.existsSync(AUTO_SAVE_FILE)) return { success: false };
     const parsed = JSON.parse(fs.readFileSync(AUTO_SAVE_FILE, 'utf-8'));
     if (parsed && parsed.__tmAutoSaveEnvelope === 1) {
@@ -3078,13 +3190,27 @@ ipcMain.handle('load-auto-save', async () => {
       if (!fileToken || fileToken !== currentToken) {
         return { success: false, stale: true, error: '自动存档属于已失效的旧局' };
       }
-      try { writeDesktopSaveMetadata('__autosave__', parsed, fs.statSync(AUTO_SAVE_FILE)); }
+      let payloadGeneration = desktopSaveGenerationFromData(parsed);
+      if (!payloadGeneration) {
+        const prepared = prepareDesktopSavePayload(parsed);
+        payloadGeneration = prepared.generation;
+        invalidateDesktopSaveGeneration('__autosave__');
+        writeFileAtomic(AUTO_SAVE_FILE, prepared.text, 'utf-8');
+      }
+      try { writeDesktopSaveMetadata('__autosave__', parsed, fs.statSync(AUTO_SAVE_FILE), payloadGeneration); }
       catch (metadataError) { console.warn('[load-auto-save] sidecar 回填失败:', metadataError && metadataError.message || metadataError); }
       return { success: true, data: parsed.data, sessionToken: fileToken };
     }
     // 首次升级前的无 envelope 旧档仅在 sidecar 尚不存在时兼容读取。
     if (getAutoSaveSessionToken()) return { success: false, stale: true, error: '旧自动存档已被新局失效' };
-    try { writeDesktopSaveMetadata('__autosave__', parsed, fs.statSync(AUTO_SAVE_FILE)); }
+    let payloadGeneration = desktopSaveGenerationFromData(parsed);
+    if (!payloadGeneration) {
+      const prepared = prepareDesktopSavePayload(parsed);
+      payloadGeneration = prepared.generation;
+      invalidateDesktopSaveGeneration('__autosave__');
+      writeFileAtomic(AUTO_SAVE_FILE, prepared.text, 'utf-8');
+    }
+    try { writeDesktopSaveMetadata('__autosave__', parsed, fs.statSync(AUTO_SAVE_FILE), payloadGeneration); }
     catch (metadataError) { console.warn('[load-auto-save] legacy sidecar 回填失败:', metadataError && metadataError.message || metadataError); }
     return { success: true, data: parsed, sessionToken: '' };
   } catch (e) {
@@ -4051,6 +4177,9 @@ if (TEST_MODE) {
     isStrictRendererUpgrade,
     sanitize,
     desktopSaveMetadataFromData,
+    prepareDesktopSavePayload,
+    desktopSavePayloadStampMatches,
+    normalizeDesktopSaveGeneration,
     fallbackDesktopSaveName,
     downloadRemoteFile,
     sha256FileStream,

--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-20T02:08:49.075Z",
+  "generatedAt": "2026-08-20T04:07:48.052Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -3691,8 +3691,8 @@
     },
     {
       "path": "tm-chronicle-system.js",
-      "sha256": "11d211ccd52e0f4313d62ef42413a59523faf9f718ae2cdb392a1968264dc1bf",
-      "size": 27657
+      "sha256": "9cadf5a129eb2a7d40c8806e12e799525356a34d26e57d0c219cabd4427646b2",
+      "size": 37896
     },
     {
       "path": "tm-chronicle-tracker.js",
@@ -4341,8 +4341,8 @@
     },
     {
       "path": "tm-integration-bridge.js",
-      "sha256": "17a52a72bda3090b03eef032331cceb2028d4c849159a2d3306444a26d8672e1",
-      "size": 43535
+      "sha256": "ca282177375a7572023743b33a4aae5094c6764af7aedfc8d8195ad1f42e3846",
+      "size": 43960
     },
     {
       "path": "tm-invariants.js",
@@ -4841,8 +4841,8 @@
     },
     {
       "path": "tm-office-panel.js",
-      "sha256": "ee45d444a48a7be5c68173ff7a2f144c48474189e99a37ff5aa13e140d1ed0d2",
-      "size": 108486
+      "sha256": "9976d2e18addda99c35205f4b9d185ac2c5ac9b6b8088347ed882c04076157aa",
+      "size": 108872
     },
     {
       "path": "tm-office-powermap.js",
@@ -5096,8 +5096,8 @@
     },
     {
       "path": "tm-save-lifecycle.js",
-      "sha256": "651c8146813e0f704cb2a28a8a8e19a1d0d225d4b83b4608330805b9856a6a0e",
-      "size": 120027
+      "sha256": "df08bf6122f9532a96a3907c02cad8dfff8f92c46eed428cbdf830fa46dfa496",
+      "size": 122568
     },
     {
       "path": "tm-save-manager.js",
@@ -5146,8 +5146,8 @@
     },
     {
       "path": "tm-state-snapshot.js",
-      "sha256": "c31cca7a535b650e39ceb7abdb2d38662c8624692256edde28b704b89036520f",
-      "size": 25261
+      "sha256": "3f74c44840e17bb4b4641d9dfd1c3c78b6c8f06304eb3a32e73938cef1b4ac97",
+      "size": 29906
     },
     {
       "path": "tm-state.js",
@@ -5156,8 +5156,8 @@
     },
     {
       "path": "tm-storage.js",
-      "sha256": "80b5b08a10f2cecabb8c589337ca930ca1972621d577b035effd90ea0e4104db",
-      "size": 68691
+      "sha256": "6d819d209d7a0e807e64ff0ef93047ed6dc60549b42527dbc2b1568b9bee425b",
+      "size": 72041
     },
     {
       "path": "tm-talent-backlash.js",

--- a/web/scripts/smoke-chronicle-world-lease.js
+++ b/web/scripts/smoke-chronicle-world-lease.js
@@ -69,6 +69,24 @@ const ctx = {
     },
     async listChronicleRecords(campaignId, timelineId) {
       return Array.from(durableChronicles.values()).filter(record => record.campaignId === campaignId && record.timelineId === timelineId).map(clone);
+    },
+    async listQuarantinedChronicleRecords(campaignId) {
+      return Array.from(durableChronicles.values()).filter(record => record.campaignId === campaignId && record.migrationState === 'legacy-unassigned').map(clone);
+    },
+    async importQuarantinedChronicleRecord(input, options) {
+      if (!input.confirmed) throw new Error('confirmation required');
+      if (options && options.writeGuard && options.writeGuard() !== true) return false;
+      const legacy = Array.from(durableChronicles.values()).find(record => record.id === input.recordId && record.migrationState === 'legacy-unassigned');
+      if (!legacy) throw new Error('legacy record missing');
+      const key = input.campaignId + ':' + input.timelineId + ':' + input.year;
+      if (durableChronicles.has(key)) throw new Error('target exists');
+      const claimed = Object.assign({}, clone(legacy), {
+        id: 'chronicle:' + key, campaignId: input.campaignId, timelineId: input.timelineId,
+        year: input.year, sourceTurn: input.sourceTurn, historyBasisHash: input.historyBasisHash,
+        migrationState: 'legacy-confirmed', importedAt: Date.now()
+      });
+      durableChronicles.set(key, claimed);
+      return clone(claimed);
     }
   },
   _dbg() {},
@@ -176,20 +194,34 @@ function setWorld(id, time, timelineId) {
     'same-campaign durable chronicle never crosses into a different timeline');
 
   const legacyChronicleTimeline = 'tml_legacy_claim_12345678';
+  const legacyStorageTimeline = 'tml_legacy_storage_12345678';
   setWorld('legacy-chronicle', { year: 2024, startYear: 2024, startMonth: 1, startDay: 1 }, legacyChronicleTimeline);
   ctx.GM.turn = 1;
   ctx.ChronicleSystem.addMonthDraft(1, '旧版年度素材', '旧版月稿');
-  durableChronicles.set('legacy-chronicle:' + legacyChronicleTimeline + ':2024', {
-    id: 'chronicle:legacy-chronicle:' + legacyChronicleTimeline + ':2024',
-    campaignId: 'legacy-chronicle', timelineId: legacyChronicleTimeline, year: 2024,
+  durableChronicles.set('legacy-chronicle:' + legacyStorageTimeline + ':2024', {
+    id: 'chronicle:legacy-chronicle:' + legacyStorageTimeline + ':2024',
+    campaignId: 'legacy-chronicle', timelineId: legacyStorageTimeline, year: 2024,
     sourceTurn: -1, historyBasisHash: '', migrationState: 'legacy-unassigned', generatedAt: 10,
     chronicle: { content: '迁移后的旧版正史', afterword: '旧史评', generatedAt: 10 }
   });
   const legacyHydrated = await ctx.ChronicleSystem.hydrateDurableRecords(ctx.GM, ctx.P);
-  const preservedLegacy = durableChronicles.get('legacy-chronicle:' + legacyChronicleTimeline + ':2024');
+  const preservedLegacy = durableChronicles.get('legacy-chronicle:' + legacyStorageTimeline + ':2024');
   check(legacyHydrated.merged === 0 && !ctx.ChronicleSystem.yearChronicles[2024]
     && preservedLegacy.migrationState === 'legacy-unassigned' && preservedLegacy.chronicle.content === '迁移后的旧版正史',
   'ambiguous v4 chronicle stays durable but is never silently attached to the first loaded legacy branch');
+  const quarantined = await ctx.ChronicleSystem.listQuarantinedLegacyRecords(ctx.GM);
+  check(quarantined.length === 1 && quarantined[0].content === '迁移后的旧版正史'
+    && ctx.ChronicleSystem.exportQuarantinedLegacyRecord(quarantined[0]).includes('迁移后的旧版正史'),
+  'quarantined legacy chronicle is explicitly viewable and exportable without automatic attachment');
+  let confirmationRejected = false;
+  try { await ctx.ChronicleSystem.importQuarantinedLegacyRecord(quarantined[0].id, { confirmed: false }); }
+  catch (_) { confirmationRejected = true; }
+  check(confirmationRejected && !ctx.ChronicleSystem.yearChronicles[2024], 'legacy import requires explicit player confirmation');
+  const importedLegacy = await ctx.ChronicleSystem.importQuarantinedLegacyRecord(quarantined[0].id, { confirmed: true });
+  check(importedLegacy.ok === true && ctx.ChronicleSystem.yearChronicles[2024].content === '迁移后的旧版正史'
+    && durableChronicles.get('legacy-chronicle:' + legacyChronicleTimeline + ':2024').migrationState === 'legacy-confirmed'
+    && durableChronicles.get('legacy-chronicle:' + legacyStorageTimeline + ':2024').migrationState === 'legacy-unassigned',
+  'confirmed legacy import claims a copy for the current timeline while preserving the quarantined source');
 
   setWorld('annual-filter', { year: 2024, startYear: 2024, startMonth: 1, startDay: 1 }, annualTimeline);
   ctx.GM.turn = first2025Turn + 1;
@@ -249,6 +281,24 @@ function setWorld(id, time, timelineId) {
   const generated = await first;
   check(generated && generated.ok === true && ctx.ChronicleSystem.yearChronicles[2024].content === '唯一年度正史',
     'current leased annual result commits exactly once');
+
+  setWorld('campaign-rearm', { year: 2024, startYear: 2024 });
+  ctx.ChronicleSystem.addMonthDraft(1, '失败读档前正在生成', '');
+  aiQueue = [];
+  const interrupted = ctx.ChronicleSystem._tryGenerateYearChronicle(2024);
+  const interruptedTask = aiQueue.shift();
+  const capturedJobs = ctx.ChronicleSystem.capturePendingWorldJobs(ctx.GM);
+  ctx._tmLoadGen++;
+  const rearmed = ctx.ChronicleSystem.rearmWorldJobs(ctx.GM, ctx.P, capturedJobs);
+  const rearmedTask = aiQueue.shift();
+  check(capturedJobs.length === 1 && rearmedTask, 'failed load rollback captures and creates a fresh annual job');
+  interruptedTask.resolve(JSON.stringify({ chronicle: '旧 Promise 不得复活', afterword: '' }));
+  rearmedTask.resolve(JSON.stringify({ chronicle: '回滚后重新生成', afterword: '' }));
+  const interruptedResult = await interrupted;
+  const rearmedResult = await rearmed;
+  check(interruptedResult.stale === true && rearmedResult.ok === true
+    && ctx.ChronicleSystem.yearChronicles[2024].content === '回滚后重新生成',
+  'load rollback invalidates the old Promise and rearms the missing annual chronicle exactly once');
 
   const detached = { _chronicleSysState: { monthDrafts: { 9: { turn: 9, year: 1999 } }, yearChronicles: {} } };
   check(ctx.ChronicleSystem.serialize(detached).monthDrafts['9'].year === 1999,

--- a/web/scripts/smoke-runtime-save-consistency.js
+++ b/web/scripts/smoke-runtime-save-consistency.js
@@ -29,6 +29,7 @@ const resume = fs.readFileSync(path.join(ROOT, 'tm-resume-point.js'), 'utf8');
 const mainImpl = fs.readFileSync(path.join(ROOT, '..', 'main-impl.js'), 'utf8');
 const preloadImpl = fs.readFileSync(path.join(ROOT, '..', 'preload-impl.js'), 'utf8');
 const startPatch = fs.readFileSync(path.join(ROOT, 'tm-patches-start.js'), 'utf8');
+const integrationBridge = fs.readFileSync(path.join(ROOT, 'tm-integration-bridge.js'), 'utf8');
 
 console.log('=== 1. unified save snapshot builder ===');
 const snapshotSrc = sliceFn(lifecycle, 'function _autoSaveSnapshotGM(');
@@ -101,6 +102,19 @@ ok(/auto-save-session-rotate/.test(mainImpl) && /autoSaveSessionMatches\(request
   && /writeFile[\s\S]*?autoSaveSessionMatches\(requestToken\)[\s\S]*?rename/.test(mainImpl), 'Electron canonical auto-save 在 write/rename 间按 session token 复验');
 ok(/rotateAutoSaveSession/.test(preloadImpl) && /_tmRotateDesktopAutoSaveSession\('full-load'/.test(lifecycle)
   && /_tmRotateDesktopAutoSaveSession\('new-game'/.test(startPatch), 'preload + 读档 + 新局共同切换 auto-save session');
+ok(/var _turnDataRecovery = await _recoverPendingTurnDataPublish\(\);[\s\S]*?_turnDataRecovery\.ok === false[\s\S]*?throw[\s\S]*?_tmForkLoadedTimeline/.test(lifecycle),
+  'receipt recovery failure aborts before the loaded world can fork its timeline');
+ok(/_tmRunCriticalLoadStep\('runtime map bind'/.test(lifecycle)
+  && /_tmRunCriticalLoadStep\('engine migration'/.test(lifecycle)
+  && /_tmRunCriticalLoadStep\('relationship reference migration'/.test(lifecycle)
+  && /_tmRunCriticalLoadStep\('fiscal configuration migration'/.test(lifecycle)
+  && /IntegrationBridge\.init\(\{ strict: true \}\)/.test(lifecycle)
+  && /_tmRunCriticalLoadStep\('loaded world validation'/.test(lifecycle),
+  'state-mutating load migrations propagate into the load transaction instead of failing open');
+ok(/function aggregateRegionsToVariables\(options\)[\s\S]*?var strict = options\.strict === true/.test(integrationBridge)
+  && /function init\(options\)[\s\S]*?aggregateRegionsToVariables\(\{ strict: true \}\)/.test(integrationBridge)
+  && /if \(strict\) throw _naturalPopulationGrowth|if \(strict\) throw _e/.test(integrationBridge),
+  'integration bridge exposes a strict load mode instead of swallowing partial migration failures');
 ok(/stageTurnData\([\s\S]*?result\.success === true[\s\S]*?回合分卷暂存失败/.test(render)
   && /turnPublishReceipt:\s*ctx\.meta\.stagedTurnData/.test(render)
   && /_tmCommitEndTurnTransaction[\s\S]*?await _endTurn_publishStagedTurnData/.test(core), '回合分卷先暂存·receipt 与世界同事务提交·仅在 commit 后发布');
@@ -220,6 +234,8 @@ async function runDynamicLeaseSmokes() {
   {
     const transactionFns = [
       sliceFn(lifecycle, 'function _tmAwaitLoadBarrier('),
+      sliceFn(lifecycle, 'function _tmCaptureLoadStepError('),
+      sliceFn(lifecycle, 'function _tmRunCriticalLoadStep('),
       sliceFn(lifecycle, 'function _tmCaptureLoadTransaction('),
       sliceFn(lifecycle, 'function _tmRestoreLoadTransaction('),
       sliceFn(lifecycle, 'function fullLoadGame('),
@@ -248,7 +264,10 @@ async function runDynamicLeaseSmokes() {
         context._tmLoadGen++;
         context._tmRotateDesktopAutoSaveSession('full-load', 'session-incoming-123456');
         await Promise.resolve();
-        throw new Error('hydrate-injected-failure');
+        context._tmRunCriticalLoadStep('engine migration', function() {
+          context.GM.enginePartiallyMigrated = true;
+          throw new Error('engine-migration-injected-failure');
+        });
       };
       vm.createContext(context);
       vm.runInContext(transactionFns, context);
@@ -258,10 +277,10 @@ async function runDynamicLeaseSmokes() {
     let loadError = null;
     try { await restored.context.fullLoadGame({}); } catch (error) { loadError = error; }
     await restored.context._tmAwaitLoadBarrier();
-    ok(loadError && loadError._tmLoadRollbackComplete === true
+    ok(loadError && loadError._tmLoadRollbackComplete === true && loadError._tmLoadStep === 'engine migration'
       && restored.context.P === restored.oldP && restored.context.GM === restored.oldGM
       && restored.context._tmLoadGen === 9 && restored.getSession() === 'session-old-1234567890',
-    'hydration 失败恢复原 P/GM 与自动存档 session，并以单调 load generation 失效旧租约');
+    'critical migration partial write rolls back original P/GM and auto-save session with monotonic load generation');
 
     const blocked = makeLoadContext(true);
     let blockedError = null;
@@ -383,6 +402,11 @@ async function runDynamicLeaseSmokes() {
     await ctx._recoverPendingTurnDataPublish();
     ok(recovered === 1 && deleted === 1 && !ctx.GM._pendingTurnDataPublish,
       'load recovery publishes only matching, non-future receipts and leaves other branches untouched');
+    ctx.window.tianming.recoverTurnData = async function() { return { success: false, error: 'disk unavailable' }; };
+    const failedRecovery = await ctx._recoverPendingTurnDataPublish();
+    ok(failedRecovery && failedRecovery.ok === false && /disk unavailable/.test(String(failedRecovery.error && failedRecovery.error.message))
+      && deleted === 1,
+    'receipt recovery failure is explicit and leaves the durable receipt available for a transactional retry');
   }
   {
     let staged = 0, discarded = 0;
@@ -558,7 +582,17 @@ async function runDynamicLeaseSmokes() {
       }
     };
     const ipcMain = { handle(name, fn) { handles[name] = fn; }, on(name, fn) { syncHandles[name] = fn; } };
-    const ctx = { ipcMain, fs: fakeFs, path: { join: (...parts) => parts.join('/') }, SAVE_DIR: 'mem', ensureSaveDir() {}, crypto: { randomUUID: () => 'generated-session-token-0001' }, Promise, JSON, String, Error };
+    const ctx = {
+      ipcMain, fs: fakeFs, path: { join: (...parts) => parts.join('/') }, SAVE_DIR: 'mem', ensureSaveDir() {},
+      crypto: { randomUUID: () => 'generated-session-token-0001' }, Promise, JSON, String, Error,
+      prepareDesktopSavePayload(data) {
+        data.__tmDesktopSaveGeneration = data.__tmDesktopSaveGeneration || 'payload-generation-test-0001';
+        return { data, generation: data.__tmDesktopSaveGeneration, text: JSON.stringify(data) };
+      },
+      desktopSaveGenerationFromData(data) { return data && data.__tmDesktopSaveGeneration || ''; },
+      invalidateDesktopSaveGeneration() {},
+      writeDesktopSaveMetadata() {}
+    };
     vm.createContext(ctx); vm.runInContext(src, ctx);
     const rotate = token => { const event = {}; syncHandles['auto-save-session-rotate'](event, token); return event.returnValue; };
     const current = () => { const event = {}; syncHandles['auto-save-session-current'](event); return event.returnValue; };

--- a/web/scripts/smoke-save-integrity-audit.js
+++ b/web/scripts/smoke-save-integrity-audit.js
@@ -35,7 +35,9 @@ console.log('=== save integrity audit ===');
   const b = ctx.stableStorageKey('甲?乙');
   ok(a !== b && a.startsWith('甲_乙--') && b.startsWith('甲_乙--'), 'sanitize 碰撞名使用内容 hash 分离');
   ok(ctx.stableStorageKey('甲:乙') === a, 'storage key 对同一显示名稳定');
-  ok(/readDesktopSaveMetadata\(storageKey, stats\)/.test(main) && /name:\s*\(sidecarCurrent/.test(main)
+  ok(/readDesktopSaveGeneration\(storageKey,\s*(?:fp|payloadPath)\)/.test(main)
+    && /readDesktopSavePayloadGeneration\(payloadPath\)/.test(main)
+    && /readDesktopSaveMetadata\(storageKey, stats, payloadGeneration\)/.test(main) && /name:\s*\(sidecarCurrent/.test(main)
     && /name:\s*canonicalName/.test(main), '列表通过轻量 sidecar 返回 display name + canonical storageKey');
 }
 

--- a/web/scripts/smoke-security-trust-boundary.js
+++ b/web/scripts/smoke-security-trust-boundary.js
@@ -181,15 +181,25 @@ async function main() {
   check(bodyError && /大小上限/.test(bodyError.message), 'undeclared oversized response is rejected after bounded read');
 
   const hostileSaveName = '<img src=x onerror="globalThis.__desktopSaveOwned=1">';
-  const sidecar = T.desktopSaveMetadataFromData({
+  const preparedSidecarPayload = T.prepareDesktopSavePayload({
     _saveMeta: { name: hostileSaveName, scenario: '<script>owned()</script>', turn: 0 },
     gameState: { turn: 0, _campaignId: 'campaign-sidecar', _timelineId: 'tml_sidecar_12345678', privatePayload: 'must-not-leak' }
-  }, 'manual-save-key', { size: 123, mtimeMs: 456 });
+  }, 'payload-generation-sidecar-0001');
+  const sidecar = T.desktopSaveMetadataFromData(preparedSidecarPayload.data, 'manual-save-key',
+    { size: 123, mtimeMs: 456, ctimeMs: 457, ino: 9 }, preparedSidecarPayload.generation);
   check(sidecar.name === hostileSaveName && sidecar.meta.turn === 0
     && sidecar.meta.campaignId === 'campaign-sidecar' && sidecar.meta.timelineId === 'tml_sidecar_12345678'
-    && sidecar.version === 2 && sidecar.payload.size === 123 && sidecar.payload.mtimeMs === 456
+    && sidecar.version === 3 && sidecar.payload.size === 123 && sidecar.payload.mtimeMs === 456
+    && sidecar.payload.ctimeMs === 457 && sidecar.payload.ino === 9
+    && sidecar.payloadGeneration === 'payload-generation-sidecar-0001'
+    && preparedSidecarPayload.data.__tmDesktopSaveGeneration === sidecar.payloadGeneration
+    && preparedSidecarPayload.text.startsWith('{"__tmDesktopSaveGeneration":"payload-generation-sidecar-0001"')
     && !Object.prototype.hasOwnProperty.call(sidecar, 'gameState') && !Object.prototype.hasOwnProperty.call(sidecar.meta, 'privatePayload'),
-  'desktop save sidecar preserves display text and identity but never copies world payloads');
+  'desktop save sidecar preserves display text and identity, binds a payload generation, and never copies world payloads');
+  const rotatedPayload = T.prepareDesktopSavePayload({ __tmDesktopSaveGeneration: 'old-payload-generation-0001', marker: true });
+  check(rotatedPayload.generation !== 'old-payload-generation-0001'
+    && rotatedPayload.text.startsWith('{"__tmDesktopSaveGeneration":"' + rotatedPayload.generation + '"'),
+  'every desktop save commit rotates the embedded payload generation instead of trusting a renderer-carried old value');
   const autoSidecar = T.desktopSaveMetadataFromData({ gameState: { turn: 3, saveName: '玩家档名' } }, '__autosave__');
   check(autoSidecar.name === '__autosave__', 'desktop canonical autosave remains hidden from manual-save listings');
 
@@ -242,7 +252,8 @@ async function main() {
   const listSavesEnd = mainSource.indexOf("ipcMain.handle('delete-save'", listSavesStart);
   const listSavesSource = mainSource.slice(listSavesStart, listSavesEnd);
   check(listSavesStart >= 0 && listSavesEnd > listSavesStart
-    && /readDesktopSaveMetadata\(storageKey, stats\)/.test(listSavesSource)
+    && /readDesktopSaveGeneration\(storageKey, fp\)/.test(listSavesSource)
+    && /readDesktopSaveMetadata\(storageKey, stats, payloadGeneration\)/.test(listSavesSource)
     && !/readFileSync\(fp|JSON\.parse\(raw/.test(listSavesSource),
   'desktop save listing reads lightweight sidecars without parsing every world payload');
   const desktopSaveDir = path.join(TMP, 'userData', 'saves');
@@ -251,16 +262,24 @@ async function main() {
   for (let i = 0; i < 100; i++) {
     const storageKey = 'large-save-' + i;
     const payloadPath = path.join(desktopSaveDir, storageKey + '.json');
-    fs.writeFileSync(payloadPath, '<invalid-json>' + 'x'.repeat(64 * 1024));
+    const payloadGeneration = 'fixture-payload-generation-' + String(i).padStart(4, '0');
+    fs.writeFileSync(payloadPath, '{"__tmDesktopSaveGeneration":"' + payloadGeneration + '","invalid":"' + 'x'.repeat(64 * 1024));
     const payloadStats = fs.statSync(payloadPath);
     fs.writeFileSync(path.join(desktopMetadataDir, storageKey + '.json'), JSON.stringify({
-      version: 2,
+      version: 3,
       storageKey,
       name: '大型存档 ' + i,
       meta: { scenario: '测试剧本', turn: i, campaignId: 'campaign-sidecars', timelineId: 'tml_sidecars_12345678' },
-      payload: { size: payloadStats.size, mtimeMs: payloadStats.mtimeMs },
+      payload: {
+        size: payloadStats.size, mtimeMs: payloadStats.mtimeMs, ctimeMs: payloadStats.ctimeMs,
+        birthtimeMs: payloadStats.birthtimeMs, ino: payloadStats.ino, dev: payloadStats.dev
+      },
+      payloadGeneration,
       metadataGeneration: 'fixture-' + i,
       updatedAt: Date.now()
+    }));
+    fs.writeFileSync(path.join(desktopMetadataDir, storageKey + '.generation.json'), JSON.stringify({
+      version: 1, storageKey, payloadGeneration, updatedAt: Date.now()
     }));
   }
   const listHandler = ipcHandlers.get('list-saves');
@@ -277,13 +296,13 @@ async function main() {
   check(listed && listed.success === true && listed.files.length === 100
     && listed.files.every(file => file.meta && file.meta.timelineId === 'tml_sidecars_12345678'),
   '100 desktop saves list successfully even when every full payload is deliberately unparsable');
-  check(readPaths.length === 100 && readPaths.every(file => path.dirname(file) === path.resolve(desktopMetadataDir)),
-    'desktop listing reads only 100 small sidecars and zero world payload files');
+  check(readPaths.length === 200 && readPaths.every(file => path.dirname(file) === path.resolve(desktopMetadataDir)),
+    'desktop listing reads only small sidecar/generation records plus bounded payload prefixes, never full world payloads');
   const refHandler = ipcHandlers.get('list-save-timeline-refs');
   const refs = await refHandler({ senderFrame: mainFrame, sender: { mainFrame } });
   check(refs && refs.success === true && refs.complete === true && refs.refs.length === 100
     && refs.refs.every(ref => ref.campaignId === 'campaign-sidecars' && ref.timelineId === 'tml_sidecars_12345678'),
-  'desktop timeline reference registry is complete when every payload has a current v2 sidecar');
+    'desktop timeline reference registry is complete when every payload has a current v3 sidecar generation');
 
   const stalePayloadPath = path.join(desktopSaveDir, 'large-save-0.json');
   fs.appendFileSync(stalePayloadPath, 'new-generation');
@@ -294,6 +313,16 @@ async function main() {
     'payload overwrite with a failed sidecar update is shown as metadataPending, never as trusted stale metadata');
   check(staleRefs && staleRefs.success === true && staleRefs.complete === false,
     'timeline GC reference registry fails closed while any desktop sidecar is missing or stale');
+
+  const sameStampPayloadPath = path.join(desktopSaveDir, 'large-save-1.json');
+  const sameStampBefore = fs.statSync(sameStampPayloadPath);
+  const sameStampBytes = fs.readFileSync(sameStampPayloadPath);
+  fs.writeFileSync(sameStampPayloadPath, Buffer.alloc(sameStampBytes.length, 0x79));
+  fs.utimesSync(sameStampPayloadPath, sameStampBefore.atime, sameStampBefore.mtime);
+  const sameStampListed = await listHandler({ senderFrame: mainFrame, sender: { mainFrame } });
+  const sameStampRow = sameStampListed.files.find(file => file.storageKey === 'large-save-1');
+  check(sameStampRow && sameStampRow.metadataPending === true && sameStampRow.meta === null,
+    'same-size payload replacement with restored mtime is rejected by the embedded payload generation');
   check(mainSource.includes("redirect: 'manual'") && mainSource.includes('dns.lookup(hostname, { all: true')
     && mainSource.includes("credentials: 'omit'") && mainSource.includes("referrerPolicy: 'no-referrer'"), 'network proxy revalidates DNS/redirects and omits ambient credentials');
   check(mainSource.includes('WORKSHOP_CATALOG_AUTHORIZATIONS.get(packageUrl)')

--- a/web/scripts/smoke-state-snapshot-integrity.js
+++ b/web/scripts/smoke-state-snapshot-integrity.js
@@ -66,11 +66,17 @@ function fakeIndexedDB(options) {
     },
     close() {},
     transaction(name) {
-      if (!stores.has(name)) throw new Error('missing store ' + name);
-      const def = stores.get(name);
+      const names = Array.isArray(name) ? name : [name];
+      names.forEach(storeName => { if (!stores.has(storeName)) throw new Error('missing store ' + storeName); });
       const tx = { error: null, oncomplete: null, onerror: null, onabort: null };
-      function completeLater() { setTimeout(function() { if (tx.oncomplete) tx.oncomplete(); }, 0); }
-      tx.objectStore = function() {
+      let completionScheduled = false;
+      function completeLater() {
+        if (completionScheduled) return;
+        completionScheduled = true;
+        setTimeout(function() { if (tx.oncomplete) tx.oncomplete(); }, 0);
+      }
+      tx.objectStore = function(storeName) {
+        const def = stores.get(storeName || names[0]);
         const facade = storeFacade(def);
         const put = facade.put;
         const del = facade.delete;
@@ -131,7 +137,8 @@ function fakeIndexedDB(options) {
   vm.createContext(ctx);
   vm.runInContext(src, ctx);
 
-  ok(/DB_VERSION = 4/.test(src) && /keyPath: 'id'/.test(src), 'v4 使用 campaign/timeline/turn compound record id');
+  ok(/DB_VERSION = 5/.test(src) && /LINEAGE_STORE = 'timeline_graph'/.test(src) && /keyPath: 'id'/.test(src),
+    'v5 使用 compound snapshot id 与独立 timeline graph');
   ok(/_buildSaveState/.test(src) && /format: 'idb', detach: true/.test(src), '快照复用完整纯存档 builder');
   ok(registeredHook && typeof registeredHook === 'function', 'after hook 已注册');
 
@@ -197,6 +204,22 @@ function fakeIndexedDB(options) {
   ok(r.ok === true && childOverrideList[0].inherited === true && childOverrideList[1].inherited === false
     && (await ctx.StateSnapshot.load(2)).state.GM.marker === 'A2-child',
   '子时间线同回合快照覆盖父线视图但不复制其他祖先 payload');
+
+  // A → B → C：中间时间线 B 尚未生成任何快照，C 仍须沿独立 timeline graph 继承 A。
+  ctx.GM = {
+    _campaignId: 'campA', _timelineId: 'tml_empty_middle_B_12345678', _parentTimelineId: 'tml_campA_12345678',
+    _forkTurn: 2, turn: 2, marker: 'B-no-snapshot', shijiHistory: [], evtLog: []
+  };
+  await ctx.StateSnapshot.recordTimeline(ctx.GM);
+  ctx.GM = {
+    _campaignId: 'campA', _timelineId: 'tml_deep_child_C_12345678', _parentTimelineId: 'tml_empty_middle_B_12345678',
+    _forkTurn: 2, turn: 2, marker: 'C-live', shijiHistory: [], evtLog: []
+  };
+  await ctx.StateSnapshot.recordTimeline(ctx.GM);
+  const deepInherited = await ctx.StateSnapshot.list('campA', 'tml_deep_child_C_12345678');
+  ok(deepInherited.map(item => item.turn).join(',') === '1,2'
+    && deepInherited.every(item => item.inherited === true && item.sourceTimelineId === 'tml_campA_12345678'),
+  'A→B→C 且 B 无快照时，C 仍通过独立 timeline graph 继承 A 的 forkTurn 前快照');
 
   ctx.GM = { _campaignId: 'campB', _timelineId: 'tml_campB_12345678', turn: 1, marker: 'B1', customWorld: { deep: 99 }, shijiHistory: [], evtLog: [] };
   ctx.P = { conf: { campaign: 'B' } };

--- a/web/scripts/smoke-storage-atomic-batch.js
+++ b/web/scripts/smoke-storage-atomic-batch.js
@@ -135,6 +135,31 @@ function makeContext(indexedDB, localStorage) {
   check(receiptBatchDeleted === true && receiptBatchIdb.stats.puts === receiptBatchPuts
     && receiptBatchIdb.stores.get('saves').size === 2 && receiptBatchIdb.stores.get('turnPublishReceipts').size === 0,
   'publishing clears only the lightweight receipt and never rewrites either world payload');
+
+  const legacyChronicle = {
+    id: 'chronicle:campaign-legacy:tml_legacy_storage_12345678:2024',
+    campaignId: 'campaign-legacy', timelineId: 'tml_legacy_storage_12345678', year: 2024,
+    sourceTurn: -1, historyBasisHash: '', migrationState: 'legacy-unassigned', generatedAt: 10,
+    chronicle: { content: '隔离旧正史', afterword: '旧史评' }
+  };
+  const legacyIdb = makeIndexedDB({ chronicleRecords: { [legacyChronicle.id]: legacyChronicle } });
+  const legacyCtx = makeContext(legacyIdb, makeLocalStorage());
+  await legacyCtx.TM_SaveDB.open();
+  const quarantined = await legacyCtx.TM_SaveDB.listQuarantinedChronicleRecords('campaign-legacy');
+  let unconfirmedRejected = false;
+  try {
+    await legacyCtx.TM_SaveDB.importQuarantinedChronicleRecord({ recordId: legacyChronicle.id, confirmed: false });
+  } catch (_) { unconfirmedRejected = true; }
+  const claimed = await legacyCtx.TM_SaveDB.importQuarantinedChronicleRecord({
+    recordId: legacyChronicle.id, confirmed: true, campaignId: 'campaign-legacy', timelineId: 'tml_current_branch_12345678',
+    year: 2024, sourceTurn: 12, historyBasisHash: 'chb_current_basis', loadGeneration: 3
+  });
+  const legacyRows = Array.from(legacyIdb.stores.get('chronicleRecords').values());
+  check(quarantined.length === 1 && unconfirmedRejected && claimed.migrationState === 'legacy-confirmed'
+    && legacyRows.length === 2 && legacyRows.some(row => row.migrationState === 'legacy-unassigned')
+    && legacyRows.some(row => row.timelineId === 'tml_current_branch_12345678' && row.sourceTurn === 12),
+  'quarantined legacy chronicles require explicit confirmation and import as a copy bound to the current history basis');
+
   let duplicateRejected = false;
   try {
     await ctx.TM_SaveDB.saveManyAtomic([

--- a/web/tm-chronicle-system.js
+++ b/web/tm-chronicle-system.js
@@ -176,6 +176,48 @@ var ChronicleSystem = {
   _inFlight: [],
   _requestSeq: 0,
 
+  capturePendingWorldJobs: function(targetGM) {
+    if (!targetGM) return [];
+    var seen = Object.create(null);
+    return ChronicleSystem._inFlight.filter(function(item) {
+      return item && item.gmRef === targetGM && Number.isSafeInteger(Number(item.year));
+    }).map(function(item) {
+      return { type: 'year-chronicle', year: Number(item.year), requestId: String(item.requestId || '') };
+    }).filter(function(job) {
+      var key = job.type + ':' + job.year;
+      if (seen[key]) return false;
+      seen[key] = true;
+      return true;
+    });
+  },
+
+  rearmWorldJobs: function(targetGM, targetP, jobs) {
+    jobs = Array.isArray(jobs) ? jobs : [];
+    if (!targetGM || !targetP || typeof GM === 'undefined' || typeof P === 'undefined' || GM !== targetGM || P !== targetP) {
+      return Promise.resolve({ ok: false, stale: true, rearmed: 0 });
+    }
+    var years = [];
+    var seen = Object.create(null);
+    jobs.forEach(function(job) {
+      var year = Number(job && job.year);
+      if (!job || job.type !== 'year-chronicle' || !Number.isSafeInteger(year) || seen[year]) return;
+      seen[year] = true;
+      years.push(year);
+    });
+    if (!years.length) return Promise.resolve({ ok: true, rearmed: 0 });
+
+    // 旧 Promise 的世界租约已经因 load generation 前移而失效；同时从去重表移除，
+    // 让恢复后的旧世界可以创建一份全新的请求，绝不复活旧 Promise。
+    ChronicleSystem._inFlight = ChronicleSystem._inFlight.filter(function(item) {
+      return !(item && item.gmRef === targetGM && seen[Number(item.year)]);
+    });
+    return Promise.all(years.map(function(year) {
+      return ChronicleSystem._tryGenerateYearChronicle(year);
+    })).then(function(results) {
+      return { ok: true, rearmed: years.length, results: results };
+    });
+  },
+
   // 兼容旧消费者的属性访问；真正数据始终落在当前 GM._chronicleSysState。
   get monthDrafts() { return _chronicleState(null, true).monthDrafts; },
   set monthDrafts(value) { _chronicleState(null, true).monthDrafts = (value && typeof value === 'object' && !Array.isArray(value)) ? value : {}; },
@@ -458,6 +500,155 @@ var ChronicleSystem = {
     return Object.keys(ChronicleSystem.yearChronicles).map(Number).filter(function(year) {
       return Number.isSafeInteger(year);
     }).sort(function(a, b) { return a - b; });
+  },
+
+  listQuarantinedLegacyRecords: function(targetGM) {
+    targetGM = targetGM || ((typeof GM !== 'undefined' && GM) ? GM : null);
+    if (!targetGM || !(typeof TM_SaveDB !== 'undefined' && TM_SaveDB &&
+      typeof TM_SaveDB.listQuarantinedChronicleRecords === 'function')) return Promise.resolve([]);
+    var campaignId = String(targetGM._campaignId || '');
+    return TM_SaveDB.listQuarantinedChronicleRecords(campaignId).then(function(records) {
+      return (records || []).map(function(record) {
+        var chronicle = record && record.chronicle && typeof record.chronicle === 'object' ? record.chronicle : {};
+        return {
+          id: String(record && record.id || ''),
+          campaignId: String(record && record.campaignId || ''),
+          timelineId: String(record && record.timelineId || ''),
+          year: Number(record && record.year),
+          generatedAt: Number(record && record.generatedAt) || 0,
+          migrationState: String(record && record.migrationState || ''),
+          content: String(chronicle.content || ''),
+          afterword: String(chronicle.afterword || '')
+        };
+      }).filter(function(record) {
+        return record.id && record.campaignId === campaignId && Number.isSafeInteger(record.year) && record.content;
+      });
+    });
+  },
+
+  exportQuarantinedLegacyRecord: function(record) {
+    record = record || {};
+    return JSON.stringify({
+      format: 'tianming-quarantined-chronicle-v1',
+      campaignId: String(record.campaignId || ''),
+      sourceTimelineId: String(record.timelineId || ''),
+      year: Number(record.year),
+      generatedAt: Number(record.generatedAt) || 0,
+      content: String(record.content || ''),
+      afterword: String(record.afterword || '')
+    }, null, 2);
+  },
+
+  importQuarantinedLegacyRecord: function(recordId, options) {
+    options = options || {};
+    if (options.confirmed !== true) return Promise.reject(new Error('必须由玩家明确确认后才能导入隔离编年'));
+    var targetGM = (typeof GM !== 'undefined') ? GM : null;
+    var targetP = (typeof P !== 'undefined') ? P : null;
+    if (!targetGM || !targetP || !(typeof TM_SaveDB !== 'undefined' && TM_SaveDB &&
+      typeof TM_SaveDB.importQuarantinedChronicleRecord === 'function')) return Promise.reject(new Error('隔离编年导入接口未就绪'));
+    var targetState = _chronicleState(targetGM, true);
+    var campaignId = String(targetGM._campaignId || '');
+    var timelineId = String(targetGM._timelineId || '');
+    var loadGen = (typeof window !== 'undefined' && window._tmLoadGen) || 0;
+    function leaseIsCurrent() {
+      return typeof GM !== 'undefined' && typeof P !== 'undefined' && GM === targetGM && P === targetP
+        && String((GM && GM._campaignId) || '') === campaignId && String((GM && GM._timelineId) || '') === timelineId
+        && (((typeof window !== 'undefined' && window._tmLoadGen) || 0) === loadGen)
+        && _chronicleState(targetGM, false) === targetState;
+    }
+    return ChronicleSystem.listQuarantinedLegacyRecords(targetGM).then(function(records) {
+      if (!leaseIsCurrent()) throw new Error('导入期间世界已切换');
+      var legacy = (records || []).find(function(record) { return record.id === String(recordId || ''); });
+      if (!legacy) throw new Error('隔离编年记录不存在');
+      if (targetState.yearChronicles[legacy.year]) throw new Error('当前时间线已有该年度正史，未覆盖');
+      var basis = targetState.yearBases[legacy.year] || _chronicleBuildYearBasis(targetGM, targetState, legacy.year);
+      if (!basis || !Number.isSafeInteger(Number(basis.sourceTurn)) || Number(basis.sourceTurn) <= 0
+        || Number(basis.sourceTurn) > Number(targetGM.turn || 0) || !String(basis.historyBasisHash || '')) {
+        throw new Error('当前时间线尚无该年度的完整历史基础，不能安全导入');
+      }
+      return TM_SaveDB.importQuarantinedChronicleRecord({
+        confirmed: true,
+        recordId: legacy.id,
+        campaignId: campaignId,
+        timelineId: timelineId,
+        year: legacy.year,
+        sourceTurn: basis.sourceTurn,
+        historyBasisHash: basis.historyBasisHash,
+        loadGeneration: loadGen
+      }, { writeGuard: leaseIsCurrent }).then(function(claimed) {
+        if (!claimed || !leaseIsCurrent()) throw new Error('隔离编年导入未提交');
+        var chronicle = JSON.parse(JSON.stringify(claimed.chronicle));
+        targetState.yearBases[legacy.year] = basis;
+        targetState.yearChronicles[legacy.year] = chronicle;
+        _chronicleTrimYears(targetState, targetP);
+        return { ok: true, year: legacy.year, record: claimed };
+      });
+    });
+  },
+
+  renderLegacyRecoveryNotice: function(parent) {
+    if (!parent || typeof document === 'undefined') return Promise.resolve(false);
+    ChronicleSystem._legacyRenderSeq = Number(ChronicleSystem._legacyRenderSeq || 0) + 1;
+    var seq = ChronicleSystem._legacyRenderSeq;
+    var targetGM = (typeof GM !== 'undefined') ? GM : null;
+    return ChronicleSystem.listQuarantinedLegacyRecords(targetGM).then(function(records) {
+      if (seq !== ChronicleSystem._legacyRenderSeq || !targetGM || typeof GM === 'undefined' || GM !== targetGM) return false;
+      var existing = parent.querySelector && parent.querySelector('.bn-legacy-chronicle-recovery');
+      if (existing && existing.parentNode) existing.parentNode.removeChild(existing);
+      if (!records.length) return false;
+      var box = document.createElement('section');
+      box.className = 'bn-legacy-chronicle-recovery';
+      box.style.cssText = 'margin:10px 0;padding:12px;border:1px solid rgba(201,160,69,.35);background:rgba(35,24,14,.72);';
+      var title = document.createElement('strong');
+      title.textContent = '发现 ' + records.length + ' 份升级隔离编年';
+      var help = document.createElement('p');
+      help.textContent = '这些旧记录无法自动证明分支归属。可先导出核对；只有当前时间线已有对应年度历史时，才允许确认导入。';
+      box.appendChild(title);
+      box.appendChild(help);
+      records.forEach(function(record) {
+        var row = document.createElement('div');
+        row.style.cssText = 'margin-top:8px;padding-top:8px;border-top:1px solid rgba(201,160,69,.18);';
+        var label = document.createElement('div');
+        label.textContent = record.year + ' 年 · ' + record.content.slice(0, 100);
+        var exportButton = document.createElement('button');
+        exportButton.type = 'button';
+        exportButton.textContent = '导出核对';
+        exportButton.addEventListener('click', function() {
+          var json = ChronicleSystem.exportQuarantinedLegacyRecord(record);
+          try {
+            var blob = new Blob([json], { type: 'application/json;charset=utf-8' });
+            var url = URL.createObjectURL(blob);
+            var link = document.createElement('a');
+            link.href = url;
+            link.download = '隔离编年-' + record.year + '.json';
+            link.click();
+            setTimeout(function() { URL.revokeObjectURL(url); }, 0);
+          } catch (error) {
+            if (navigator.clipboard && navigator.clipboard.writeText) navigator.clipboard.writeText(json);
+          }
+        });
+        var importButton = document.createElement('button');
+        importButton.type = 'button';
+        importButton.textContent = '确认导入当前时间线';
+        importButton.addEventListener('click', function() {
+          if (typeof confirm === 'function' && !confirm('仅在你确认这份 ' + record.year + ' 年正史属于当前分支时导入。继续吗？')) return;
+          importButton.disabled = true;
+          ChronicleSystem.importQuarantinedLegacyRecord(record.id, { confirmed: true }).then(function(result) {
+            if (typeof toast === 'function') toast('已导入 ' + result.year + ' 年隔离编年');
+            if (typeof renderBiannian === 'function') renderBiannian(true);
+          }).catch(function(error) {
+            importButton.disabled = false;
+            if (typeof toast === 'function') toast('隔离编年未导入：' + (error && error.message || error));
+          });
+        });
+        row.appendChild(label);
+        row.appendChild(exportButton);
+        row.appendChild(importButton);
+        box.appendChild(row);
+      });
+      parent.appendChild(box);
+      return true;
+    });
   },
 
   /** 从独立轻量 store 合并当前战役已完成的年度正史。 */

--- a/web/tm-integration-bridge.js
+++ b/web/tm-integration-bridge.js
@@ -595,12 +595,17 @@
     });
   }
 
-  function aggregateRegionsToVariables() {
+  function aggregateRegionsToVariables(options) {
+    options = options || {};
+    var strict = options.strict === true;
     var G = global.GM;
     if (!G) return;
 
     // 0. 人口自然漂移（在汇总之前）
-    try { _naturalPopulationGrowth(); } catch(_e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_e, 'bridge] natPopGrowth') : console.warn('[bridge] natPopGrowth', _e); }
+    try { _naturalPopulationGrowth(); } catch(_e) {
+      (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_e, 'bridge] natPopGrowth') : console.warn('[bridge] natPopGrowth', _e);
+      if (strict) throw _e;
+    }
 
     var topLevel = getTopLevelDivisions(G.adminHierarchy, 'player');
     if (topLevel.length === 0) return;
@@ -706,7 +711,7 @@
         if (G.corruption.byDept.palace === undefined)    G.corruption.byDept.palace    = Math.round(avgProvCorr * 1.10);
         if (G.corruption.byDept.technical === undefined) G.corruption.byDept.technical = Math.round(avgProvCorr * 0.55);
         // 按 NPC 派系/私产向上推高技术官外各部门（每周期）
-        try { _accumulateCorruptionFromNpcs(G); } catch(_e) {}
+        try { _accumulateCorruptionFromNpcs(G); } catch(_e) { if (strict) throw _e; }
         // overall = 6 部门平均
         var deptSum = 0, deptCnt = 0;
         Object.keys(G.corruption.byDept || {}).forEach(function(d) {
@@ -775,12 +780,18 @@
         prov.minxinDetails.index = _v;
         prov.minxinDetails.trueIndex = _v;
       });
-    } catch (_uiMxSyncE) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_uiMxSyncE, 'bridge] uiMinxinSync') : console.error('[bridge] uiMinxinSync', _uiMxSyncE); }
+    } catch (_uiMxSyncE) {
+      (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_uiMxSyncE, 'bridge] uiMinxinSync') : console.error('[bridge] uiMinxinSync', _uiMxSyncE);
+      if (strict) throw _uiMxSyncE;
+    }
 
     // P-DZ·回合末数值定型后，统一把 minxin/huangwei/huangquan 的 phase 段位 + 皇威 tyrant/失威状态
     //   重算对齐当前数值（minxin.trueIndex 此处刚由聚合写定、huangwei.index 由 _tickHuangwei 衰减写定）——
     //   修「数值变了但段位/暴君标记滞留」：面板段位错位 + authority-complete 等按 phase 触发的后果被带偏。
-    try { if (global.AuthorityEngines && typeof global.AuthorityEngines.syncAuthorityPhases === 'function') global.AuthorityEngines.syncAuthorityPhases(); } catch (_syncPhaseE) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_syncPhaseE, 'bridge] syncAuthorityPhases') : console.error('[bridge] syncAuthorityPhases', _syncPhaseE); }
+    try { if (global.AuthorityEngines && typeof global.AuthorityEngines.syncAuthorityPhases === 'function') global.AuthorityEngines.syncAuthorityPhases(); } catch (_syncPhaseE) {
+      (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_syncPhaseE, 'bridge] syncAuthorityPhases') : console.error('[bridge] syncAuthorityPhases', _syncPhaseE);
+      if (strict) throw _syncPhaseE;
+    }
   }
 
   // ═══════════════════════════════════════════════════════════════════
@@ -816,7 +827,13 @@
     try { aggregateRegionsToVariables(); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'bridge] aggregate:') : console.error('[bridge] aggregate:', e); }
   }
 
-  function init() {
+  function init(options) {
+    options = options || {};
+    if (options.strict === true) {
+      initializeFromLegacy();
+      aggregateRegionsToVariables({ strict: true });
+      return;
+    }
     try { initializeFromLegacy(); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'bridge] init:') : console.error('[bridge] init:', e); }
     // 首次聚合
     try { aggregateRegionsToVariables(); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-integration-bridge');}catch(_){}}

--- a/web/tm-office-panel.js
+++ b/web/tm-office-panel.js
@@ -1437,6 +1437,11 @@ function renderBiannian(force){
     }
 
     activeEl.innerHTML = aHtml;
+    if (typeof ChronicleSystem !== 'undefined' && ChronicleSystem && typeof ChronicleSystem.renderLegacyRecoveryNotice === 'function') {
+      ChronicleSystem.renderLegacyRecoveryNotice(activeEl).catch(function(error) {
+        try { if (window.TM && TM.errors && TM.errors.captureSilent) TM.errors.captureSilent(error, 'Biannian·legacy recovery'); } catch (_) {}
+      });
+    }
   }
 
   // ═══ Section 3：永久编年·史册 ═══

--- a/web/tm-save-lifecycle.js
+++ b/web/tm-save-lifecycle.js
@@ -1015,6 +1015,59 @@ var PREF_CONF_KEYS = [
   'insecureTlsRelay'
 ];
 
+function _tmCaptureLoadStepError(error, label, silent) {
+  if (!error || (typeof error !== 'object' && typeof error !== 'function')) error = new Error(String(error));
+  try { error._tmLoadStep = String(label || 'unknown'); } catch (_) {}
+  try {
+    if (window.TM && TM.errors) {
+      if (silent && typeof TM.errors.captureSilent === 'function') TM.errors.captureSilent(error, 'fullLoadGame·' + label);
+      else if (typeof TM.errors.capture === 'function') TM.errors.capture(error, 'fullLoadGame·' + label);
+    }
+  } catch (_) {}
+  return error;
+}
+
+function _tmRunCriticalLoadStep(label, fn) {
+  try { return fn(); }
+  catch (error) { throw _tmCaptureLoadStepError(error, label, false); }
+}
+
+function _tmRunDegradableLoadStep(label, fn) {
+  try { return fn(); }
+  catch (error) {
+    _tmCaptureLoadStepError(error, label, true);
+    return null;
+  }
+}
+
+function _tmRunDegradableLoadStepAsync(label, fn) {
+  return Promise.resolve().then(fn).catch(function(error) {
+    _tmCaptureLoadStepError(error, label, true);
+    return null;
+  });
+}
+
+function _tmValidateLoadedWorld(targetP, targetGM) {
+  if (!targetP || typeof targetP !== 'object' || Array.isArray(targetP)) throw new Error('存档 P 不是合法对象');
+  if (!targetGM || typeof targetGM !== 'object' || Array.isArray(targetGM)) throw new Error('存档 GM 不是合法对象');
+  var turn = Number(targetGM.turn);
+  if (!Number.isSafeInteger(turn) || turn < 0) throw new Error('存档回合号非法');
+  if (!String(targetGM._campaignId || '')) throw new Error('存档缺少 campaignId');
+  if (!_tmEnsureTimelineIdentity(targetGM)) throw new Error('存档缺少 timelineId');
+  [['chars', targetGM.chars], ['facs', targetGM.facs], ['armies', targetGM.armies], ['officeTree', targetGM.officeTree]].forEach(function(pair) {
+    if (pair[1] != null && !Array.isArray(pair[1])) throw new Error('存档字段 ' + pair[0] + ' 必须为数组');
+  });
+  if (targetGM.mapData != null) {
+    if (typeof targetGM.mapData !== 'object' || Array.isArray(targetGM.mapData)) throw new Error('运行地图结构非法');
+    if (targetGM.mapData.regions != null && !Array.isArray(targetGM.mapData.regions)) throw new Error('运行地图地区必须为数组');
+    if (targetP.map === targetGM.mapData || targetP.mapData === targetGM.mapData) throw new Error('运行地图与剧本模板仍共享引用');
+  }
+  if (targetGM._chronicleSysState != null && (typeof targetGM._chronicleSysState !== 'object' || Array.isArray(targetGM._chronicleSysState))) {
+    throw new Error('编年状态结构非法');
+  }
+  return true;
+}
+
 function _recoverPendingTurnDataPublish() {
   if (!(GM && window.tianming && typeof window.tianming.recoverTurnData === 'function')) return Promise.resolve({ ok: true, skipped: true });
   var targetGM = GM;
@@ -1069,7 +1122,7 @@ function _recoverPendingTurnDataPublish() {
   }).catch(function(error) {
     if (GM !== targetGM) return;
     try { if (window.TM && TM.errors && TM.errors.capture) TM.errors.capture(error, 'fullLoadGame] recover turn-data'); } catch (_) {}
-    try { if (typeof toast === 'function') toast('存档已载入；回合分卷仍待补发，将在下次读档重试。'); } catch (_) {}
+    try { if (typeof toast === 'function') toast('回合分卷恢复失败，正在恢复读档前世界；请排除磁盘问题后重试。'); } catch (_) {}
     return { ok: false, error: error };
   });
 }
@@ -1078,8 +1131,14 @@ function _tmCaptureLoadTransaction() {
   var oldP = (typeof P !== 'undefined') ? P : null;
   var oldGM = (typeof GM !== 'undefined') ? GM : null;
   var presets = null;
+  var backgroundJobs = [];
   try {
     presets = window.scriptData && window.scriptData.customPresets;
+  } catch (_) {}
+  try {
+    if (typeof ChronicleSystem !== 'undefined' && ChronicleSystem && typeof ChronicleSystem.capturePendingWorldJobs === 'function') {
+      backgroundJobs = ChronicleSystem.capturePendingWorldJobs(oldGM);
+    }
   } catch (_) {}
   return {
     id: 'load-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 12),
@@ -1088,7 +1147,8 @@ function _tmCaptureLoadTransaction() {
     gmBusy: oldGM && oldGM.busy,
     hydrationPending: oldGM && oldGM._loadHydrationPending,
     autoSaveSessionToken: (typeof _tmGetDesktopAutoSaveSessionToken === 'function') ? _tmGetDesktopAutoSaveSessionToken() : '',
-    customPresets: presets
+    customPresets: presets,
+    backgroundJobs: backgroundJobs
   };
 }
 
@@ -1139,6 +1199,16 @@ function _tmRestoreLoadTransaction(txn) {
       'renderShijiList', 'renderGameTech', 'renderGameCivic', 'renderRenwu', 'renderSidePanels'].forEach(function(name) {
       try { if (typeof window[name] === 'function') window[name](); } catch (_) {}
     });
+  }
+  try {
+    if (GM && P && txn.backgroundJobs && txn.backgroundJobs.length && typeof ChronicleSystem !== 'undefined' &&
+      ChronicleSystem && typeof ChronicleSystem.rearmWorldJobs === 'function') {
+      Promise.resolve(ChronicleSystem.rearmWorldJobs(GM, P, txn.backgroundJobs)).catch(function(error) {
+        _tmCaptureLoadStepError(error, 'background rearm after rollback', true);
+      });
+    }
+  } catch (rearmError) {
+    _tmCaptureLoadStepError(rearmError, 'background rearm after rollback', true);
   }
   return true;
 }
@@ -1239,11 +1309,11 @@ async function _fullLoadGameApplyImpl(data, loadOptions, _loadTxn){
   }
   // 同步通知主进程切换 canonical auto-save session。旧 IPC 即使正在 writeFile，rename 前也会因 token 失效被拒；
   // 从 canonical 自动档恢复时沿用其 token，普通案卷/残局读档则创建新 token。
-  try {
+  _tmRunCriticalLoadStep('auto-save session rotate', function() {
     if (typeof _tmRotateDesktopAutoSaveSession === 'function') {
       _tmRotateDesktopAutoSaveSession('full-load', loadOptions.autoSaveSessionToken || '');
     }
-  } catch (_asRotateE) { try { console.warn('[autoSave] 读档 session 切换失败:', _asRotateE); } catch (_) {} }
+  });
   // 恢复被存档冲掉的 API 配置（key/url/model 等都从 localStorage 拉回）
   if (_preservedAi && typeof _preservedAi === 'object' && (_preservedAi.key || _preservedAi.url)) {
     if (!P.ai) P.ai = {};
@@ -1261,7 +1331,9 @@ async function _fullLoadGameApplyImpl(data, loadOptions, _loadTxn){
   if(GM){
     GM.running=true;
     // 旧档可能没有或带着陈旧 GM.year/month/day；读档后按 turn + P.time 重新派生。
-    try { if (typeof _tmSyncGMCalendar === 'function') _tmSyncGMCalendar(GM, GM.turn || 1); } catch (_calendarLoadE) {}
+    _tmRunCriticalLoadStep('calendar sync', function() {
+      if (typeof _tmSyncGMCalendar === 'function') _tmSyncGMCalendar(GM, GM.turn || 1);
+    });
     // 必需 hydration/receipt 恢复完成前保持 busy，旧界面残留按钮也不能提前过回合。
     GM.busy = true;
     GM._loadHydrationPending = true;
@@ -1282,22 +1354,18 @@ async function _fullLoadGameApplyImpl(data, loadOptions, _loadTxn){
     // 恢复所有_saved*字段
     _restoreSavedFields();
     // Stage 2·L1·KejuParadigm migrate·旧存档自动 init paradigm·version-aware
-    try {
+    _tmRunCriticalLoadStep('kjpMigrate', function() {
       if (typeof _kjpMigrate === 'function') _kjpMigrate();
-    } catch (_kjpME) {
-      try { window.TM && TM.errors && TM.errors.captureSilent(_kjpME, 'fullLoadGame·kjpMigrate'); } catch(_) {}
-    }
-    try {
+    });
+    _tmRunCriticalLoadStep('phase8 formal drafts', function() {
       if (window.TMPhase8FormalBridge && typeof window.TMPhase8FormalBridge.restoreDraftsFromGM === 'function') {
         window.TMPhase8FormalBridge.restoreDraftsFromGM(true);
       } else if (typeof window.restorePhase8FormalDraftsFromGM === 'function') {
         window.restorePhase8FormalDraftsFromGM(true);
       }
-    } catch(_phase8DraftLoadE) {
-      try { window.TM && TM.errors && TM.errors.captureSilent(_phase8DraftLoadE, 'fullLoadGame·phase8FormalDrafts'); } catch(_) {}
-    }
+    });
     // 存档载入后恢复独立地图 live state；P 保留剧本模板，禁止与 GM 共享引用。
-    try {
+    _tmRunCriticalLoadStep('runtime map bind', function() {
       var _liveMapSrc = (GM && GM.mapData && GM.mapData.regions && GM.mapData.regions.length > 0) ? GM.mapData :
         (P && P.map && P.map.regions && P.map.regions.length > 0) ? P.map :
         (P && P.mapData && P.mapData.regions && P.mapData.regions.length > 0) ? P.mapData : null;
@@ -1313,22 +1381,24 @@ async function _fullLoadGameApplyImpl(data, loadOptions, _loadTxn){
         GM.mapData = _safeClone(_liveMapSrc);
         GM._useAIGeo = false;
       }
-    } catch(_mapRestoreE) { try{ window.TM&&TM.errors&&TM.errors.captureSilent(_mapRestoreE,'fullLoadGame·mapLiveState'); }catch(_){} }
+    });
 
     // 一次性清理·扫除存档里历史误抓人物(强烈/连日/乌纱/平静等命中 NAME_BLACKLIST 词组)
-    try {
+    _tmRunCriticalLoadStep('blacklisted character purge', function() {
       if (typeof purgeBlacklistedCharacters === 'function') {
         var _purged = purgeBlacklistedCharacters();
         if (_purged && (_purged.chars.length || _purged.pending.length)) {
           if (typeof addEB === 'function') addEB('清理', '清扫历史误抓人物·chars: ' + _purged.chars.length + '·pending: ' + _purged.pending.length);
         }
       }
-    } catch(_purgeE) { try{ window.TM&&TM.errors&&TM.errors.captureSilent(_purgeE,'fullLoadGame·purge'); }catch(_){} }
+    });
 
     // 迁移官制树到双层模型
     if (typeof _offMigrateTree === 'function' && GM.officeTree) _offMigrateTree(GM.officeTree);
     // 单一真相源:读档时去重人物+从树回填officialTitle+派生任职者(治双源漂移/布衣/重复人物)
-    try { if (typeof _offSyncHoldersFromChars === 'function') _offSyncHoldersFromChars({ importSeats: true, dedupChars: true, force: true }); } catch (_e) {}
+    _tmRunCriticalLoadStep('office holder synchronization', function() {
+      if (typeof _offSyncHoldersFromChars === 'function') _offSyncHoldersFromChars({ importSeats: true, dedupChars: true, force: true });
+    });
     // 官制officialTitle同步——确保ch.officialTitle与GM.officeTree一致
     if (GM.officeTree && GM.chars) {
       (function _syncTitles(nodes) {
@@ -1336,7 +1406,7 @@ async function _fullLoadGameApplyImpl(data, loadOptions, _loadTxn){
           (n.positions||[]).forEach(function(p) {
             var _names = [];
             if (typeof _offAllHolders === 'function') {
-              try { _names = _offAllHolders(p) || []; } catch(_) { _names = []; }
+              _names = _tmRunCriticalLoadStep('office holder enumeration', function() { return _offAllHolders(p) || []; });
             }
             if (!_names.length && p.holder) _names = [p.holder];
             _names.forEach(function(_nm, _idx) {
@@ -1353,51 +1423,55 @@ async function _fullLoadGameApplyImpl(data, loadOptions, _loadTxn){
     // 确保所有字段有默认值
     _ensureGMDefaults();
     _ensurePDefaults();
-    try { if (typeof TMArmyUnits !== 'undefined') TMArmyUnits.ensureAllArmies(GM); } catch (e) {}   // 御驾亲征接入 Phase0:army.composition→units[] 编制地基(载入一次性·幂等·永不崩·不改 composition)
-    if (typeof buildCoreMetricLabels === 'function') buildCoreMetricLabels();
+    _tmRunCriticalLoadStep('army structure migration', function() {
+      if (typeof TMArmyUnits !== 'undefined') TMArmyUnits.ensureAllArmies(GM);
+    });   // 御驾亲征接入 Phase0:army.composition→units[] 编制地基(载入一次性·幂等·不改 composition)
+    _tmRunDegradableLoadStep('core metric labels', function() {
+      if (typeof buildCoreMetricLabels === 'function') buildCoreMetricLabels();
+    });
 
     // 角色完整字段补齐（兼容旧存档/手工导入的 JSON）
-    try {
+    _tmRunCriticalLoadStep('character schema migration', function() {
       if (typeof CharFullSchema !== 'undefined' && typeof CharFullSchema.ensureAll === 'function') {
         CharFullSchema.ensureAll(GM.chars);
       }
-    } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'fullLoadGame] CharFullSchema.ensureAll 失败:') : console.error('[fullLoadGame] CharFullSchema.ensureAll 失败:', e); }
+    });
 
-    try {
+    _tmRunCriticalLoadStep('engine migration', function() {
       if (typeof EngineMigration !== 'undefined' && typeof EngineMigration.run === 'function') {
         EngineMigration.run(GM);
       }
-    } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'fullLoadGame] EngineMigration.run 失败:') : console.error('[fullLoadGame] EngineMigration.run 失败:', e); }
+    });
 
-    try {
+    _tmRunCriticalLoadStep('relationship reference migration', function() {
       if (typeof RelGraph !== 'undefined' && typeof RelGraph.syncCharRefs === 'function' && Array.isArray(GM.chars)) {
         GM.chars.forEach(function(ch) {
-          try { RelGraph.syncCharRefs(ch, GM); } catch(_) {}
+          RelGraph.syncCharRefs(ch, GM);
         });
       }
-    } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'fullLoadGame] RelGraph.syncCharRefs 失败:') : console.error('[fullLoadGame] RelGraph.syncCharRefs 失败:', e); }
+    });
 
     // 影子条目存量清障(2026-07-04)：历史版本 AI 落建造在 BUILDING_TYPES 反查失败时铸的「未知建筑」
     // 死条目(无描述/无 status/无效果)随档累积·且按 territory|type 键位把营造志真记录挤出合并清单
     // (地块面板全显「未知建筑·完好」病根之一)。读档一次性清·随后 buildIndices 重建索引保持一致。
-    try {
+    _tmRunCriticalLoadStep('shadow building purge', function() {
       if (Array.isArray(GM.buildings) && typeof BUILDING_TYPES !== 'undefined') {
         var _shadowN = GM.buildings.length;
         GM.buildings = GM.buildings.filter(function(b){ return b && !(b.name === '未知建筑' && !BUILDING_TYPES[b.type]); });   // arch-ok:读档迁移·影子死账一次性清障(非游戏内业务直写)
         _shadowN -= GM.buildings.length;
         if (_shadowN > 0) console.log('[fullLoadGame] 清除「未知建筑」影子条目 ' + _shadowN + ' 条(历史AI落建造反查失败所铸)');
       }
-    } catch(_shadowPurgeE) {}
+    });
     // 重建索引
     if (typeof buildIndices === 'function') buildIndices();
     // 2026-06-10·_facIndex 已不入存档(autoSave SKIP·派生索引)·读档后在 chars/官衔/迁移全就绪处重建·
     // 兼顾旧存档:旧档里的 _facIndex 反序列化后本就是与 chars 脱钩的死拷贝·重建一并治
-    try {
+    _tmRunCriticalLoadStep('faction index rebuild', function() {
       if (window.TM && TM.FactionIndex && typeof TM.FactionIndex.rebuild === 'function') TM.FactionIndex.rebuild();
-    } catch(_fxRebuildE) { try{ window.TM&&TM.errors&&TM.errors.captureSilent(_fxRebuildE,'fullLoadGame·facIndexRebuild'); }catch(_){} }
+    });
 
     // P6.3 修：老存档加载后·若 _memTables 缺失或仅有空 schema·自动反向重建以保留历史
-    try {
+    _tmRunCriticalLoadStep('memory tables migration', function() {
       if (window.MemTables && MemTables.ensureInit) {
         MemTables.ensureInit();
         var _eh = MemTables.getSheet('eventHistory');
@@ -1413,16 +1487,16 @@ async function _fullLoadGameApplyImpl(data, loadOptions, _loadTxn){
           }
         }
       }
-    } catch(_mtRebuildE) { console.warn('[fullLoadGame] 12 表自动重建失败:', _mtRebuildE); }
+    });
 
-    try {
+    _tmRunCriticalLoadStep('memory turn backfill', function() {
       if (window.TM && TM.MemoryTurnBackfill && typeof TM.MemoryTurnBackfill.ensureBackfilled === 'function') {
         var _memSpine = TM.MemoryTurnBackfill.ensureBackfilled(GM, { turn: GM.turn, archiveCap: 80 });
         if (_memSpine && (_memSpine.rebuilt || _memSpine.reason === 'rollup_rebuilt_from_existing_archive')) {
           console.log('[fullLoadGame] memory spine backfill: ' + (_memSpine.legacyBundles || 0) + ' bundles');
         }
       }
-    } catch(_memSpineE) { console.warn('[fullLoadGame] memory spine backfill failed:', _memSpineE); }
+    });
 
     // ── 管辖层级/封建字段迁移（老存档兼容）──
     if (GM.facs && GM.facs.length > 0) {
@@ -1437,14 +1511,14 @@ async function _fullLoadGameApplyImpl(data, loadOptions, _loadTxn){
     }
     // 派生所有区划 autonomy（首次载入/老存档）
     if (typeof applyAutonomyToAllDivisions === 'function') {
-      try { applyAutonomyToAllDivisions(); } catch(_autE) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_autE, 'autonomy] 派生失败') : console.warn('[autonomy] 派生失败', _autE); }
+      _tmRunCriticalLoadStep('division autonomy migration', function() { applyAutonomyToAllDivisions(); });
     }
     // 自动分配后妃居所
     if (typeof autoAssignHaremResidences === 'function') {
-      try { autoAssignHaremResidences(); } catch(_resE) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_resE, 'residence] 分配失败') : console.warn('[residence] 分配失败', _resE); }
+      _tmRunCriticalLoadStep('harem residence migration', function() { autoAssignHaremResidences(); });
     }
     // 载入存档后：若 GM.adminHierarchy 缺失/为空（老存档），从剧本或 P 恢复
-    try {
+    _tmRunCriticalLoadStep('admin hierarchy migration', function() {
       var _ahEmpty = !GM.adminHierarchy ||
                      typeof GM.adminHierarchy !== 'object' ||
                      Object.keys(GM.adminHierarchy).length === 0;
@@ -1458,12 +1532,12 @@ async function _fullLoadGameApplyImpl(data, loadOptions, _loadTxn){
           console.log('[fullLoadGame] GM.adminHierarchy 从 P 恢复·keys=' + Object.keys(GM.adminHierarchy).join(','));
         }
       }
-    } catch(_ahLE) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_ahLE, 'fullLoadGame] adminHierarchy 恢复失败') : console.warn('[fullLoadGame] adminHierarchy 恢复失败', _ahLE); }
+    });
 
     // 老存档兼容：GM.fiscal.{royalClanPressure,huangzhuangIncome,imperialBusinesses} 缺失时从 P.fiscalConfig.neicangRules 镜像
     // tm-fiscal-fixed-expense.js:_calcRoyalStipend 等读 G.fiscal.royalClanPressure·缺则宗禄岁出 = 0
     // Old-save compatibility: mirror explicit scenario constants/groups into GM and P.
-    try {
+    _tmRunCriticalLoadStep('engine constants migration', function() {
       var _scEC = (typeof findScenarioById === 'function' && GM.sid) ? findScenarioById(GM.sid) : null;
       if (_scEC) {
         if (!GM.engineConstants && _scEC.engineConstants) {
@@ -1481,9 +1555,9 @@ async function _fullLoadGameApplyImpl(data, loadOptions, _loadTxn){
           }
         }
       }
-    } catch(_ecLE) { try{window.TM&&TM.errors&&TM.errors.captureSilent(_ecLE,'fullLoadGame-engineConstants-GM-P');}catch(_){} }
+    });
 
-    try {
+    _tmRunCriticalLoadStep('fiscal configuration migration', function() {
       var _scFC = (typeof findScenarioById === 'function' && GM.sid) ? findScenarioById(GM.sid) : null;
       var _fcSrc = (P.fiscalConfig && P.fiscalConfig.neicangRules)
                 || (_scFC && _scFC.fiscalConfig && _scFC.fiscalConfig.neicangRules);
@@ -1493,30 +1567,41 @@ async function _fullLoadGameApplyImpl(data, loadOptions, _loadTxn){
         if (_fcSrc.huangzhuangIncome && !GM.fiscal.huangzhuangIncome) GM.fiscal.huangzhuangIncome = deepClone(_fcSrc.huangzhuangIncome);
         if (_fcSrc.imperialBusinesses && !GM.fiscal.imperialBusinesses) GM.fiscal.imperialBusinesses = deepClone(_fcSrc.imperialBusinesses);
       }
-    } catch(_fcLE) { try{window.TM&&TM.errors&&TM.errors.captureSilent(_fcLE,'fullLoadGame·fiscalConfig→GM.fiscal');}catch(_){} }
+    });
 
     // 集成桥梁：老存档可能缺 divisions 深化字段，init 会补齐并建立 legacy proxy
     if (typeof IntegrationBridge !== 'undefined' && typeof IntegrationBridge.init === 'function') {
-      try { IntegrationBridge.init(); } catch(_ibE) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_ibE, 'bridge] init 失败') : console.warn('[bridge] init 失败', _ibE); }
+      _tmRunCriticalLoadStep('integration bridge migration', function() { IntegrationBridge.init({ strict: true }); });
     }
 
     // 同步剧本自定义预设（HistoricalPresets 动态 getter 读取 window.scriptData.customPresets）
-    try {
+    _tmRunCriticalLoadStep('custom presets synchronization', function() {
       if (P && P.customPresets) {
         if (!window.scriptData) window.scriptData = {};
         window.scriptData.customPresets = P.customPresets;
       }
-    } catch(_cpLE) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_cpLE, 'load] customPresets sync 失败') : console.warn('[load] customPresets sync 失败', _cpLE); }
+    });
+
+    _tmRunCriticalLoadStep('loaded world validation', function() { return _tmValidateLoadedWorld(P, GM); });
 
     // 读档完成屏障：先合并当前父时间线的有效辅助记录和可恢复分卷，再开放任何玩法操作。
     if (typeof ChronicleSystem !== 'undefined' && typeof ChronicleSystem.hydrateDurableRecords === 'function') {
       await ChronicleSystem.hydrateDurableRecords(GM, P);
       _assertLoadLeaseCurrent();
     }
-    await _recoverPendingTurnDataPublish();
+    var _turnDataRecovery = await _recoverPendingTurnDataPublish();
+    if (_turnDataRecovery && _turnDataRecovery.ok === false) {
+      throw (_turnDataRecovery.error || new Error('回合分卷恢复失败'));
+    }
     _assertLoadLeaseCurrent();
     // 每次从快照继续都建立子时间线；失败回滚可显式 preserveTimeline 复原原身份。
     if (!loadOptions.preserveTimeline) _tmForkLoadedTimeline(GM, loadOptions.source || 'load');
+    if (typeof StateSnapshot !== 'undefined' && StateSnapshot && typeof StateSnapshot.recordTimeline === 'function') {
+      await _tmRunDegradableLoadStepAsync('timeline lineage persistence', function() {
+        return StateSnapshot.recordTimeline(GM);
+      });
+      _assertLoadLeaseCurrent();
+    }
     GM._loadHydrationPending = false;
     GM.busy = false;
 

--- a/web/tm-state-snapshot.js
+++ b/web/tm-state-snapshot.js
@@ -12,7 +12,8 @@
   var DB_NAME = 'tianming_snapshots';
   var LEGACY_STORE = 'snapshots';
   var STORE = 'snapshots_v2';
-  var DB_VERSION = 4;
+  var LINEAGE_STORE = 'timeline_graph';
+  var DB_VERSION = 5;
   var MAX_SNAPSHOTS = 200;
   var _dbPromise = null;
 
@@ -71,6 +72,35 @@
     return campaignId + ':' + timelineId + ':' + _strictTurn(turn);
   }
 
+  function _lineageId(campaignId, timelineId) {
+    return String(campaignId || '') + ':' + String(timelineId || '');
+  }
+
+  function _lineageRecordFromGM(gm, campaignId, timelineId) {
+    if (!gm || typeof gm !== 'object') return null;
+    campaignId = String(campaignId || gm._campaignId || '');
+    timelineId = String(timelineId || gm._timelineId || '');
+    if (!campaignId || !/^tml_[A-Za-z0-9_-]{8,124}$/.test(timelineId)) return null;
+    var parentTimelineId = String(gm._parentTimelineId || '');
+    var forkTurn = Number(gm._forkTurn);
+    if (!parentTimelineId || !/^tml_[A-Za-z0-9_-]{8,124}$/.test(parentTimelineId) || parentTimelineId === timelineId) {
+      parentTimelineId = '';
+      forkTurn = 0;
+    } else if (!Number.isSafeInteger(forkTurn) || forkTurn < 0) {
+      return null;
+    }
+    return {
+      id: _lineageId(campaignId, timelineId),
+      campaignId: campaignId,
+      timelineId: timelineId,
+      parentTimelineId: parentTimelineId,
+      forkTurn: forkTurn,
+      forkReason: String(gm._timelineForkReason || '').slice(0, 80),
+      createdAt: Number(gm._timelineCreatedAt) || Date.now(),
+      updatedAt: Date.now()
+    };
+  }
+
   function _deepClone(obj) {
     if (obj == null || typeof obj !== 'object') return obj;
     try {
@@ -86,6 +116,18 @@
       var req = indexedDB.open(DB_NAME, DB_VERSION);
       req.onupgradeneeded = function(e) {
         var db = e.target.result;
+        var lineageStore;
+        if (!db.objectStoreNames.contains(LINEAGE_STORE)) {
+          lineageStore = db.createObjectStore(LINEAGE_STORE, { keyPath: 'id' });
+          lineageStore.createIndex('campaignId', 'campaignId', { unique: false });
+        } else {
+          lineageStore = e.target.transaction.objectStore(LINEAGE_STORE);
+          try {
+            if (!lineageStore.indexNames || !lineageStore.indexNames.contains('campaignId')) {
+              lineageStore.createIndex('campaignId', 'campaignId', { unique: false });
+            }
+          } catch (_) {}
+        }
         if (!db.objectStoreNames.contains(STORE)) {
           var store = db.createObjectStore(STORE, { keyPath: 'id' });
           store.createIndex('campaignId', 'campaignId', { unique: false });
@@ -106,13 +148,13 @@
               existingStore.createIndex('timelineTurn', ['campaignId', 'timelineId', 'turn'], { unique: true });
             }
           } catch (_) {}
-          if (e.oldVersion > 0 && e.oldVersion < 4) {
+          if (e.oldVersion > 0 && e.oldVersion < 5) {
             var cursorReq = existingStore.openCursor();
             cursorReq.onsuccess = function() {
               var cursor = cursorReq.result;
               if (!cursor) return;
               var record = cursor.value;
-              if (record && record.campaignId && !/^tml_[A-Za-z0-9_-]{8,124}$/.test(String(record.timelineId || ''))) {
+              if (e.oldVersion < 4 && record && record.campaignId && !/^tml_[A-Za-z0-9_-]{8,124}$/.test(String(record.timelineId || ''))) {
                 var oldId = String(record.id || '');
                 var timelineId = _legacyTimelineId(record.campaignId);
                 record.timelineId = timelineId;
@@ -124,6 +166,9 @@
                 existingStore.put(record);
                 if (oldId && oldId !== record.id) existingStore.delete(oldId);
               }
+              var lineage = record && record.state && record.state.GM
+                ? _lineageRecordFromGM(record.state.GM, record.campaignId, record.timelineId) : null;
+              if (lineage) lineageStore.put(lineage);
               cursor.continue();
             };
           }
@@ -161,8 +206,11 @@
       return new Promise(function(resolve, reject) {
         var tx;
         try {
-          tx = db.transaction(STORE, 'readwrite');
+          tx = db.transaction([STORE, LINEAGE_STORE], 'readwrite');
           tx.objectStore(STORE).put(record);
+          var lineage = record && record.state && record.state.GM
+            ? _lineageRecordFromGM(record.state.GM, record.campaignId, record.timelineId) : null;
+          if (lineage) tx.objectStore(LINEAGE_STORE).put(lineage);
           tx.oncomplete = function() { resolve(record); };
           tx.onerror = function(e) { reject((e.target && e.target.error) || tx.error || new Error('快照写入失败')); };
           tx.onabort = function(e) { reject((e.target && e.target.error) || tx.error || new Error('快照事务已中止')); };
@@ -186,6 +234,42 @@
     });
   }
 
+  function _getAllLineageRecords() {
+    return _openDB().then(function(db) {
+      return new Promise(function(resolve, reject) {
+        var tx;
+        try {
+          tx = db.transaction(LINEAGE_STORE, 'readonly');
+          var req = tx.objectStore(LINEAGE_STORE).getAll();
+          req.onsuccess = function(e) { resolve(e.target.result || []); };
+          req.onerror = function(e) { reject(e.target.error || new Error('时间线图读取失败')); };
+          tx.onabort = function(e) { reject((e.target && e.target.error) || tx.error || new Error('时间线图读取事务已中止')); };
+        } catch (e) { reject(e); }
+      });
+    });
+  }
+
+  function recordTimeline(gm) {
+    gm = gm || global.GM || (typeof GM !== 'undefined' ? GM : null);
+    if (!gm) return Promise.resolve({ ok: false, reason: 'no GM' });
+    var campaignId = _ensureCampaignId(gm);
+    var timelineId = _ensureTimelineId(gm);
+    var record = _lineageRecordFromGM(gm, campaignId, timelineId);
+    if (!record) return Promise.reject(new Error('时间线谱系结构非法'));
+    return _openDB().then(function(db) {
+      return new Promise(function(resolve, reject) {
+        var tx;
+        try {
+          tx = db.transaction(LINEAGE_STORE, 'readwrite');
+          tx.objectStore(LINEAGE_STORE).put(record);
+          tx.oncomplete = function() { resolve({ ok: true, record: record }); };
+          tx.onerror = function(e) { reject((e.target && e.target.error) || tx.error || new Error('时间线谱系写入失败')); };
+          tx.onabort = function(e) { reject((e.target && e.target.error) || tx.error || new Error('时间线谱系事务已中止')); };
+        } catch (e) { reject(e); }
+      });
+    });
+  }
+
   function _timelineOwnerFromRecords(records, campaignId, timelineId, maxTurn) {
     var candidates = (records || []).filter(function(record) {
       return record && record.campaignId === campaignId && record.timelineId === timelineId
@@ -196,22 +280,27 @@
 
   // 子时间线可只读继承 forkTurn 以前的祖先快照。当前线记录优先；祖先 payload 不复制，
   // 因而长局分叉不会造成成倍存储，同时不会让一次正常读档把 T1..Tn 历史列表清空。
-  function _accessibleSnapshotRecords(records, campaignId, timelineId, currentGM) {
+  function _accessibleSnapshotRecords(records, lineageRecords, campaignId, timelineId, currentGM) {
     var chain = [];
     var seen = Object.create(null);
+    var lineageByTimeline = Object.create(null);
+    (lineageRecords || []).forEach(function(record) {
+      if (record && record.campaignId === campaignId && record.timelineId) lineageByTimeline[record.timelineId] = record;
+    });
     var cursorTimeline = timelineId;
     var cursorOwner = currentGM && currentGM._campaignId === campaignId && currentGM._timelineId === timelineId ? currentGM : null;
     var maxTurn = Infinity;
     while (cursorTimeline && !seen[cursorTimeline]) {
       seen[cursorTimeline] = true;
       chain.push({ timelineId: cursorTimeline, maxTurn: maxTurn });
-      if (!cursorOwner) cursorOwner = _timelineOwnerFromRecords(records, campaignId, cursorTimeline, maxTurn);
-      var parentTimeline = cursorOwner && String(cursorOwner._parentTimelineId || '');
-      var forkTurn = cursorOwner && Number(cursorOwner._forkTurn);
+      var lineage = lineageByTimeline[cursorTimeline];
+      if (!cursorOwner && !lineage) cursorOwner = _timelineOwnerFromRecords(records, campaignId, cursorTimeline, maxTurn);
+      var parentTimeline = lineage ? String(lineage.parentTimelineId || '') : (cursorOwner && String(cursorOwner._parentTimelineId || ''));
+      var forkTurn = lineage ? Number(lineage.forkTurn) : (cursorOwner && Number(cursorOwner._forkTurn));
       if (!parentTimeline || !Number.isSafeInteger(forkTurn) || forkTurn < 0) break;
       maxTurn = Math.min(maxTurn, forkTurn);
       cursorTimeline = parentTimeline;
-      cursorOwner = _timelineOwnerFromRecords(records, campaignId, cursorTimeline, maxTurn);
+      cursorOwner = null;
     }
     var byTurn = Object.create(null);
     chain.forEach(function(access, depth) {
@@ -308,9 +397,11 @@
         });
       }).then(function(exact) {
         if (exact) return exact;
-        return _getAllRecords().then(function(records) {
+        return Promise.all([_getAllRecords(), _getAllLineageRecords()]).then(function(parts) {
+          var records = parts[0];
+          var lineageRecords = parts[1];
           var currentGM = global.GM || (typeof GM !== 'undefined' ? GM : null);
-          var accessible = _accessibleSnapshotRecords(records, campaignId, timelineId, currentGM);
+          var accessible = _accessibleSnapshotRecords(records, lineageRecords, campaignId, timelineId, currentGM);
           var match = accessible.find(function(item) { return Number(item.record.turn) === _strictTurn(turn); });
           if (!match) return null;
           var inherited = _deepClone(match.record);
@@ -327,8 +418,8 @@
     campaignId = campaignId || (gm ? _ensureCampaignId(gm) : '');
     timelineId = timelineId || (gm ? _ensureTimelineId(gm) : '');
     if (!campaignId || !timelineId) return Promise.resolve([]);
-    return _getAllRecords().then(function(records) {
-      return _accessibleSnapshotRecords(records, campaignId, timelineId, gm).map(function(item) {
+    return Promise.all([_getAllRecords(), _getAllLineageRecords()]).then(function(parts) {
+      return _accessibleSnapshotRecords(parts[0], parts[1], campaignId, timelineId, gm).map(function(item) {
         var r = item.record;
         return {
           turn: r.turn,
@@ -502,6 +593,7 @@
     list: listSnapshots,
     delete: deleteSnapshot,
     timeTravel: timeTravel,
+    recordTimeline: recordTimeline,
     newCampaignId: _newCampaignId
   };
   Object.defineProperty(global, '_timeTravel', { value: timeTravel, writable: false, configurable: true });

--- a/web/tm-storage.js
+++ b/web/tm-storage.js
@@ -1028,6 +1028,70 @@ var TM_SaveDB = (function() {
     });
   }
 
+  function listQuarantinedChronicleRecords(campaignId) {
+    campaignId = String(campaignId || '');
+    if (!campaignId) return Promise.resolve([]);
+    return _ensureOpen().then(function() { return _listAll(CHRONICLE_RECORD_STORE); }).then(function(records) {
+      return (records || []).filter(function(record) {
+        return record && String(record.campaignId || '') === campaignId
+          && String(record.migrationState || '') === 'legacy-unassigned';
+      }).sort(function(a, b) {
+        return Number(a && a.year || 0) - Number(b && b.year || 0)
+          || Number(a && a.generatedAt || 0) - Number(b && b.generatedAt || 0);
+      });
+    });
+  }
+
+  function importQuarantinedChronicleRecord(input, options) {
+    input = input || {};
+    options = options || {};
+    if (input.confirmed !== true) return Promise.reject(new Error('导入隔离编年必须由玩家明确确认'));
+    var recordId = String(input.recordId || '');
+    var campaignId = String(input.campaignId || '');
+    var timelineId = String(input.timelineId || '');
+    var year = Number(input.year);
+    var sourceTurn = Number(input.sourceTurn);
+    var historyBasisHash = String(input.historyBasisHash || '');
+    if (!recordId || !campaignId || !_validTimelineId(timelineId)) return Promise.reject(new Error('隔离编年导入身份无效'));
+    if (!Number.isSafeInteger(year) || !Number.isSafeInteger(sourceTurn) || sourceTurn < 0 || !historyBasisHash) {
+      return Promise.reject(new Error('隔离编年导入缺少当前时间线历史基础'));
+    }
+    var targetId = _auxRecordId('chronicle', campaignId, timelineId + ':' + year);
+    return _ensureOpen().then(function() {
+      return Promise.all([_get(CHRONICLE_RECORD_STORE, recordId), _get(CHRONICLE_RECORD_STORE, targetId)]);
+    }).then(function(rows) {
+      var legacy = rows[0];
+      var existing = rows[1];
+      if (!legacy || String(legacy.campaignId || '') !== campaignId || String(legacy.migrationState || '') !== 'legacy-unassigned') {
+        throw new Error('隔离编年记录不存在或已失效');
+      }
+      if (Number(legacy.year) !== year) throw new Error('隔离编年年份不匹配');
+      if (existing) throw new Error('当前时间线已有该年度正史，未覆盖');
+      var chronicle;
+      try { chronicle = JSON.parse(JSON.stringify(legacy.chronicle)); }
+      catch (error) { throw new Error('隔离编年内容损坏：' + (error && error.message || error)); }
+      var claimed = {
+        id: targetId,
+        campaignId: campaignId,
+        timelineId: timelineId,
+        year: year,
+        sourceTurn: sourceTurn,
+        historyBasisHash: historyBasisHash,
+        requestId: 'legacy-import-' + Date.now(),
+        loadGeneration: Number(input.loadGeneration) || 0,
+        generatedAt: Number(legacy.generatedAt) || Date.now(),
+        chronicle: chronicle,
+        migrationState: 'legacy-confirmed',
+        legacySourceId: String(legacy.legacySourceId || legacy.id || ''),
+        importedAt: Date.now()
+      };
+      return _put(CHRONICLE_RECORD_STORE, claimed, 0, options.writeGuard).then(function(saved) {
+        if (saved !== true) return saved;
+        return claimed;
+      });
+    });
+  }
+
   function pruneChronicleRecords(campaignId, timelineId, maxYears) {
     maxYears = Math.max(1, Math.floor(Number(maxYears) || 20));
     return listChronicleRecords(campaignId, timelineId).then(function(records) {
@@ -1431,6 +1495,8 @@ var TM_SaveDB = (function() {
     clearPendingTurnDataPublishAtomic: clearPendingTurnDataPublishAtomic,
     saveChronicleRecord: saveChronicleRecord,
     listChronicleRecords: listChronicleRecords,
+    listQuarantinedChronicleRecords: listQuarantinedChronicleRecords,
+    importQuarantinedChronicleRecord: importQuarantinedChronicleRecord,
     pruneChronicleRecords: pruneChronicleRecords,
     saveTurnPublishReceipt: saveTurnPublishReceipt,
     listTurnPublishReceipts: listTurnPublishReceipts,


### PR DESCRIPTION
## 修复内容

- 分卷恢复失败会在时间线分叉前中止读档，并由既有 load transaction 恢复原世界。
- 地图、引擎、人物关系、财政、军队、官制和集成桥等状态迁移统一进入 critical load 边界；集成桥新增 strict 模式，内部错误不再被吞掉。
- 读档失败恢复旧世界后，重新调度被 load generation 安全失效的年度编年任务，不复活旧 Promise。
- 为 `legacy-unassigned` 编年提供安全查看、导出和玩家明确确认后的当前时间线导入；原隔离记录保留。
- 时间快照新增独立 `timeline_graph`，即使中间分支没有快照，深层子线仍能继承祖先在 forkTurn 前的历史。
- 桌面存档正文、commit marker 与 sidecar 绑定同一且每次轮换的 payload generation；列表只读取 512 字节正文前缀，正文与元数据代际不一致时 fail closed。
- 刷新 1.3.4.11 全量 OTA 基线：1082 个文件，无资产增删，仅更新 6 个运行脚本哈希。

## 验证

- `node web/scripts/ci-smokes.js`：847 项；845 通过，2 项为隔离工作树缺大资产的既有白名单豁免
- `node web/scripts/lint-arch-all.js`：8/8
- `node web/scripts/verify-official-scenario-parity.js`：27/27
- `node scripts/verify-release-contract.js`：166/166
- `node web/scripts/verify-hot-builder-gates.js`：27/27
- 完整仓主资产树热更基线：1082 文件 PASS
- `npm audit --registry=https://registry.npmjs.org --omit=dev --audit-level=high`：0 vulnerabilities

本 PR 不改版本号、不打包、不触发 Pages 或正式发版。