### PR TITLE
fix: close eleventh-round audit load idempotence gaps

### DIFF
--- a/main-impl.js
+++ b/main-impl.js
@@ -2974,17 +2974,11 @@ ipcMain.handle('load-project', async (event, filename) => {
     const ref = saveFileRef(filename);
     if (!fs.existsSync(ref.path)) return { success: false, error: '文件不存在' };
     const data = JSON.parse(fs.readFileSync(ref.path, 'utf-8'));
-    let payloadGeneration = desktopSaveGenerationFromData(data);
-    if (!payloadGeneration) {
-      const prepared = prepareDesktopSavePayload(data);
-      payloadGeneration = prepared.generation;
-      invalidateDesktopSaveGeneration(ref.key);
-      writeFileAtomic(ref.path, prepared.text, 'utf-8');
-    }
-    try { writeDesktopSaveMetadata(ref.key, data, fs.statSync(ref.path), payloadGeneration); } catch (metadataError) {
-      console.warn('[load-project] sidecar 回填失败:', metadataError && metadataError.message || metadataError);
-    }
-    return { success: true, data, storageKey: ref.key };
+    // 读取必须保持只读：旧 payload 没有 generation 时仍立即允许加载，绝不能
+    // 因目录只读、磁盘已满或同步软件锁文件而把合法存档判成加载失败。generation
+    // 与 sidecar 在下一次真正保存时升级；列表此前保持 metadataPending。
+    const payloadGeneration = desktopSaveGenerationFromData(data);
+    return { success: true, data, storageKey: ref.key, metadataPending: !payloadGeneration };
   } catch (e) {
     return { success: false, error: e.message };
   }
@@ -3185,34 +3179,24 @@ ipcMain.handle('load-auto-save', async () => {
     if (parsed && parsed.__tmAutoSaveEnvelope === 1) {
       const fileToken = normalizeAutoSaveSessionToken(parsed.sessionToken);
       let currentToken = getAutoSaveSessionToken();
-      // 兼容 sidecar 丢失但 canonical envelope 完整的安装：以文件 token 自愈 sidecar。
-      if (!currentToken && fileToken) currentToken = persistAutoSaveSessionToken(fileToken);
+      // 兼容 session sidecar 丢失但 canonical envelope 完整的安装：本次会话仅在
+      // 内存采用文件 token。读取路径不得因磁盘只读而失败，也不得改动任何文件；
+      // 下一次真正保存/轮换 session 时自然会写入新的 canonical sidecar。
+      if (!currentToken && fileToken) {
+        autoSaveSessionToken = fileToken;
+        autoSaveSessionLoaded = true;
+        currentToken = fileToken;
+      }
       if (!fileToken || fileToken !== currentToken) {
         return { success: false, stale: true, error: '自动存档属于已失效的旧局' };
       }
-      let payloadGeneration = desktopSaveGenerationFromData(parsed);
-      if (!payloadGeneration) {
-        const prepared = prepareDesktopSavePayload(parsed);
-        payloadGeneration = prepared.generation;
-        invalidateDesktopSaveGeneration('__autosave__');
-        writeFileAtomic(AUTO_SAVE_FILE, prepared.text, 'utf-8');
-      }
-      try { writeDesktopSaveMetadata('__autosave__', parsed, fs.statSync(AUTO_SAVE_FILE), payloadGeneration); }
-      catch (metadataError) { console.warn('[load-auto-save] sidecar 回填失败:', metadataError && metadataError.message || metadataError); }
-      return { success: true, data: parsed.data, sessionToken: fileToken };
+      const payloadGeneration = desktopSaveGenerationFromData(parsed);
+      return { success: true, data: parsed.data, sessionToken: fileToken, metadataPending: !payloadGeneration };
     }
     // 首次升级前的无 envelope 旧档仅在 sidecar 尚不存在时兼容读取。
     if (getAutoSaveSessionToken()) return { success: false, stale: true, error: '旧自动存档已被新局失效' };
-    let payloadGeneration = desktopSaveGenerationFromData(parsed);
-    if (!payloadGeneration) {
-      const prepared = prepareDesktopSavePayload(parsed);
-      payloadGeneration = prepared.generation;
-      invalidateDesktopSaveGeneration('__autosave__');
-      writeFileAtomic(AUTO_SAVE_FILE, prepared.text, 'utf-8');
-    }
-    try { writeDesktopSaveMetadata('__autosave__', parsed, fs.statSync(AUTO_SAVE_FILE), payloadGeneration); }
-    catch (metadataError) { console.warn('[load-auto-save] legacy sidecar 回填失败:', metadataError && metadataError.message || metadataError); }
-    return { success: true, data: parsed, sessionToken: '' };
+    const payloadGeneration = desktopSaveGenerationFromData(parsed);
+    return { success: true, data: parsed, sessionToken: '', metadataPending: !payloadGeneration };
   } catch (e) {
     return { success: false, error: e.message };
   }

--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-20T04:07:48.052Z",
+  "generatedAt": "2026-08-20T09:27:33.436Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -2161,8 +2161,8 @@
     },
     {
       "path": "index.html",
-      "sha256": "4d6cee867ed96d514ca6b47c4cb3900148fce95ad740ae4c14a2b0944c0dc982",
-      "size": 68606
+      "sha256": "0c8370e27186dfde1cb13b8f1e2a8926720cefd916f5849faec4f9fac5b9dcf8",
+      "size": 68609
     },
     {
       "path": "INDEX.md",
@@ -4341,8 +4341,8 @@
     },
     {
       "path": "tm-integration-bridge.js",
-      "sha256": "ca282177375a7572023743b33a4aae5094c6764af7aedfc8d8195ad1f42e3846",
-      "size": 43960
+      "sha256": "557ab6788c7e58f70cae5f5201bd25fe765a190c0a9512b92ce39df68594360e",
+      "size": 45204
     },
     {
       "path": "tm-invariants.js",
@@ -5096,8 +5096,8 @@
     },
     {
       "path": "tm-save-lifecycle.js",
-      "sha256": "df08bf6122f9532a96a3907c02cad8dfff8f92c46eed428cbdf830fa46dfa496",
-      "size": 122568
+      "sha256": "54a939444c59284141df4429f75f90260ce66866635aef1eafbef1bcba32a012",
+      "size": 126247
     },
     {
       "path": "tm-save-manager.js",
@@ -5146,8 +5146,8 @@
     },
     {
       "path": "tm-state-snapshot.js",
-      "sha256": "3f74c44840e17bb4b4641d9dfd1c3c78b6c8f06304eb3a32e73938cef1b4ac97",
-      "size": 29906
+      "sha256": "1a54f23716b9f7c0678d171e2e5315eb4f3cee410ace20e1565cfa2cee7e4e91",
+      "size": 31323
     },
     {
       "path": "tm-state.js",

--- a/web/index.html
+++ b/web/index.html
@@ -557,7 +557,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-memory-tables.js?v=2026050101"></script>
 <!-- 2026-04-30 Phase 2.1 Swipe 快照与 timeTravel 回溯 -->
 <script src="tm-world-identity.js?v=20260820-auditfix9"></script>
-<script src="tm-state-snapshot.js?v=20260820-auditfix9"></script>
+<script src="tm-state-snapshot.js?v=20260820-auditfix11"></script>
 <!-- 2026-04-30 Phase 2.2 本地语义检索（bge-small-zh-v1.5） -->
 <script src="tm-semantic-recall.js?v=20260811-auditfix1"></script>
 <!-- 2026-04-30 P10.4A 召回节流门控（KokoroMemo retrieval_gate 范式） -->
@@ -838,7 +838,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-bgm-config.js?v=2026051201"></script>
 <!-- R131 (2026-04-25) tm-audio-theme.js 拆分 → audio-theme + save-lifecycle + office-editor -->
 <script src="tm-audio-theme.js?v=20260710-fontscale"></script>
-<script src="tm-save-lifecycle.js?v=20260820-auditfix9"></script>
+<script src="tm-save-lifecycle.js?v=20260820-auditfix11"></script>
 <script src="tm-office-editor.js?v=20260707-nestflat2"></script>
 <script src="tm-topbar-vars.js?v=20260514-phase8-vars-2"></script>
 <!-- R137 (2026-04-25) 拆 shell-extras → shell UI + 时政面板 -->
@@ -912,7 +912,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-ethnic-religion.js?v=2026050701"></script>
 <script src="tm-edict-thresholds.js?v=2026042714"></script>
 <script src="tm-fiscal-ui.js?v=2026042714"></script>
-<script src="tm-integration-bridge.js?v=20260811-auditfix1"></script>
+<script src="tm-integration-bridge.js?v=20260820-auditfix11"></script>
 <script src="tm-fiscal-engine.js?v=20260811-auditfix1"></script>
 <script src="tm-perf.js?v=2026042714"></script>
 <script src="tm-invariants.js?v=2026042714"></script>

--- a/web/scripts/smoke-runtime-save-consistency.js
+++ b/web/scripts/smoke-runtime-save-consistency.js
@@ -104,17 +104,22 @@ ok(/rotateAutoSaveSession/.test(preloadImpl) && /_tmRotateDesktopAutoSaveSession
   && /_tmRotateDesktopAutoSaveSession\('new-game'/.test(startPatch), 'preload + 读档 + 新局共同切换 auto-save session');
 ok(/var _turnDataRecovery = await _recoverPendingTurnDataPublish\(\);[\s\S]*?_turnDataRecovery\.ok === false[\s\S]*?throw[\s\S]*?_tmForkLoadedTimeline/.test(lifecycle),
   'receipt recovery failure aborts before the loaded world can fork its timeline');
-ok(/_tmRunCriticalLoadStep\('runtime map bind'/.test(lifecycle)
+ok(/_tmRebindRuntimeWorld\(\{ strict: true, integration: false/.test(lifecycle)
   && /_tmRunCriticalLoadStep\('engine migration'/.test(lifecycle)
   && /_tmRunCriticalLoadStep\('relationship reference migration'/.test(lifecycle)
   && /_tmRunCriticalLoadStep\('fiscal configuration migration'/.test(lifecycle)
-  && /IntegrationBridge\.init\(\{ strict: true \}\)/.test(lifecycle)
+  && /_tmRebindRuntimeWorld\(\{ strict: true, map: false \}\)/.test(lifecycle)
   && /_tmRunCriticalLoadStep\('loaded world validation'/.test(lifecycle),
   'state-mutating load migrations propagate into the load transaction instead of failing open');
 ok(/function aggregateRegionsToVariables\(options\)[\s\S]*?var strict = options\.strict === true/.test(integrationBridge)
-  && /function init\(options\)[\s\S]*?aggregateRegionsToVariables\(\{ strict: true \}\)/.test(integrationBridge)
-  && /if \(strict\) throw _naturalPopulationGrowth|if \(strict\) throw _e/.test(integrationBridge),
-  'integration bridge exposes a strict load mode instead of swallowing partial migration failures');
+  && /var advanceSimulation = options\.advanceSimulation === true/.test(integrationBridge)
+  && /function migrateAndRebind\(options\)[\s\S]*?advanceSimulation: false/.test(integrationBridge)
+  && /function tick\(options\)[\s\S]*?advanceSimulation: true/.test(integrationBridge),
+  'integration bridge separates pure load rebind from the one explicit simulation tick');
+ok(/function _tmStripSaveTransportMetadata\([\s\S]*?\^__tm\(\?:Desktop\|AutoSave\)/.test(lifecycle)
+  && /_tmStripSaveTransportMetadata\(_incomingP\)/.test(lifecycle)
+  && /_tmStripSaveTransportMetadata\(_incomingGM\)/.test(lifecycle),
+  'desktop and auto-save envelope fields are stripped before P/GM become runtime state');
 ok(/stageTurnData\([\s\S]*?result\.success === true[\s\S]*?回合分卷暂存失败/.test(render)
   && /turnPublishReceipt:\s*ctx\.meta\.stagedTurnData/.test(render)
   && /_tmCommitEndTurnTransaction[\s\S]*?await _endTurn_publishStagedTurnData/.test(core), '回合分卷先暂存·receipt 与世界同事务提交·仅在 commit 后发布');
@@ -232,10 +237,79 @@ async function runDynamicLeaseSmokes() {
     ok(settled === true, 'hydration 完成后 load barrier 才放行等待中的操作');
   }
   {
+    const division = {
+      id: 'region-1', population: { mouths: 50000000, households: 10000000, ding: 12500000 },
+      populationDetail: { mouths: 50000000, households: 10000000, ding: 12500000 },
+      minxin: 60, corruption: 30, environment: { currentLoad: 0.5, carrying: 100000000 }, fiscal: {}
+    };
+    const ctx = {
+      console, Promise, JSON, Math, Number, Object, Array, Date,
+      GM: {
+        turn: 10, adminHierarchy: { player: { divisions: [division] } },
+        population: { national: { mouths: 50000000, households: 10000000 } },
+        minxin: { trueIndex: 60 }, corruption: { trueIndex: 30, overall: 30, byDept: {} },
+        chars: [{ name: '测试官', officialTitle: '知县', integrity: 0, resources: { private: { money: 500000 } } }]
+      },
+      P: {}, TM: { errors: { capture() {}, captureSilent() {} } }
+    };
+    ctx.window = ctx;
+    vm.createContext(ctx);
+    vm.runInContext(integrationBridge, ctx);
+    ctx.IntegrationBridge.migrateAndRebind({ strict: true }); // 一次性 schema 对齐
+    function gameplayState() {
+      const leaf = ctx.GM.adminHierarchy.player.divisions[0];
+      return JSON.stringify({
+        turn: ctx.GM.turn, population: leaf.population, populationDetail: leaf.populationDetail,
+        corruption: ctx.GM.corruption, currentLoad: leaf.environment.currentLoad
+      });
+    }
+    const stable = gameplayState();
+    for (let i = 0; i < 10; i++) {
+      const disk = JSON.parse(JSON.stringify({ GM: ctx.GM, P: ctx.P }));
+      ctx.GM = disk.GM; ctx.P = disk.P;
+      ctx.IntegrationBridge.migrateAndRebind({ strict: true });
+    }
+    const afterTenLoads = gameplayState();
+    ctx.IntegrationBridge.tick({ strict: true });
+    const afterTick = gameplayState();
+    ok(afterTenLoads === stable && afterTick !== stable,
+      '读档—保存循环 10 次不推进人口/腐败/承载，唯一 tick 才推进玩法状态');
+  }
+  {
+    const helpers = [
+      sliceFn(lifecycle, 'function _tmStripSaveTransportMetadata('),
+      sliceFn(lifecycle, 'function _tmValidateUniqueStableIds('),
+      sliceFn(lifecycle, 'function _tmValidateFiniteWorldNumbers('),
+      sliceFn(lifecycle, 'function _tmValidateLoadedWorld(')
+    ].join('\n');
+    const ctx = {
+      Number, Object, Array, String, Error, WeakSet,
+      _tmEnsureTimelineIdentity(gm) { return !!gm._timelineId; }
+    };
+    vm.createContext(ctx); vm.runInContext(helpers, ctx);
+    const p = { __tmDesktopSaveGeneration: 'storage-only', __tmAutoSaveEnvelope: 1, conf: {} };
+    const gm = {
+      __tmDesktopPrivate: true, __tmAutoSavePrivate: true,
+      turn: 1, _campaignId: 'campaign', _timelineId: 'tml_runtime_12345678',
+      chars: [{ id: 'char-1' }], facs: [{ id: 'fac-1' }], armies: [], officeTree: [], mapData: { regions: [{ id: 'region-1' }] }
+    };
+    ctx._tmStripSaveTransportMetadata(p); ctx._tmStripSaveTransportMetadata(gm);
+    ok(!Object.keys(p).some(key => /^__tm(?:Desktop|AutoSave)/.test(key))
+      && !Object.keys(gm).some(key => /^__tm(?:Desktop|AutoSave)/.test(key))
+      && ctx._tmValidateLoadedWorld(p, gm) === true,
+    'storage envelope metadata never enters validated runtime P/GM');
+    let duplicateRejected = false;
+    try { ctx._tmValidateLoadedWorld(p, Object.assign({}, gm, { chars: [{ id: 'dup' }, { id: 'dup' }] })); }
+    catch (error) { duplicateRejected = /重复 id/.test(error.message); }
+    ok(duplicateRejected, 'loaded-world invariant gate rejects duplicate stable character IDs before UI opens');
+  }
+  {
     const transactionFns = [
       sliceFn(lifecycle, 'function _tmAwaitLoadBarrier('),
       sliceFn(lifecycle, 'function _tmCaptureLoadStepError('),
       sliceFn(lifecycle, 'function _tmRunCriticalLoadStep('),
+      sliceFn(lifecycle, 'function _tmRuntimeMapSourceForWorld('),
+      sliceFn(lifecycle, 'function _tmRebindRuntimeWorld('),
       sliceFn(lifecycle, 'function _tmCaptureLoadTransaction('),
       sliceFn(lifecycle, 'function _tmRestoreLoadTransaction('),
       sliceFn(lifecycle, 'function fullLoadGame('),
@@ -243,6 +317,7 @@ async function runDynamicLeaseSmokes() {
     ].join('\n');
     function makeLoadContext(rollbackMustFail) {
       let sessionToken = 'session-old-1234567890';
+      const reboundWorlds = [];
       const oldP = { marker: 'old-P' };
       const oldGM = { marker: 'old-GM', running: true, busy: false, _chronicleSysState: { monthDrafts: {}, yearChronicles: {}, yearBases: {} } };
       const context = {
@@ -251,7 +326,11 @@ async function runDynamicLeaseSmokes() {
         _tmGetDesktopAutoSaveSessionToken() { return sessionToken; },
         _tmRotateDesktopAutoSaveSession(_reason, token) { sessionToken = token; return token; },
         ChronicleSystem: { deserialize() {} },
-        buildIndices: rollbackMustFail ? function() { throw new Error('rollback-index-failure'); } : function() {}
+        bindRuntimeMapState() { reboundWorlds.push(['map', context.GM]); },
+        IntegrationBridge: { migrateAndRebind() { reboundWorlds.push(['integration', context.GM]); } },
+        buildIndices: rollbackMustFail ? function() { throw new Error('rollback-index-failure'); } : function() { reboundWorlds.push(['indices', context.GM]); },
+        MemTables: { ensureInit() { reboundWorlds.push(['memory', context.GM]); } },
+        TM: { FactionIndex: { rebuild() { reboundWorlds.push(['faction', context.GM]); } } }
       };
       context.window = context;
       context._tmLoadGen = 7;
@@ -271,7 +350,7 @@ async function runDynamicLeaseSmokes() {
       };
       vm.createContext(context);
       vm.runInContext(transactionFns, context);
-      return { context, oldP, oldGM, getSession: () => sessionToken };
+      return { context, oldP, oldGM, reboundWorlds, getSession: () => sessionToken };
     }
     const restored = makeLoadContext(false);
     let loadError = null;
@@ -279,8 +358,9 @@ async function runDynamicLeaseSmokes() {
     await restored.context._tmAwaitLoadBarrier();
     ok(loadError && loadError._tmLoadRollbackComplete === true && loadError._tmLoadStep === 'engine migration'
       && restored.context.P === restored.oldP && restored.context.GM === restored.oldGM
-      && restored.context._tmLoadGen === 9 && restored.getSession() === 'session-old-1234567890',
-    'critical migration partial write rolls back original P/GM and auto-save session with monotonic load generation');
+      && restored.context._tmLoadGen === 9 && restored.getSession() === 'session-old-1234567890'
+      && restored.reboundWorlds.length >= 4 && restored.reboundWorlds.every(entry => entry[1] === restored.oldGM),
+    'critical migration partial write rolls back P/GM/session and rebinds every runtime singleton to the old world');
 
     const blocked = makeLoadContext(true);
     let blockedError = null;

--- a/web/scripts/smoke-security-trust-boundary.js
+++ b/web/scripts/smoke-security-trust-boundary.js
@@ -251,6 +251,17 @@ async function main() {
   const listSavesStart = mainSource.indexOf("ipcMain.handle('list-saves'");
   const listSavesEnd = mainSource.indexOf("ipcMain.handle('delete-save'", listSavesStart);
   const listSavesSource = mainSource.slice(listSavesStart, listSavesEnd);
+  const loadProjectStart = mainSource.indexOf("ipcMain.handle('load-project'");
+  const loadProjectEnd = mainSource.indexOf("ipcMain.handle('list-saves'", loadProjectStart);
+  const loadProjectSource = mainSource.slice(loadProjectStart, loadProjectEnd);
+  const loadAutoStart = mainSource.indexOf("ipcMain.handle('load-auto-save'");
+  const loadAutoEnd = mainSource.indexOf("ipcMain.handle('dialog-export'", loadAutoStart);
+  const loadAutoSource = mainSource.slice(loadAutoStart, loadAutoEnd);
+  check(loadProjectStart >= 0 && loadProjectEnd > loadProjectStart
+    && loadAutoStart >= 0 && loadAutoEnd > loadAutoStart
+    && !/prepareDesktopSavePayload|writeFileAtomic|writeDesktopSaveMetadata|invalidateDesktopSaveGeneration/.test(loadProjectSource)
+    && !/prepareDesktopSavePayload|writeFileAtomic|writeDesktopSaveMetadata|invalidateDesktopSaveGeneration|persistAutoSaveSessionToken/.test(loadAutoSource),
+  'desktop manual and autosave read handlers never rewrite payloads or sidecars during load');
   check(listSavesStart >= 0 && listSavesEnd > listSavesStart
     && /readDesktopSaveGeneration\(storageKey, fp\)/.test(listSavesSource)
     && /readDesktopSaveMetadata\(storageKey, stats, payloadGeneration\)/.test(listSavesSource)
@@ -323,6 +334,70 @@ async function main() {
   const sameStampRow = sameStampListed.files.find(file => file.storageKey === 'large-save-1');
   check(sameStampRow && sameStampRow.metadataPending === true && sameStampRow.meta === null,
     'same-size payload replacement with restored mtime is rejected by the embedded payload generation');
+
+  const legacyReadOnlyPath = path.join(desktopSaveDir, 'legacy-readonly.json');
+  const legacyReadOnlyData = {
+    _saveMeta: { name: '只读旧档', scenario: '兼容测试', turn: 7 },
+    gameState: { turn: 7, _campaignId: 'campaign-readonly', _timelineId: 'tml_readonly_12345678' }
+  };
+  fs.writeFileSync(legacyReadOnlyPath, JSON.stringify(legacyReadOnlyData));
+  const legacyBytesBefore = fs.readFileSync(legacyReadOnlyPath);
+  const legacyStatBefore = fs.statSync(legacyReadOnlyPath);
+  const loadHandler = ipcHandlers.get('load-project');
+  check(typeof loadHandler === 'function', 'desktop load-project IPC handler is registered through the trusted gate');
+  const originalOpenSync = fs.openSync;
+  fs.openSync = function(file, flags) {
+    if (/[wax+]/.test(String(flags || ''))) {
+      const error = new Error('simulated read-only storage');
+      error.code = 'ENOSPC';
+      throw error;
+    }
+    return originalOpenSync.apply(this, arguments);
+  };
+  let legacyLoaded;
+  try {
+    legacyLoaded = await loadHandler({ senderFrame: mainFrame, sender: { mainFrame } }, 'legacy-readonly');
+  } finally {
+    fs.openSync = originalOpenSync;
+  }
+  const legacyStatAfter = fs.statSync(legacyReadOnlyPath);
+  check(legacyLoaded && legacyLoaded.success === true && legacyLoaded.metadataPending === true
+    && legacyLoaded.data.gameState.turn === 7,
+  'legacy desktop payload without a generation still loads when every attempted write would fail');
+  check(fs.readFileSync(legacyReadOnlyPath).equals(legacyBytesBefore)
+    && legacyStatAfter.mtimeMs === legacyStatBefore.mtimeMs,
+  'loading a legacy desktop payload preserves its bytes and modification time');
+
+  const legacyAutoPath = path.join(desktopSaveDir, '__autosave__.json');
+  const legacyAutoData = {
+    __tmAutoSaveEnvelope: 1,
+    sessionToken: 'readonly-session-token-1234',
+    data: { gameState: { turn: 8, _campaignId: 'campaign-auto-readonly', _timelineId: 'tml_auto_readonly_12345678' } }
+  };
+  fs.writeFileSync(legacyAutoPath, JSON.stringify(legacyAutoData));
+  const legacyAutoBytes = fs.readFileSync(legacyAutoPath);
+  const legacyAutoStat = fs.statSync(legacyAutoPath);
+  const loadAutoHandler = ipcHandlers.get('load-auto-save');
+  check(typeof loadAutoHandler === 'function', 'desktop load-auto-save IPC handler is registered through the trusted gate');
+  const originalWriteFileSync = fs.writeFileSync;
+  fs.writeFileSync = function() {
+    const error = new Error('simulated read-only autosave storage');
+    error.code = 'EACCES';
+    throw error;
+  };
+  let legacyAutoLoaded;
+  try {
+    legacyAutoLoaded = await loadAutoHandler({ senderFrame: mainFrame, sender: { mainFrame } });
+  } finally {
+    fs.writeFileSync = originalWriteFileSync;
+  }
+  const legacyAutoStatAfter = fs.statSync(legacyAutoPath);
+  check(legacyAutoLoaded && legacyAutoLoaded.success === true && legacyAutoLoaded.metadataPending === true
+    && legacyAutoLoaded.data.gameState.turn === 8,
+  'legacy autosave adopts a missing session sidecar in memory and still loads on read-only storage');
+  check(fs.readFileSync(legacyAutoPath).equals(legacyAutoBytes)
+    && legacyAutoStatAfter.mtimeMs === legacyAutoStat.mtimeMs,
+  'loading a legacy autosave preserves its payload bytes and modification time');
   check(mainSource.includes("redirect: 'manual'") && mainSource.includes('dns.lookup(hostname, { all: true')
     && mainSource.includes("credentials: 'omit'") && mainSource.includes("referrerPolicy: 'no-referrer'"), 'network proxy revalidates DNS/redirects and omits ambient credentials');
   check(mainSource.includes('WORKSHOP_CATALOG_AUTHORIZATIONS.get(packageUrl)')

--- a/web/scripts/smoke-state-snapshot-integrity.js
+++ b/web/scripts/smoke-state-snapshot-integrity.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
-// StateSnapshot v4：旧快照迁移、祖先只读继承、完整状态恢复、异步身份租约与 awaited hook。
+// StateSnapshot v6：旧快照迁移、索引化祖先只读继承、完整状态恢复、异步身份租约与 awaited hook。
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
@@ -16,6 +16,7 @@ function fakeIndexedDB(options) {
   options = options || {};
   const stores = new Map();
   const deletedIndexes = [];
+  const stats = { fullStoreGetAll: 0, indexGetAll: 0 };
   if (Array.isArray(options.records)) {
     stores.set('snapshots_v2', {
       keyPath: 'id',
@@ -37,9 +38,30 @@ function fakeIndexedDB(options) {
         return req;
       },
       getAll() {
+        stats.fullStoreGetAll++;
         const req = {};
         setTimeout(function() { if (req.onsuccess) req.onsuccess({ target: { result: Array.from(def.rows.values()).map(clone) } }); }, 0);
         return req;
+      },
+      index(name) {
+        if (!def.indexes.has(name)) throw new Error('missing index ' + name);
+        return {
+          getAll(query) {
+            stats.indexGetAll++;
+            const req = {};
+            function indexKey(record) {
+              if (name === 'campaignTimeline') return [record.campaignId, record.timelineId];
+              if (name === 'timelineTurn') return [record.campaignId, record.timelineId, record.turn];
+              if (name === 'campaignParent') return [record.campaignId, record.parentTimelineId];
+              if (name === 'campaignId') return record.campaignId;
+              return undefined;
+            }
+            const wanted = JSON.stringify(query);
+            const values = Array.from(def.rows.values()).filter(record => JSON.stringify(indexKey(record)) === wanted).map(clone);
+            setTimeout(function() { if (req.onsuccess) req.onsuccess({ target: { result: values } }); }, 0);
+            return req;
+          }
+        };
       },
       delete(key) { def.rows.delete(String(key)); return {}; },
       openCursor() {
@@ -90,6 +112,7 @@ function fakeIndexedDB(options) {
   return {
     stores,
     deletedIndexes,
+    stats,
     open(_name, version) {
       const req = {};
       setTimeout(function() {
@@ -104,11 +127,12 @@ function fakeIndexedDB(options) {
 
 (async function() {
   let registeredHook = null;
+  const primaryDb = fakeIndexedDB();
   const ctx = {
     console, Promise, Date, Math, JSON, Object, Array, Number,
     setTimeout, clearTimeout, structuredClone,
     crypto: { randomUUID: function() { return 'fixed-id'; } },
-    indexedDB: fakeIndexedDB(),
+    indexedDB: primaryDb,
     EndTurnHooks: {
       register(phase, callback, name) {
         if (phase === 'after' && name === 'StateSnapshot.autoSave') registeredHook = callback;
@@ -137,8 +161,8 @@ function fakeIndexedDB(options) {
   vm.createContext(ctx);
   vm.runInContext(src, ctx);
 
-  ok(/DB_VERSION = 5/.test(src) && /LINEAGE_STORE = 'timeline_graph'/.test(src) && /keyPath: 'id'/.test(src),
-    'v5 使用 compound snapshot id 与独立 timeline graph');
+  ok(/DB_VERSION = 6/.test(src) && /LINEAGE_STORE = 'timeline_graph'/.test(src) && /campaignParent/.test(src) && /keyPath: 'id'/.test(src),
+    'v6 使用 compound snapshot id、父链索引与独立 timeline graph');
   ok(/_buildSaveState/.test(src) && /format: 'idb', detach: true/.test(src), '快照复用完整纯存档 builder');
   ok(registeredHook && typeof registeredHook === 'function', 'after hook 已注册');
 
@@ -182,6 +206,14 @@ function fakeIndexedDB(options) {
   ctx.P = { conf: { campaign: 'A' }, mapData: { a: 1 } };
   let r = await ctx.StateSnapshot.save(1);
   ok(r.ok === true, 'campA/T1 完整快照写入');
+  // 注入 100 个无关战役；当前列表必须继续只走 campaign+timeline 复合索引。
+  const snapshotRows = primaryDb.stores.get('snapshots_v2').rows;
+  for (let i = 0; i < 100; i++) {
+    snapshotRows.set('noise-' + i, {
+      id: 'noise-' + i, campaignId: 'noise-campaign-' + i, timelineId: 'tml_noise_' + String(i).padStart(8, '0'),
+      turn: i, ts: i, state: { GM: { turn: i }, P: {} }
+    });
+  }
 
   ctx.GM.turn = 2; ctx.GM.marker = 'A2'; ctx.GM.customWorld.deep = 22;
   ctx.GM.shijiHistory.push({ turn: 2, a: 2 }); ctx.P.mapData.a = 2;
@@ -199,6 +231,10 @@ function fakeIndexedDB(options) {
     && inheritedList.every(item => item.inherited === true)
     && inheritedA1 && inheritedA1.inherited === true && inheritedA1.state.GM.marker === 'A1',
   '子时间线以父链只读继承 forkTurn 以前的完整快照列表');
+  const inheritedDelete = await ctx.StateSnapshot.delete(1);
+  ok(inheritedDelete.ok === false && inheritedDelete.reason === 'inherited-readonly'
+    && (await ctx.StateSnapshot.load(1)).state.GM.marker === 'A1',
+  '继承快照明确只读，删除请求不得伪装成功或影响祖先记录');
   r = await ctx.StateSnapshot.save(2);
   const childOverrideList = await ctx.StateSnapshot.list();
   ok(r.ok === true && childOverrideList[0].inherited === true && childOverrideList[1].inherited === false
@@ -270,6 +306,9 @@ function fakeIndexedDB(options) {
   ok(/_stillCurrent\(sourceGM, sourceP, sourceLoadGen, campaignId, timelineId\)/.test(src), 'timeTravel 在异步边界复验 GM/P/loadGen/campaign/timeline');
   ok(/failed to save return point/.test(src) && /time-travel-rollback/.test(src), '返航点失败不恢复，目标恢复失败会回滚');
   ok(/return saveSnapshot\(t\)\.then/.test(src), '自动 hook 显式返回保存链');
+  ok(primaryDb.stats.indexGetAll > 0 && primaryDb.stats.fullStoreGetAll === 0
+    && !/objectStore\(STORE\)\.getAll\(\)/.test(src) && !/objectStore\(LINEAGE_STORE\)\.getAll\(\)/.test(src),
+  '多战役快照列表按复合索引和谱系主键读取，不执行全库 getAll');
 
   console.log('\n[smoke-state-snapshot-integrity] pass=' + pass);
 })().catch(function(e) {

--- a/web/scripts/smoke-yingzao-shadow.js
+++ b/web/scripts/smoke-yingzao-shadow.js
@@ -64,8 +64,11 @@ ok(purgeAt > 0, '刀3a: fullLoadGame 带影子条目存量清障段');
 const purgeSeg = saveSrc.slice(purgeAt, purgeAt + 900);
 ok(/GM\.buildings\.filter/.test(purgeSeg) && /未知建筑/.test(purgeSeg) && /!BUILDING_TYPES\[b\.type\]/.test(purgeSeg),
   '刀3a: 清障判据 = 名未知建筑 且 type 反查不到（与刀3b 同判据）');
-const buildIndicesAt = saveSrc.indexOf('buildIndices()', purgeAt);
-ok(buildIndicesAt > purgeAt, '刀3a: 清障先于 buildIndices 重建索引（buildingByTerritory 不残留死引用）');
+const rebindHelperAt = saveSrc.indexOf('function _tmRebindRuntimeWorld(');
+const rebindHelperSeg = saveSrc.slice(rebindHelperAt, rebindHelperAt + 3000);
+const finalRebindAt = saveSrc.indexOf('_tmRebindRuntimeWorld({ strict: true, map: false })', purgeAt);
+ok(rebindHelperAt > 0 && /buildIndices\(\)/.test(rebindHelperSeg) && finalRebindAt > purgeAt,
+  '刀3a: 清障先于统一 runtime rebind 内的 buildIndices 重建（buildingByTerritory 不残留死引用）');
 
 // ── C. 刀1/刀1b/刀2 源契约：AI落建造写口（tm-endturn-apply.js）──
 const applySrc = fs.readFileSync(path.join(ROOT, 'tm-endturn-apply.js'), 'utf8');

--- a/web/tm-integration-bridge.js
+++ b/web/tm-integration-bridge.js
@@ -598,13 +598,20 @@
   function aggregateRegionsToVariables(options) {
     options = options || {};
     var strict = options.strict === true;
+    // 聚合/重绑定必须是幂等操作。只有每回合唯一的 tick() 才能推进人口与
+    // NPC 腐败；读档、首局初始化、UI 刷新和 AI 前后的派生汇总一律不得
+    // 偷走一个“时间步”。旧实现把 strict（错误传播）误当成了模拟开关，
+    // 导致每次读档都增长人口并改变腐败。
+    var advanceSimulation = options.advanceSimulation === true;
     var G = global.GM;
     if (!G) return;
 
     // 0. 人口自然漂移（在汇总之前）
-    try { _naturalPopulationGrowth(); } catch(_e) {
-      (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_e, 'bridge] natPopGrowth') : console.warn('[bridge] natPopGrowth', _e);
-      if (strict) throw _e;
+    if (advanceSimulation) {
+      try { _naturalPopulationGrowth(); } catch(_e) {
+        (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_e, 'bridge] natPopGrowth') : console.warn('[bridge] natPopGrowth', _e);
+        if (strict) throw _e;
+      }
     }
 
     var topLevel = getTopLevelDivisions(G.adminHierarchy, 'player');
@@ -710,8 +717,11 @@
         if (G.corruption.byDept.military === undefined)  G.corruption.byDept.military  = Math.round(avgProvCorr * 0.95);
         if (G.corruption.byDept.palace === undefined)    G.corruption.byDept.palace    = Math.round(avgProvCorr * 1.10);
         if (G.corruption.byDept.technical === undefined) G.corruption.byDept.technical = Math.round(avgProvCorr * 0.55);
-        // 按 NPC 派系/私产向上推高技术官外各部门（每周期）
-        try { _accumulateCorruptionFromNpcs(G); } catch(_e) { if (strict) throw _e; }
+        // 按 NPC 派系/私产向上推高技术官外各部门（每周期）。派生汇总只读
+        // 现值；时间传导只允许 tick() 明确开启。
+        if (advanceSimulation) {
+          try { _accumulateCorruptionFromNpcs(G); } catch(_e) { if (strict) throw _e; }
+        }
         // overall = 6 部门平均
         var deptSum = 0, deptCnt = 0;
         Object.keys(G.corruption.byDept || {}).forEach(function(d) {
@@ -823,24 +833,40 @@
   //  tick + init
   // ═══════════════════════════════════════════════════════════════════
 
-  function tick(ctx) {
-    try { aggregateRegionsToVariables(); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'bridge] aggregate:') : console.error('[bridge] aggregate:', e); }
+  function tick(options) {
+    options = options || {};
+    // tick 是关键账本步骤：默认向事务边界传播异常。只有显式 strict:false
+    // 的兼容调用才允许记录后降级。
+    var strict = options.strict !== false;
+    try {
+      return aggregateRegionsToVariables({ strict: strict, advanceSimulation: true });
+    } catch(e) {
+      (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'bridge] aggregate:') : console.error('[bridge] aggregate:', e);
+      if (strict) throw e;
+      return null;
+    }
   }
 
-  function init(options) {
+  function migrateAndRebind(options) {
     options = options || {};
     if (options.strict === true) {
       initializeFromLegacy();
-      aggregateRegionsToVariables({ strict: true });
-      return;
+      aggregateRegionsToVariables({ strict: true, advanceSimulation: false });
+      return true;
     }
     try { initializeFromLegacy(); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'bridge] init:') : console.error('[bridge] init:', e); }
-    // 首次聚合
-    try { aggregateRegionsToVariables(); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-integration-bridge');}catch(_){}}
+    // 首次聚合/读档重绑定只对齐 schema、代理与派生汇总，不推进玩法时间。
+    try { aggregateRegionsToVariables({ advanceSimulation: false }); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-integration-bridge');}catch(_){}}
+    return true;
+  }
+
+  function init(options) {
+    return migrateAndRebind(options);
   }
 
   global.IntegrationBridge = {
     init: init,
+    migrateAndRebind: migrateAndRebind,
     tick: tick,
     flattenDivisions: flattenDivisions,
     getTopLevelDivisions: getTopLevelDivisions,

--- a/web/tm-save-lifecycle.js
+++ b/web/tm-save-lifecycle.js
@@ -1047,6 +1047,108 @@ function _tmRunDegradableLoadStepAsync(label, fn) {
   });
 }
 
+function _tmStripSaveTransportMetadata(target) {
+  if (!target || typeof target !== 'object' || Array.isArray(target)) return target;
+  Object.keys(target).forEach(function(key) {
+    // Electron 文件 envelope / auto-save envelope 只属于传输层，绝不能随 P/GM
+    // 进入玩法状态、快照或下一份导出档。
+    if (/^__tm(?:Desktop|AutoSave)/.test(key)) delete target[key];
+  });
+  return target;
+}
+
+function _tmRuntimeMapSourceForWorld(targetP, targetGM) {
+  var source = (targetGM && targetGM.mapData && targetGM.mapData.regions && targetGM.mapData.regions.length > 0) ? targetGM.mapData :
+    (targetP && targetP.map && targetP.map.regions && targetP.map.regions.length > 0) ? targetP.map :
+    (targetP && targetP.mapData && targetP.mapData.regions && targetP.mapData.regions.length > 0) ? targetP.mapData : null;
+  if (!source && typeof findScenarioById === 'function' && targetGM && targetGM.sid) {
+    var scenario = findScenarioById(targetGM.sid);
+    var scenarioMap = scenario && ((scenario.mapData && scenario.mapData.regions && scenario.mapData.regions.length > 0) ? scenario.mapData : scenario.map);
+    if (scenarioMap && scenarioMap.regions && scenarioMap.regions.length > 0) source = scenarioMap;
+  }
+  return source;
+}
+
+// 成功读档与失败回滚共用同一条“纯重绑定”路径。它可以补 schema、代理和
+// 派生索引，但不得推进人口、腐败、财政、战争或任何其他玩法时间。
+function _tmRebindRuntimeWorld(options) {
+  options = options || {};
+  var strict = options.strict === true;
+  var targetP = options.p || P;
+  var targetGM = options.gm || GM;
+  if (!targetP || !targetGM || targetP !== P || targetGM !== GM) throw new Error('运行世界重绑定目标不是当前 P/GM');
+
+  function run(label, fn) {
+    if (strict) return _tmRunCriticalLoadStep(label, fn);
+    return _tmRunDegradableLoadStep(label, fn);
+  }
+
+  if (options.map !== false) {
+    run('runtime map rebind', function() {
+      var liveMapSource = _tmRuntimeMapSourceForWorld(targetP, targetGM);
+      if (liveMapSource && typeof bindRuntimeMapState === 'function') {
+        bindRuntimeMapState(liveMapSource);
+        targetGM._useAIGeo = false;
+      } else if (liveMapSource) {
+        targetGM.mapData = _safeClone(liveMapSource);
+        targetGM._useAIGeo = false;
+      }
+    });
+  }
+
+  if (options.integration !== false && typeof IntegrationBridge !== 'undefined' && IntegrationBridge) {
+    run('integration bridge pure rebind', function() {
+      var rebind = typeof IntegrationBridge.migrateAndRebind === 'function'
+        ? IntegrationBridge.migrateAndRebind : IntegrationBridge.init;
+      if (typeof rebind === 'function') rebind.call(IntegrationBridge, { strict: strict, advanceSimulation: false });
+    });
+  }
+  if (options.indices !== false && typeof buildIndices === 'function') {
+    run('runtime indices rebind', function() { buildIndices(); });
+  }
+  if (options.faction !== false && window.TM && TM.FactionIndex && typeof TM.FactionIndex.rebuild === 'function') {
+    run('faction index rebind', function() { TM.FactionIndex.rebuild(); });
+  }
+  if (options.memory !== false && window.MemTables && typeof MemTables.ensureInit === 'function') {
+    run('memory tables rebind', function() { MemTables.ensureInit(); });
+  }
+  return true;
+}
+
+function _tmValidateUniqueStableIds(label, list) {
+  if (!Array.isArray(list)) return;
+  var seen = Object.create(null);
+  list.forEach(function(item, index) {
+    if (!item || item.id === undefined || item.id === null || item.id === '') return;
+    var id = String(item.id);
+    if (seen[id] !== undefined) throw new Error(label + ' 存在重复 id: ' + id + '（索引 ' + seen[id] + ' / ' + index + '）');
+    seen[id] = index;
+  });
+}
+
+function _tmValidateFiniteWorldNumbers(root, label) {
+  var stack = [{ value: root, path: label }];
+  var seen = typeof WeakSet === 'function' ? new WeakSet() : null;
+  while (stack.length) {
+    var current = stack.pop();
+    var value = current.value;
+    if (typeof value === 'number') {
+      if (!Number.isFinite(value)) throw new Error('存档数值非法: ' + current.path);
+      continue;
+    }
+    if (!value || typeof value !== 'object') continue;
+    if (seen) {
+      if (seen.has(value)) continue;
+      seen.add(value);
+    }
+    // Map/Set/Blob 等运行时派生容器不属于 JSON 世界正文；其内部由各自重建器负责。
+    var keys = Object.keys(value);
+    for (var i = 0; i < keys.length; i++) {
+      stack.push({ value: value[keys[i]], path: current.path + '.' + keys[i] });
+    }
+  }
+}
+
 function _tmValidateLoadedWorld(targetP, targetGM) {
   if (!targetP || typeof targetP !== 'object' || Array.isArray(targetP)) throw new Error('存档 P 不是合法对象');
   if (!targetGM || typeof targetGM !== 'object' || Array.isArray(targetGM)) throw new Error('存档 GM 不是合法对象');
@@ -1065,6 +1167,12 @@ function _tmValidateLoadedWorld(targetP, targetGM) {
   if (targetGM._chronicleSysState != null && (typeof targetGM._chronicleSysState !== 'object' || Array.isArray(targetGM._chronicleSysState))) {
     throw new Error('编年状态结构非法');
   }
+  _tmValidateUniqueStableIds('人物', targetGM.chars);
+  _tmValidateUniqueStableIds('势力', targetGM.facs);
+  _tmValidateUniqueStableIds('军队', targetGM.armies);
+  _tmValidateUniqueStableIds('地图地区', targetGM.mapData && targetGM.mapData.regions);
+  _tmValidateFiniteWorldNumbers(targetP, 'P');
+  _tmValidateFiniteWorldNumbers(targetGM, 'GM');
   return true;
 }
 
@@ -1185,10 +1293,9 @@ function _tmRestoreLoadTransaction(txn) {
   try {
     if (window.scriptData) window.scriptData.customPresets = txn.customPresets;
   } catch (_) {}
-  if (typeof buildIndices === 'function') buildIndices();
-  try {
-    if (window.TM && TM.FactionIndex && typeof TM.FactionIndex.rebuild === 'function') TM.FactionIndex.rebuild();
-  } catch (_) {}
+  // 首屏尚无旧世界时，失败读档只能恢复到启动态；不要把“没有可重绑的世界”
+  // 误判成回滚自身失败。已有世界则必须完整重绑所有 singleton/索引。
+  if (P && GM) _tmRebindRuntimeWorld({ strict: true });
   try {
     if (window.TMPhase8FormalBridge && typeof window.TMPhase8FormalBridge.restoreDraftsFromGM === 'function') {
       window.TMPhase8FormalBridge.restoreDraftsFromGM(true);
@@ -1285,10 +1392,13 @@ async function _fullLoadGameApplyImpl(data, loadOptions, _loadTxn){
     _incomingGM = data.gameState.GM;
   } else {
     // 格式A：标准格式
-    _incomingP = data;
+    _incomingP = Object.assign({}, data);
     _incomingGM = data.gameState;
   }
   if (!_incomingP || !_incomingGM) throw new Error('存档结构不完整：缺少 P/GM');
+  if (_incomingP && _incomingP.gameState) delete _incomingP.gameState;
+  _tmStripSaveTransportMetadata(_incomingP);
+  _tmStripSaveTransportMetadata(_incomingGM);
   // 迁移和默认值先在尚未发布的 incoming 对象上完成；失败时 live P/GM 保持原局，
   // 且版本戳不会前移，下一次仍可安全重试。
   _ensurePDefaults(_incomingP, _incomingGM);
@@ -1364,24 +1474,8 @@ async function _fullLoadGameApplyImpl(data, loadOptions, _loadTxn){
         window.restorePhase8FormalDraftsFromGM(true);
       }
     });
-    // 存档载入后恢复独立地图 live state；P 保留剧本模板，禁止与 GM 共享引用。
-    _tmRunCriticalLoadStep('runtime map bind', function() {
-      var _liveMapSrc = (GM && GM.mapData && GM.mapData.regions && GM.mapData.regions.length > 0) ? GM.mapData :
-        (P && P.map && P.map.regions && P.map.regions.length > 0) ? P.map :
-        (P && P.mapData && P.mapData.regions && P.mapData.regions.length > 0) ? P.mapData : null;
-      if (!_liveMapSrc && typeof findScenarioById === 'function' && GM && GM.sid) {
-        var _scMapOwner = findScenarioById(GM.sid);
-        var _scMapSrc = _scMapOwner && ((_scMapOwner.mapData && _scMapOwner.mapData.regions && _scMapOwner.mapData.regions.length > 0) ? _scMapOwner.mapData : _scMapOwner.map);
-        if (_scMapSrc && _scMapSrc.regions && _scMapSrc.regions.length > 0) _liveMapSrc = _scMapSrc;
-      }
-      if (_liveMapSrc && typeof bindRuntimeMapState === 'function') {
-        bindRuntimeMapState(_liveMapSrc);
-        GM._useAIGeo = false;
-      } else if (_liveMapSrc) {
-        GM.mapData = _safeClone(_liveMapSrc);
-        GM._useAIGeo = false;
-      }
-    });
+    // 部分旧迁移读取 GM.mapData；先走统一纯重绑定入口中的 map-only 阶段。
+    _tmRebindRuntimeWorld({ strict: true, integration: false, indices: false, faction: false, memory: false });
 
     // 一次性清理·扫除存档里历史误抓人物(强烈/连日/乌纱/平静等命中 NAME_BLACKLIST 词组)
     _tmRunCriticalLoadStep('blacklisted character purge', function() {
@@ -1462,14 +1556,6 @@ async function _fullLoadGameApplyImpl(data, loadOptions, _loadTxn){
         if (_shadowN > 0) console.log('[fullLoadGame] 清除「未知建筑」影子条目 ' + _shadowN + ' 条(历史AI落建造反查失败所铸)');
       }
     });
-    // 重建索引
-    if (typeof buildIndices === 'function') buildIndices();
-    // 2026-06-10·_facIndex 已不入存档(autoSave SKIP·派生索引)·读档后在 chars/官衔/迁移全就绪处重建·
-    // 兼顾旧存档:旧档里的 _facIndex 反序列化后本就是与 chars 脱钩的死拷贝·重建一并治
-    _tmRunCriticalLoadStep('faction index rebuild', function() {
-      if (window.TM && TM.FactionIndex && typeof TM.FactionIndex.rebuild === 'function') TM.FactionIndex.rebuild();
-    });
-
     // P6.3 修：老存档加载后·若 _memTables 缺失或仅有空 schema·自动反向重建以保留历史
     _tmRunCriticalLoadStep('memory tables migration', function() {
       if (window.MemTables && MemTables.ensureInit) {
@@ -1569,10 +1655,8 @@ async function _fullLoadGameApplyImpl(data, loadOptions, _loadTxn){
       }
     });
 
-    // 集成桥梁：老存档可能缺 divisions 深化字段，init 会补齐并建立 legacy proxy
-    if (typeof IntegrationBridge !== 'undefined' && typeof IntegrationBridge.init === 'function') {
-      _tmRunCriticalLoadStep('integration bridge migration', function() { IntegrationBridge.init({ strict: true }); });
-    }
+    // 全部 schema 迁移完成后，用成功/回滚共享的纯入口重建代理和派生索引。
+    _tmRebindRuntimeWorld({ strict: true, map: false });
 
     // 同步剧本自定义预设（HistoricalPresets 动态 getter 读取 window.scriptData.customPresets）
     _tmRunCriticalLoadStep('custom presets synchronization', function() {

--- a/web/tm-state-snapshot.js
+++ b/web/tm-state-snapshot.js
@@ -13,7 +13,7 @@
   var LEGACY_STORE = 'snapshots';
   var STORE = 'snapshots_v2';
   var LINEAGE_STORE = 'timeline_graph';
-  var DB_VERSION = 5;
+  var DB_VERSION = 6;
   var MAX_SNAPSHOTS = 200;
   var _dbPromise = null;
 
@@ -120,11 +120,23 @@
         if (!db.objectStoreNames.contains(LINEAGE_STORE)) {
           lineageStore = db.createObjectStore(LINEAGE_STORE, { keyPath: 'id' });
           lineageStore.createIndex('campaignId', 'campaignId', { unique: false });
+          lineageStore.createIndex('campaignTimeline', ['campaignId', 'timelineId'], { unique: true });
+          lineageStore.createIndex('campaignParent', ['campaignId', 'parentTimelineId'], { unique: false });
         } else {
           lineageStore = e.target.transaction.objectStore(LINEAGE_STORE);
           try {
             if (!lineageStore.indexNames || !lineageStore.indexNames.contains('campaignId')) {
               lineageStore.createIndex('campaignId', 'campaignId', { unique: false });
+            }
+          } catch (_) {}
+          try {
+            if (!lineageStore.indexNames || !lineageStore.indexNames.contains('campaignTimeline')) {
+              lineageStore.createIndex('campaignTimeline', ['campaignId', 'timelineId'], { unique: true });
+            }
+          } catch (_) {}
+          try {
+            if (!lineageStore.indexNames || !lineageStore.indexNames.contains('campaignParent')) {
+              lineageStore.createIndex('campaignParent', ['campaignId', 'parentTimelineId'], { unique: false });
             }
           } catch (_) {}
         }
@@ -219,31 +231,47 @@
     });
   }
 
-  function _getAllRecords() {
+  function _getTimelineRecords(campaignId, timelineId) {
     return _openDB().then(function(db) {
       return new Promise(function(resolve, reject) {
         var tx;
         try {
           tx = db.transaction(STORE, 'readonly');
-          var req = tx.objectStore(STORE).getAll();
+          var req = tx.objectStore(STORE).index('campaignTimeline').getAll([campaignId, timelineId]);
           req.onsuccess = function(e) { resolve(e.target.result || []); };
-          req.onerror = function(e) { reject(e.target.error || new Error('快照列表读取失败')); };
+          req.onerror = function(e) { reject(e.target.error || new Error('时间线快照读取失败')); };
           tx.onabort = function(e) { reject((e.target && e.target.error) || tx.error || new Error('快照读取事务已中止')); };
         } catch (e) { reject(e); }
       });
     });
   }
 
-  function _getAllLineageRecords() {
+  function _getLineageRecord(campaignId, timelineId) {
     return _openDB().then(function(db) {
       return new Promise(function(resolve, reject) {
         var tx;
         try {
           tx = db.transaction(LINEAGE_STORE, 'readonly');
-          var req = tx.objectStore(LINEAGE_STORE).getAll();
-          req.onsuccess = function(e) { resolve(e.target.result || []); };
-          req.onerror = function(e) { reject(e.target.error || new Error('时间线图读取失败')); };
+          var req = tx.objectStore(LINEAGE_STORE).get(_lineageId(campaignId, timelineId));
+          req.onsuccess = function(e) { resolve(e.target.result || null); };
+          req.onerror = function(e) { reject(e.target.error || new Error('时间线谱系读取失败')); };
           tx.onabort = function(e) { reject((e.target && e.target.error) || tx.error || new Error('时间线图读取事务已中止')); };
+        } catch (e) { reject(e); }
+      });
+    });
+  }
+
+  function _getExactRecord(campaignId, timelineId, turn) {
+    var id = _recordId(campaignId, timelineId, turn);
+    return _openDB().then(function(db) {
+      return new Promise(function(resolve, reject) {
+        var tx;
+        try {
+          tx = db.transaction(STORE, 'readonly');
+          var req = tx.objectStore(STORE).get(id);
+          req.onsuccess = function(e) { resolve(e.target.result || null); };
+          req.onerror = function(e) { reject(e.target.error || new Error('快照读取失败')); };
+          tx.onabort = function(e) { reject((e.target && e.target.error) || tx.error || new Error('快照读取事务已中止')); };
         } catch (e) { reject(e); }
       });
     });
@@ -278,47 +306,58 @@
     return candidates.length ? candidates[0].state.GM : null;
   }
 
-  // 子时间线可只读继承 forkTurn 以前的祖先快照。当前线记录优先；祖先 payload 不复制，
-  // 因而长局分叉不会造成成倍存储，同时不会让一次正常读档把 T1..Tn 历史列表清空。
-  function _accessibleSnapshotRecords(records, lineageRecords, campaignId, timelineId, currentGM) {
-    var chain = [];
+  // 子时间线可只读继承 forkTurn 以前的祖先快照。每层只按 compound index
+  // 读取该 timeline 的记录，再按独立 lineage key 向父链走；禁止 getAll 全库扫描。
+  function _collectAccessibleSnapshotRecords(campaignId, timelineId, currentGM) {
     var seen = Object.create(null);
-    var lineageByTimeline = Object.create(null);
-    (lineageRecords || []).forEach(function(record) {
-      if (record && record.campaignId === campaignId && record.timelineId) lineageByTimeline[record.timelineId] = record;
-    });
+    var byTurn = Object.create(null);
     var cursorTimeline = timelineId;
     var cursorOwner = currentGM && currentGM._campaignId === campaignId && currentGM._timelineId === timelineId ? currentGM : null;
     var maxTurn = Infinity;
-    while (cursorTimeline && !seen[cursorTimeline]) {
+    var depth = 0;
+
+    function visitNext() {
+      if (!cursorTimeline || seen[cursorTimeline]) return Promise.resolve();
       seen[cursorTimeline] = true;
-      chain.push({ timelineId: cursorTimeline, maxTurn: maxTurn });
-      var lineage = lineageByTimeline[cursorTimeline];
-      if (!cursorOwner && !lineage) cursorOwner = _timelineOwnerFromRecords(records, campaignId, cursorTimeline, maxTurn);
-      var parentTimeline = lineage ? String(lineage.parentTimelineId || '') : (cursorOwner && String(cursorOwner._parentTimelineId || ''));
-      var forkTurn = lineage ? Number(lineage.forkTurn) : (cursorOwner && Number(cursorOwner._forkTurn));
-      if (!parentTimeline || !Number.isSafeInteger(forkTurn) || forkTurn < 0) break;
-      maxTurn = Math.min(maxTurn, forkTurn);
-      cursorTimeline = parentTimeline;
-      cursorOwner = null;
-    }
-    var byTurn = Object.create(null);
-    chain.forEach(function(access, depth) {
-      (records || []).forEach(function(record) {
-        if (!record || record.campaignId !== campaignId || record.timelineId !== access.timelineId) return;
-        var turn = Number(record.turn);
-        if (!Number.isSafeInteger(turn) || turn > access.maxTurn || byTurn[turn]) return;
-        byTurn[turn] = { record: record, inherited: depth > 0, sourceTimelineId: access.timelineId };
+      var visitingTimeline = cursorTimeline;
+      var visitingMaxTurn = maxTurn;
+      var visitingDepth = depth;
+      return Promise.all([
+        _getTimelineRecords(campaignId, visitingTimeline),
+        _getLineageRecord(campaignId, visitingTimeline)
+      ]).then(function(parts) {
+        var records = parts[0] || [];
+        var lineage = parts[1];
+        records.forEach(function(record) {
+          if (!record || record.campaignId !== campaignId || record.timelineId !== visitingTimeline) return;
+          var turn = Number(record.turn);
+          if (!Number.isSafeInteger(turn) || turn > visitingMaxTurn || byTurn[turn]) return;
+          byTurn[turn] = { record: record, inherited: visitingDepth > 0, sourceTimelineId: visitingTimeline };
+        });
+        if (!cursorOwner && !lineage) cursorOwner = _timelineOwnerFromRecords(records, campaignId, visitingTimeline, visitingMaxTurn);
+        var parentTimeline = lineage ? String(lineage.parentTimelineId || '') : (cursorOwner && String(cursorOwner._parentTimelineId || ''));
+        var forkTurn = lineage ? Number(lineage.forkTurn) : (cursorOwner && Number(cursorOwner._forkTurn));
+        if (!parentTimeline || !Number.isSafeInteger(forkTurn) || forkTurn < 0) {
+          cursorTimeline = '';
+          return;
+        }
+        maxTurn = Math.min(visitingMaxTurn, forkTurn);
+        cursorTimeline = parentTimeline;
+        cursorOwner = null;
+        depth = visitingDepth + 1;
+        return visitNext();
       });
-    });
-    return Object.keys(byTurn).map(function(turn) { return byTurn[turn]; }).sort(function(a, b) {
-      return Number(a.record.turn) - Number(b.record.turn);
+    }
+
+    return visitNext().then(function() {
+      return Object.keys(byTurn).map(function(turn) { return byTurn[turn]; }).sort(function(a, b) {
+        return Number(a.record.turn) - Number(b.record.turn);
+      });
     });
   }
 
   function _enforceLRU(campaignId, timelineId, max) {
-    return _getAllRecords().then(function(records) {
-      var own = records.filter(function(r) { return r && r.campaignId === campaignId && r.timelineId === timelineId; });
+    return _getTimelineRecords(campaignId, timelineId).then(function(own) {
       own.sort(function(a, b) { return (a.turn - b.turn) || (a.ts - b.ts); });
       var remove = own.slice(0, Math.max(0, own.length - max));
       if (!remove.length) return;
@@ -383,25 +422,10 @@
       campaignId = campaignId || (gm ? _ensureCampaignId(gm) : '');
       timelineId = timelineId || (gm ? _ensureTimelineId(gm) : '');
       if (!campaignId || !timelineId) return Promise.resolve(null);
-      var id = _recordId(campaignId, timelineId, turn);
-      return _openDB().then(function(db) {
-        return new Promise(function(resolve, reject) {
-          var tx;
-          try {
-            tx = db.transaction(STORE, 'readonly');
-            var req = tx.objectStore(STORE).get(id);
-            req.onsuccess = function(e) { resolve(e.target.result || null); };
-            req.onerror = function(e) { reject(e.target.error || new Error('快照读取失败')); };
-            tx.onabort = function(e) { reject((e.target && e.target.error) || tx.error || new Error('快照读取事务已中止')); };
-          } catch (e) { reject(e); }
-        });
-      }).then(function(exact) {
+      return _getExactRecord(campaignId, timelineId, turn).then(function(exact) {
         if (exact) return exact;
-        return Promise.all([_getAllRecords(), _getAllLineageRecords()]).then(function(parts) {
-          var records = parts[0];
-          var lineageRecords = parts[1];
-          var currentGM = global.GM || (typeof GM !== 'undefined' ? GM : null);
-          var accessible = _accessibleSnapshotRecords(records, lineageRecords, campaignId, timelineId, currentGM);
+        var currentGM = global.GM || (typeof GM !== 'undefined' ? GM : null);
+        return _collectAccessibleSnapshotRecords(campaignId, timelineId, currentGM).then(function(accessible) {
           var match = accessible.find(function(item) { return Number(item.record.turn) === _strictTurn(turn); });
           if (!match) return null;
           var inherited = _deepClone(match.record);
@@ -418,8 +442,8 @@
     campaignId = campaignId || (gm ? _ensureCampaignId(gm) : '');
     timelineId = timelineId || (gm ? _ensureTimelineId(gm) : '');
     if (!campaignId || !timelineId) return Promise.resolve([]);
-    return Promise.all([_getAllRecords(), _getAllLineageRecords()]).then(function(parts) {
-      return _accessibleSnapshotRecords(parts[0], parts[1], campaignId, timelineId, gm).map(function(item) {
+    return _collectAccessibleSnapshotRecords(campaignId, timelineId, gm).then(function(accessible) {
+      return accessible.map(function(item) {
         var r = item.record;
         return {
           turn: r.turn,
@@ -439,17 +463,28 @@
       campaignId = campaignId || (gm ? _ensureCampaignId(gm) : '');
       timelineId = timelineId || (gm ? _ensureTimelineId(gm) : '');
       if (!campaignId || !timelineId) return Promise.resolve({ ok: false, reason: 'no world identity' });
+      turn = _strictTurn(turn);
       var id = _recordId(campaignId, timelineId, turn);
-      return _openDB().then(function(db) {
+      return _getExactRecord(campaignId, timelineId, turn).then(function(exact) {
+        if (!exact) {
+          return _collectAccessibleSnapshotRecords(campaignId, timelineId, gm).then(function(accessible) {
+            var inherited = accessible.some(function(item) {
+              return item.inherited === true && Number(item.record && item.record.turn) === turn;
+            });
+            return { ok: false, reason: inherited ? 'inherited-readonly' : 'not-found' };
+          });
+        }
+        return _openDB().then(function(db) {
         return new Promise(function(resolve, reject) {
           var tx;
           try {
             tx = db.transaction(STORE, 'readwrite');
             tx.objectStore(STORE).delete(id);
-            tx.oncomplete = function() { resolve({ ok: true }); };
+            tx.oncomplete = function() { resolve({ ok: true, turn: turn }); };
             tx.onerror = function(e) { reject((e.target && e.target.error) || tx.error || new Error('快照删除失败')); };
             tx.onabort = function(e) { reject((e.target && e.target.error) || tx.error || new Error('快照删除事务已中止')); };
           } catch (e) { reject(e); }
+        });
         });
       });
     } catch (e) { return Promise.reject(e); }


### PR DESCRIPTION
## 修复内容

- 将 IntegrationBridge 的纯迁移/重绑定与唯一回合 tick 分离，读档不再推进人口、腐败或承载负载
- 读档成功与失败回滚共用无时间副作用的 runtime rebind，并加强稳定 ID/有限数校验
- 桌面手动档和自动档读取保持只读；旧档无 generation、sidecar 缺失或介质只读时仍可加载
- 剥离 `__tmDesktop*` / `__tmAutoSave*` 传输元数据，禁止其进入 P/GM
- 快照按 campaign+timeline 复合索引和独立谱系读取；继承快照明确只读
- 刷新三个运行时脚本缓存戳及完整热更基线

## 验证

- `node web/scripts/ci-smokes.js`：847 项，845 通过，2 项为隔离工作树缺大型资产的既有白名单豁免
- `node web/scripts/lint-arch-all.js`：8/8
- `node web/scripts/verify-official-scenario-parity.js`：27/27
- `node scripts/verify-release-contract.js`：166/166
- `node web/scripts/verify-hot-builder-gates.js`：27/27
- 完整资产树热更基线：1082 项 PASS（806 MB asset overlay）
- `npm audit --omit=dev --audit-level=high`：0 vulnerabilities

本 PR 仅修源码与基线，不触发打包、Pages 或正式发版。