### PR TITLE
fix: close twelfth-round audit population and identity gaps

### DIFF
--- a/main-impl.js
+++ b/main-impl.js
@@ -18,6 +18,7 @@ const yauzl = require('yauzl');
 const { pipeline } = require('stream');
 const { autoUpdater } = require('electron-updater');
 const { createTurnDataCommitter } = require('./main-turn-data-commit.js');
+const { readJsonFileOffMainThread } = require('./main-json-file.js');
 
 // ============================================================
 //  基本配置
@@ -2973,7 +2974,7 @@ ipcMain.handle('load-project', async (event, filename) => {
   try {
     const ref = saveFileRef(filename);
     if (!fs.existsSync(ref.path)) return { success: false, error: '文件不存在' };
-    const data = JSON.parse(fs.readFileSync(ref.path, 'utf-8'));
+    const data = await readJsonFileOffMainThread(ref.path);
     // 读取必须保持只读：旧 payload 没有 generation 时仍立即允许加载，绝不能
     // 因目录只读、磁盘已满或同步软件锁文件而把合法存档判成加载失败。generation
     // 与 sidecar 在下一次真正保存时升级；列表此前保持 metadataPending。
@@ -3175,7 +3176,7 @@ ipcMain.handle('load-auto-save', async () => {
   try {
     await autoSaveWriteQueue;
     if (!fs.existsSync(AUTO_SAVE_FILE)) return { success: false };
-    const parsed = JSON.parse(fs.readFileSync(AUTO_SAVE_FILE, 'utf-8'));
+    const parsed = await readJsonFileOffMainThread(AUTO_SAVE_FILE);
     if (parsed && parsed.__tmAutoSaveEnvelope === 1) {
       const fileToken = normalizeAutoSaveSessionToken(parsed.sessionToken);
       let currentToken = getAutoSaveSessionToken();

--- a/main-json-file.js
+++ b/main-json-file.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const fs = require('fs');
+const { Worker, isMainThread, parentPort, workerData } = require('worker_threads');
+
+const DEFAULT_WORKER_THRESHOLD = 4 * 1024 * 1024;
+const DEFAULT_MAX_BYTES = 512 * 1024 * 1024;
+const DEFAULT_TIMEOUT_MS = 120000;
+
+function errorRecord(error) {
+  return {
+    name: String(error && error.name || 'Error'),
+    message: String(error && error.message || error),
+    code: error && error.code ? String(error.code) : '',
+    stack: error && error.stack ? String(error.stack) : ''
+  };
+}
+
+function reviveWorkerError(record) {
+  const error = new Error(record && record.message || 'JSON worker failed');
+  if (record && record.name) error.name = record.name;
+  if (record && record.code) error.code = record.code;
+  if (record && record.stack) error.stack = record.stack;
+  return error;
+}
+
+if (!isMainThread && workerData && workerData.tmJsonFileWorker === 1) {
+  try {
+    const text = fs.readFileSync(workerData.file, 'utf8');
+    const data = JSON.parse(text);
+    parentPort.postMessage({ ok: true, data });
+  } catch (error) {
+    parentPort.postMessage({ ok: false, error: errorRecord(error) });
+  }
+} else {
+  async function readJsonFileOffMainThread(file, options) {
+    options = options || {};
+    const stat = await fs.promises.stat(file);
+    const maxBytes = Number.isFinite(options.maxBytes) ? options.maxBytes : DEFAULT_MAX_BYTES;
+    if (!stat.isFile()) throw new Error('JSON 路径不是文件');
+    if (stat.size > maxBytes) throw new RangeError('JSON 文件超过读取上限');
+
+    const threshold = Number.isFinite(options.workerThresholdBytes)
+      ? Math.max(0, options.workerThresholdBytes)
+      : DEFAULT_WORKER_THRESHOLD;
+    if (stat.size < threshold) {
+      const text = await fs.promises.readFile(file, 'utf8');
+      return JSON.parse(text);
+    }
+
+    return new Promise((resolve, reject) => {
+      const worker = new Worker(__filename, {
+        workerData: { tmJsonFileWorker: 1, file: file }
+      });
+      const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : DEFAULT_TIMEOUT_MS;
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        worker.terminate().catch(() => {});
+        reject(new Error('JSON 文件解析超时'));
+      }, timeoutMs);
+      if (typeof timer.unref === 'function') timer.unref();
+
+      function finish(fn, value) {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        fn(value);
+      }
+
+      worker.once('message', message => {
+        if (message && message.ok === true) finish(resolve, message.data);
+        else finish(reject, reviveWorkerError(message && message.error));
+      });
+      worker.once('error', error => finish(reject, error));
+      worker.once('exit', code => {
+        if (!settled) finish(reject, new Error('JSON worker exited before returning data (code ' + code + ')'));
+      });
+    });
+  }
+
+  module.exports = {
+    readJsonFileOffMainThread,
+    DEFAULT_WORKER_THRESHOLD,
+    DEFAULT_MAX_BYTES
+  };
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "files": [
       "main.js",
       "main-impl.js",
+      "main-json-file.js",
       "main-turn-data-commit.js",
       "preload.js",
       "preload-impl.js",

--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-20T09:27:33.436Z",
+  "generatedAt": "2026-08-20T18:11:27.726Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -2161,8 +2161,8 @@
     },
     {
       "path": "index.html",
-      "sha256": "0c8370e27186dfde1cb13b8f1e2a8926720cefd916f5849faec4f9fac5b9dcf8",
-      "size": 68609
+      "sha256": "97de890b0c389a8fe610494ef105adb8dadded4a60e63a4836f433895ba4d17b",
+      "size": 68621
     },
     {
       "path": "INDEX.md",
@@ -4016,8 +4016,8 @@
     },
     {
       "path": "tm-endturn-systems.js",
-      "sha256": "2f79686edcff09014a7b222a51a16230394ba20a11b270d6ce1431a5e62df6f5",
-      "size": 39434
+      "sha256": "74a9de8fdf3d76054a6446cdea40d058366e8c5a68fc222f89a8ecf787c09f22",
+      "size": 39462
     },
     {
       "path": "tm-endturn-timing-ledger.js",
@@ -4316,8 +4316,8 @@
     },
     {
       "path": "tm-huji-engine.js",
-      "sha256": "390890e160bf837591ffde48e994268cf40ab659eb7f75c65eb0191472b19804",
-      "size": 58710
+      "sha256": "84fdb7a00f7ad58173063c2d5fbe101a7e76f9552604cd509511b712ccd02049",
+      "size": 60871
     },
     {
       "path": "tm-huji-governance-loop.js",
@@ -4341,8 +4341,8 @@
     },
     {
       "path": "tm-integration-bridge.js",
-      "sha256": "557ab6788c7e58f70cae5f5201bd25fe765a190c0a9512b92ce39df68594360e",
-      "size": 45204
+      "sha256": "85e41226ada9de260046c773ef0b7d699b148999aa270de999a875e03aa26e42",
+      "size": 39165
     },
     {
       "path": "tm-invariants.js",
@@ -5096,8 +5096,8 @@
     },
     {
       "path": "tm-save-lifecycle.js",
-      "sha256": "54a939444c59284141df4429f75f90260ce66866635aef1eafbef1bcba32a012",
-      "size": 126247
+      "sha256": "168d51228342065452ce8c4f250a780d1032ca50921645a778fcafa0ba072e26",
+      "size": 133101
     },
     {
       "path": "tm-save-manager.js",

--- a/web/index.html
+++ b/web/index.html
@@ -654,7 +654,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-world-digest.js?v=20260630"></script><!-- 天下牵动·因果综述·W1a·把割裂的系统反应重组成连贯因果注入推演 -->
 <script src="tm-benji.js?v=20260707"></script><!-- 帝王本纪·终局回顾式修史(鼎革R1g·每12回合一卷串行修纂·flag benjiEnabled) -->
 <script src="tm-world-reactors.js?v=20260630"></script><!-- 世界反应总线·跨系统reactor·W2a军事→势力·flag-gated默认关 -->
-<script src="tm-endturn-systems.js?v=20260811-auditfix1"></script>
+<script src="tm-endturn-systems.js?v=20260821-auditfix12"></script>
 <script src="tm-endturn-ai-helpers.js?v=2026042714"></script>
 <script src="tm-endturn-ai-context.js?v=2026050401"></script>
 <script src="tm-history-events.js?v=20260719-histanchors"></script>
@@ -838,7 +838,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-bgm-config.js?v=2026051201"></script>
 <!-- R131 (2026-04-25) tm-audio-theme.js 拆分 → audio-theme + save-lifecycle + office-editor -->
 <script src="tm-audio-theme.js?v=20260710-fontscale"></script>
-<script src="tm-save-lifecycle.js?v=20260820-auditfix11"></script>
+<script src="tm-save-lifecycle.js?v=20260821-auditfix12"></script>
 <script src="tm-office-editor.js?v=20260707-nestflat2"></script>
 <script src="tm-topbar-vars.js?v=20260514-phase8-vars-2"></script>
 <!-- R137 (2026-04-25) 拆 shell-extras → shell UI + 时政面板 -->
@@ -875,7 +875,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-economy-engine-currency.js?v=20260706-splitsync"></script><!-- 立项拆分：§A CurrencyUnit+§B CurrencyEngine 两整IIFE·紧挨 economy-engine 之前保序·勿动位置 -->
 <script src="tm-economy-engine.js?v=20260706-splitsync"></script>
 <script src="tm-central-local-engine.js?v=20260709"></script>
-<script src="tm-huji-engine.js?v=20260709"></script>
+<script src="tm-huji-engine.js?v=20260821-auditfix12"></script>
 <script src="tm-edict-parser.js?v=20260709"></script>
 <script src="tm-huji-deep-fill.js?v=2026042714"></script>
 <script src="tm-huji-runtime-bridge.js?v=20260601-huji-runtime-bridge"></script>
@@ -912,7 +912,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-ethnic-religion.js?v=2026050701"></script>
 <script src="tm-edict-thresholds.js?v=2026042714"></script>
 <script src="tm-fiscal-ui.js?v=2026042714"></script>
-<script src="tm-integration-bridge.js?v=20260820-auditfix11"></script>
+<script src="tm-integration-bridge.js?v=20260821-auditfix12"></script>
 <script src="tm-fiscal-engine.js?v=20260811-auditfix1"></script>
 <script src="tm-perf.js?v=2026042714"></script>
 <script src="tm-invariants.js?v=2026042714"></script>

--- a/web/scripts/smoke-desktop-save-async-load.js
+++ b/web/scripts/smoke-desktop-save-async-load.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const mainImpl = fs.readFileSync(path.join(ROOT, 'main-impl.js'), 'utf8');
+const packageJson = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+const { readJsonFileOffMainThread } = require(path.join(ROOT, 'main-json-file.js'));
+
+let pass = 0;
+let fail = 0;
+function ok(condition, message) {
+  if (condition) {
+    pass++;
+    console.log('  PASS - ' + message);
+  } else {
+    fail++;
+    console.error('  FAIL - ' + message);
+  }
+}
+
+async function run() {
+  console.log('[smoke-desktop-save-async-load]');
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'tianming-json-worker-'));
+  const largeFile = path.join(tempRoot, 'large-save.json');
+  const badFile = path.join(tempRoot, 'bad-save.json');
+  try {
+    const payload = {
+      name: 'large-save',
+      gameState: { turn: 88 },
+      padding: '天命'.repeat(3 * 1024 * 1024)
+    };
+    fs.writeFileSync(largeFile, JSON.stringify(payload));
+    fs.writeFileSync(badFile, '{"broken":');
+
+    let heartbeats = 0;
+    const timer = setInterval(() => { heartbeats++; }, 1);
+    const loaded = await readJsonFileOffMainThread(largeFile, {
+      workerThresholdBytes: 1,
+      timeoutMs: 30000
+    });
+    clearInterval(timer);
+
+    ok(loaded && loaded.name === 'large-save' && loaded.gameState.turn === 88,
+      'large desktop JSON is parsed correctly by the worker path');
+    ok(heartbeats > 0, 'main event loop remains responsive while the large JSON is parsed');
+
+    let parseError = null;
+    try {
+      await readJsonFileOffMainThread(badFile, { workerThresholdBytes: 1, timeoutMs: 30000 });
+    } catch (error) {
+      parseError = error;
+    }
+    ok(parseError instanceof Error, 'worker parse failures reject instead of returning partial data');
+
+    ok(/ipcMain\.handle\('load-project',[\s\S]*?await readJsonFileOffMainThread\(ref\.path\)/.test(mainImpl),
+      'project loading uses the off-main-thread JSON reader');
+    ok(/ipcMain\.handle\('load-auto-save',[\s\S]*?await readJsonFileOffMainThread\(AUTO_SAVE_FILE\)/.test(mainImpl),
+      'desktop auto-save loading uses the off-main-thread JSON reader');
+    ok(Array.isArray(packageJson.build && packageJson.build.files)
+      && packageJson.build.files.includes('main-json-file.js'),
+    'the packaged Electron app includes the JSON worker module');
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+
+  console.log('\n[smoke-desktop-save-async-load] ' + pass + ' passed / ' + fail + ' failed');
+  process.exit(fail ? 1 : 0);
+}
+
+run().catch(error => {
+  console.error(error && error.stack || error);
+  process.exit(1);
+});

--- a/web/scripts/smoke-dikuai-systems.js
+++ b/web/scripts/smoke-dikuai-systems.js
@@ -80,10 +80,14 @@ console.log('— D2 · 叶级吏治连账(行为) —');
 /* ── D1 · 源码契约 ─────────────────────────────────────────── */
 console.log('— D1 · 人口三重错位根治(契约) —');
 var bridge = read('tm-integration-bridge.js');
-ok(/function growLeaf\(div\)/.test(bridge) && /kids\.forEach\(growLeaf\); return;/.test(bridge), '递归到叶(嵌套树不再只扫顶层)');
-ok(/\[pop, pd\]\.forEach/.test(bridge), 'population 与 populationDetail 双账同写');
-ok(/acc\.households \+ Math\.round\(acc\.households \* rate\)/.test(bridge), '户按本叶既有数等比缩放(不再 5/0.25 硬比率)');
-ok(/div\.environment\.currentLoad = Math\.max\(0, Math\.min\(1\.5, mNow \/ cap\)\)/.test(bridge), '活承载:负载随人口重算');
+var huji = read('tm-huji-engine.js');
+ok(/function _allLeafDivisions\(G\)/.test(huji) && /IB\.getLeafDivisions\(ah, facId\)/.test(huji), '人口权威递归取得所有行政区叶子');
+ok(/function _syncLeafPopulationMirrors\(leaf, detail\)/.test(huji)
+  && /leaf\.population\.mouths = detail\.mouths/.test(huji), 'Huji 同步 population 与 populationDetail 双账');
+ok(/leafMouthsPerHousehold = Number\(pd\.households\) > 0 \? mouths \/ Number\(pd\.households\)/.test(huji)
+  && /leafDingRatio = Number\(pd\.ding\) > 0 \? Number\(pd\.ding\) \/ mouths/.test(huji), '户与丁按本叶既有结构同比缩放');
+ok(/detail\.mouths \/ cap/.test(huji) && /env\.currentLoad = load/.test(huji), '活承载负载随 Huji 人口重算');
+ok(!/function _naturalPopulationGrowth\(/.test(bridge), 'IntegrationBridge 不再成为第二个人口生产者');
 
 /* ── D4 · 源码契约 ─────────────────────────────────────────── */
 console.log('— D4 · 势力接地块三断链(契约) —');

--- a/web/scripts/smoke-endturn-transaction-failures.js
+++ b/web/scripts/smoke-endturn-transaction-failures.js
@@ -9,6 +9,7 @@ const WEB = path.resolve(__dirname, '..');
 const coreSource = fs.readFileSync(path.join(WEB, 'tm-endturn-core.js'), 'utf8');
 const systemsSource = fs.readFileSync(path.join(WEB, 'tm-endturn-systems.js'), 'utf8');
 const pipelineStepsSource = fs.readFileSync(path.join(WEB, 'tm-endturn-pipeline-steps.js'), 'utf8');
+const hujiSource = fs.readFileSync(path.join(WEB, 'tm-huji-engine.js'), 'utf8');
 let assertions = 0;
 function ok(value, label) {
   if (!value) throw new Error('[smoke-endturn-transaction-failures] ' + label);
@@ -149,6 +150,38 @@ async function main() {
   ok(await expectFailure(ctx._endTurn_updateSystems(1, ''), 'guoku-ledger-failure'), 'treasury failure propagates after an intermediate turn increment');
   ctx._tmRollbackEndTurnTransaction(txn, new Error('guoku-ledger-failure'));
   ok(ctx.GM.treasury === 50 && ctx.GM.turn === 4, 'partial treasury mutation and turn increment roll back atomically');
+
+  resetWorld({
+    environment: { nationalLoad: 0.5 }, vars: { disasterLevel: 0 }, activeWars: [],
+    population: {
+      national: { mouths: 1000000, households: 200000, ding: 300000 },
+      byRegion: {},
+      dynamics: { birthRateBase: 0.03, deathRateBase: 0.022, yearlyLog: [] }
+    }
+  });
+  const firstLeaf = { id: 'first', populationDetail: { mouths: 600000, households: 120000, ding: 180000 } };
+  const secondDetail = { households: 80000, ding: 120000 };
+  Object.defineProperty(secondDetail, 'mouths', {
+    configurable: true,
+    enumerable: true,
+    get() {
+      if (firstLeaf.populationDetail.mouths !== 600000) throw new Error('huji-second-region-failure');
+      return 400000;
+    }
+  });
+  const secondLeaf = { id: 'second', populationDetail: secondDetail };
+  ctx.GM.adminHierarchy = { player: { divisions: [firstLeaf, secondLeaf] } };
+  ctx.P.conf.populationBottomUpEnabled = false;
+  ctx.IntegrationBridge = { getLeafDivisions() { return [firstLeaf, secondLeaf]; } };
+  vm.runInContext(hujiSource, ctx);
+  const hujiBeforeGM = comparableWorld(ctx.GM);
+  const hujiBeforeP = comparableWorld(ctx.P);
+  txn = ctx._tmCaptureEndTurnTransaction();
+  ok(await expectFailure(ctx._endTurn_updateSystems(1, ''), 'huji-second-region-failure'),
+    'real Huji partial-region failure reaches the outer turn transaction');
+  ctx._tmRollbackEndTurnTransaction(txn, new Error('huji-second-region-failure'));
+  ok(comparableWorld(ctx.GM) === hujiBeforeGM && comparableWorld(ctx.P) === hujiBeforeP,
+    'real Huji partial population writes and turn increment roll back atomically');
 
   resetWorld({ turn: 8 });
   let releaseSubticks;

--- a/web/scripts/smoke-faction-binding-lint.js
+++ b/web/scripts/smoke-faction-binding-lint.js
@@ -81,6 +81,10 @@ const ALLOW_LINES = [
   // map-editor-to-game.js: division.factionId is scenario map ownership metadata inherited from autonomyHierarchy,
   // not character/army/province membership mutation.
   { file: 'map-editor-to-game.js', match: /nd\.factionId\s*=\s*facId/ },
+  // tm-save-lifecycle.js: one-time deterministic schema migration only backfills missing stable IDs.
+  // It must not emit membership-change events while an old world is still detached during load.
+  { file: 'tm-save-lifecycle.js', match: /ch\.factionId\s*=\s*id/ },
+  { file: 'tm-save-lifecycle.js', match: /region\.factionId\s*=\s*id/ },
   // tm-endturn-agent-mode.js·d 是维度标志对象(_activeDims)·d.faction=1 是「势力维度有活动」的开关位·非势力归属绑定
   { file: 'tm-endturn-agent-mode.js', match: /d\.faction\s*=\s*1/ },
   // tm-endturn-agent-write-tools.js·change 是工具 schema 透传对象·change.faction 传给 applyAIArmyChange·

--- a/web/scripts/smoke-pop-bottomup-s1.js
+++ b/web/scripts/smoke-pop-bottomup-s1.js
@@ -48,11 +48,15 @@ console.log('  [T1a] 地方差异(民心高>低)：' + (T1a ? 'OK' : 'FAIL'));
 console.log('  [T1b] 守恒 national==Σ叶：' + (T1b ? 'OK' : 'FAIL'));
 console.log('  [T1c] 叶 populationDetail 被写：' + (T1c ? 'OK' : 'FAIL'));
 
-// ── T2·开关关：原全国逻辑（叶级路径不碰叶 populationDetail）──
+// ── T2·开关关：仍由叶级唯一真值推进，但不应用地方差异修正 ──
 var s2 = setup(false);
 HujiEngine.tick({ turn: 1, monthRatio: 1, _monthRatio: 1 });
-var T2 = s2.L1.populationDetail.mouths === 600000 && s2.L2.populationDetail.mouths === 400000;
-console.log('[T2·开关关零回归] 叶 populationDetail 不被叶级路径碰：' + (T2 ? 'OK' : 'FAIL'));
+var l1rate = (s2.L1.populationDetail.mouths - 600000) / 600000;
+var l2rate = (s2.L2.populationDetail.mouths - 400000) / 400000;
+var T2 = s2.L1.populationDetail.mouths !== 600000
+  && s2.L2.populationDetail.mouths !== 400000
+  && Math.abs(l1rate - l2rate) < 0.00001;
+console.log('[T2·开关关闭回归] 叶级人口仍推进且使用统一全国率：' + (T2 ? 'OK' : 'FAIL'));
 
 var all = T1a && T1b && T1c && T2;
 console.log('\n=== ' + (all ? 'ALL PASS' : 'FAIL') + ' ===');

--- a/web/scripts/smoke-population-single-authority.js
+++ b/web/scripts/smoke-population-single-authority.js
@@ -1,0 +1,193 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.join(__dirname, '..');
+const hujiSource = fs.readFileSync(path.join(ROOT, 'tm-huji-engine.js'), 'utf8');
+const bridgeSource = fs.readFileSync(path.join(ROOT, 'tm-integration-bridge.js'), 'utf8');
+
+let pass = 0;
+let fail = 0;
+function ok(condition, message) {
+  if (condition) {
+    pass++;
+    console.log('  PASS - ' + message);
+  } else {
+    fail++;
+    console.error('  FAIL - ' + message);
+  }
+}
+
+function makeLeaf(id, mouths, minxin) {
+  return {
+    id,
+    name: id,
+    minxin,
+    prosperity: 50,
+    population: { mouths, households: Math.round(mouths / 5), ding: Math.round(mouths * 0.3) },
+    populationDetail: { mouths, households: Math.round(mouths / 5), ding: Math.round(mouths * 0.3) },
+    minxinDetails: { true: minxin, shown: minxin },
+    fiscal: { treasury: 0, revenue: 0, expenditure: 0 },
+    environment: { carrying: mouths * 2, currentLoad: 0.5 }
+  };
+}
+
+function makeWorld(bottomUp) {
+  const a = makeLeaf('a', 30000000, 75);
+  const b = makeLeaf('b', 20000000, 25);
+  return {
+    P: { conf: { populationBottomUpEnabled: !!bottomUp }, time: { year: 1627 } },
+    GM: {
+      turn: 1,
+      year: 1627,
+      vars: { disasterLevel: 0 },
+      activeWars: [],
+      chars: [],
+      adminHierarchy: { player: { divisions: [a, b] } },
+      population: {
+        national: { mouths: 50000000, households: 10000000, ding: 15000000 },
+        byRegion: {
+          a: { mouths: 30000000, households: 6000000, ding: 9000000 },
+          b: { mouths: 20000000, households: 4000000, ding: 6000000 },
+          ghost: { mouths: 99, households: 20, ding: 30 }
+        },
+        dynamics: {
+          birthRateBase: 0.030,
+          deathRateBase: 0.022,
+          prosperityBonus: 0,
+          agingPenalty: 0,
+          diseaseBoost: 0,
+          yearlyLog: []
+        }
+      },
+      minxin: { trueIndex: 60, byRegion: { ghost: { true: 1 } } },
+      fiscal: { regions: { ghost: { treasury: 1 } } },
+      environment: { nationalLoad: 0.5, byRegion: { ghost: { currentLoad: 1 } } },
+      corruption: { byDept: { central: 31, provincial: 32, county: 33, military: 34, palace: 35, technical: 36 } },
+      regionMap: { ghost: { id: 'ghost' } }
+    },
+    leaves: [a, b]
+  };
+}
+
+function createRuntime(world, bridge) {
+  const context = {
+    console,
+    Math,
+    Number,
+    Object,
+    Array,
+    String,
+    Date,
+    JSON,
+    isFinite,
+    setTimeout,
+    clearTimeout,
+    GM: world.GM,
+    P: world.P,
+    TM: {},
+    turnsForMonths: months => months,
+    _getDaysPerTurn: () => 30,
+    calcDateFromTurn: () => ({ adYear: 1627 })
+  };
+  context.window = context;
+  context.global = context;
+  vm.createContext(context);
+  if (bridge) vm.runInContext(bridgeSource, context, { filename: 'tm-integration-bridge.js' });
+  vm.runInContext(hujiSource, context, { filename: 'tm-huji-engine.js' });
+  return context;
+}
+
+function runMonths(monthRatio, steps) {
+  const world = makeWorld(false);
+  const ctx = createRuntime(world, true);
+  ctx.IntegrationBridge.migrateAndRebind({ strict: true });
+  for (let i = 0; i < steps; i++) {
+    ctx.GM.turn = i + 1;
+    ctx.HujiEngine.tick({ turn: i + 1, monthRatio, strict: true });
+    ctx.IntegrationBridge.tick({ strict: true });
+  }
+  return Number(ctx.GM.population.national.mouths);
+}
+
+console.log('[smoke-population-single-authority]');
+
+{
+  const world = makeWorld(true);
+  world.leaves[1].populationDetail.households = 5000000;
+  world.leaves[1].populationDetail.ding = 4000000;
+  world.leaves[1].population.households = 5000000;
+  world.leaves[1].population.ding = 4000000;
+  const ctx = createRuntime(world, true);
+  ctx.IntegrationBridge.migrateAndRebind({ strict: true });
+  const leafHouseholdRatio = world.leaves[1].populationDetail.households / world.leaves[1].populationDetail.mouths;
+  const leafDingRatio = world.leaves[1].populationDetail.ding / world.leaves[1].populationDetail.mouths;
+  ctx.HujiEngine.tick({ turn: 1, monthRatio: 1, strict: true });
+  const afterHuji = world.leaves.map(leaf => leaf.populationDetail.mouths);
+  const corruptionAfterHuji = JSON.stringify(ctx.GM.corruption.byDept);
+  ctx.IntegrationBridge.tick({ turn: 1, monthRatio: 1, strict: true });
+  const afterBridge = world.leaves.map(leaf => leaf.populationDetail.mouths);
+  ok(JSON.stringify(afterBridge) === JSON.stringify(afterHuji), 'IntegrationBridge does not advance leaf population after Huji');
+  ok(JSON.stringify(ctx.GM.corruption.byDept) === corruptionAfterHuji, 'IntegrationBridge does not apply a second corruption tick');
+  ok(Math.abs(world.leaves[1].populationDetail.households / world.leaves[1].populationDetail.mouths - leafHouseholdRatio) < 0.000001
+    && Math.abs(world.leaves[1].populationDetail.ding / world.leaves[1].populationDetail.mouths - leafDingRatio) < 0.000001,
+  'leaf household and ding ratios remain local instead of being replaced by national defaults');
+  ok(!Object.prototype.hasOwnProperty.call(ctx.GM.population.byRegion, 'ghost')
+    && !Object.prototype.hasOwnProperty.call(ctx.GM.minxin.byRegion, 'ghost')
+    && !Object.prototype.hasOwnProperty.call(ctx.GM.fiscal.regions, 'ghost')
+    && !Object.prototype.hasOwnProperty.call(ctx.GM.environment.byRegion, 'ghost')
+    && !Object.prototype.hasOwnProperty.call(ctx.GM.regionMap, 'ghost'),
+  'legacy region proxies are rebuilt without ghost keys');
+}
+
+{
+  const daily = runMonths(1 / 30, 360);
+  const monthly = runMonths(1 / 3, 36);
+  const thirtyDay = runMonths(1, 12);
+  const quarterly = runMonths(3, 4);
+  const results = [daily, monthly, thirtyDay, quarterly];
+  const relativeDifference = (Math.max.apply(Math, results) - Math.min.apply(Math, results)) / Math.max.apply(Math, results);
+  ok(relativeDifference < 0.0002, 'equal simulated time stays consistent across 1-day, 10-day, 30-day and 90-day turns');
+}
+
+{
+  const world = makeWorld(false);
+  world.GM.adminHierarchy = {};
+  const ctx = createRuntime(world, false);
+  ctx.IntegrationBridge = { getLeafDivisions: () => [] };
+  const oldMouths = ctx.GM.population.national.mouths;
+  const oldHouseholds = ctx.GM.population.national.households;
+  const oldDing = ctx.GM.population.national.ding;
+  ctx.HujiEngine.tick({ turn: 1, monthRatio: 3, strict: true });
+  const next = ctx.GM.population.national;
+  ok(next.households !== oldHouseholds && Math.abs(next.households / next.mouths - oldHouseholds / oldMouths) < 0.000001,
+    'legacy household count follows the pre-growth population ratio');
+  ok(next.ding !== oldDing && Math.abs(next.ding / next.mouths - oldDing / oldMouths) < 0.000001,
+    'legacy ding count follows the pre-growth population ratio');
+  const net = next.mouths - oldMouths;
+  ok(ctx.GM.population.dynamics.lastYearNet === net * 4, 'lastYearNet annualizes by monthRatio');
+}
+
+{
+  const world = makeWorld(false);
+  let firstMouths = world.leaves[0].populationDetail.mouths;
+  Object.defineProperty(world.leaves[1].populationDetail, 'mouths', {
+    configurable: true,
+    get() { throw new Error('injected second-region failure'); }
+  });
+  const ctx = createRuntime(world, false);
+  ctx.IntegrationBridge = { getLeafDivisions: () => world.leaves };
+  let thrown = null;
+  try {
+    ctx.HujiEngine.tick({ turn: 1, monthRatio: 1, strict: true });
+  } catch (error) {
+    thrown = error;
+  }
+  ok(!!thrown && /injected second-region failure/.test(thrown.message), 'strict Huji propagates a population substep failure');
+  ok(world.leaves[0].populationDetail.mouths !== firstMouths, 'failure injection occurred after an earlier region was mutated');
+}
+
+console.log('\n[smoke-population-single-authority] ' + pass + ' passed / ' + fail + ' failed');
+process.exit(fail ? 1 : 0);

--- a/web/scripts/smoke-runtime-save-consistency.js
+++ b/web/scripts/smoke-runtime-save-consistency.js
@@ -30,6 +30,7 @@ const mainImpl = fs.readFileSync(path.join(ROOT, '..', 'main-impl.js'), 'utf8');
 const preloadImpl = fs.readFileSync(path.join(ROOT, '..', 'preload-impl.js'), 'utf8');
 const startPatch = fs.readFileSync(path.join(ROOT, 'tm-patches-start.js'), 'utf8');
 const integrationBridge = fs.readFileSync(path.join(ROOT, 'tm-integration-bridge.js'), 'utf8');
+const hujiEngine = fs.readFileSync(path.join(ROOT, 'tm-huji-engine.js'), 'utf8');
 
 console.log('=== 1. unified save snapshot builder ===');
 const snapshotSrc = sliceFn(lifecycle, 'function _autoSaveSnapshotGM(');
@@ -112,10 +113,10 @@ ok(/_tmRebindRuntimeWorld\(\{ strict: true, integration: false/.test(lifecycle)
   && /_tmRunCriticalLoadStep\('loaded world validation'/.test(lifecycle),
   'state-mutating load migrations propagate into the load transaction instead of failing open');
 ok(/function aggregateRegionsToVariables\(options\)[\s\S]*?var strict = options\.strict === true/.test(integrationBridge)
-  && /var advanceSimulation = options\.advanceSimulation === true/.test(integrationBridge)
-  && /function migrateAndRebind\(options\)[\s\S]*?advanceSimulation: false/.test(integrationBridge)
-  && /function tick\(options\)[\s\S]*?advanceSimulation: true/.test(integrationBridge),
-  'integration bridge separates pure load rebind from the one explicit simulation tick');
+  && !/function _naturalPopulationGrowth\(/.test(integrationBridge)
+  && !/function _accumulateCorruptionFromNpcs\(/.test(integrationBridge)
+  && /function tick\(options\)[\s\S]*?aggregateRegionsToVariables\(\{ strict: strict \}\)/.test(integrationBridge),
+  'integration bridge is aggregation-only; Huji and CorruptionEngine own simulation time');
 ok(/function _tmStripSaveTransportMetadata\([\s\S]*?\^__tm\(\?:Desktop\|AutoSave\)/.test(lifecycle)
   && /_tmStripSaveTransportMetadata\(_incomingP\)/.test(lifecycle)
   && /_tmStripSaveTransportMetadata\(_incomingGM\)/.test(lifecycle),
@@ -246,15 +247,22 @@ async function runDynamicLeaseSmokes() {
       console, Promise, JSON, Math, Number, Object, Array, Date,
       GM: {
         turn: 10, adminHierarchy: { player: { divisions: [division] } },
-        population: { national: { mouths: 50000000, households: 10000000 } },
+        population: {
+          national: { mouths: 50000000, households: 10000000, ding: 12500000 },
+          dynamics: { birthRateBase: 0.03, deathRateBase: 0.022, yearlyLog: [] }
+        },
         minxin: { trueIndex: 60 }, corruption: { trueIndex: 30, overall: 30, byDept: {} },
         chars: [{ name: '测试官', officialTitle: '知县', integrity: 0, resources: { private: { money: 500000 } } }]
       },
-      P: {}, TM: { errors: { capture() {}, captureSilent() {} } }
+      P: { conf: { populationBottomUpEnabled: false }, time: { year: 1627 } },
+      TM: { errors: { capture() {}, captureSilent() {} } },
+      turnsForMonths(months) { return months; },
+      _getDaysPerTurn() { return 30; }
     };
     ctx.window = ctx;
     vm.createContext(ctx);
     vm.runInContext(integrationBridge, ctx);
+    vm.runInContext(hujiEngine, ctx);
     ctx.IntegrationBridge.migrateAndRebind({ strict: true }); // 一次性 schema 对齐
     function gameplayState() {
       const leaf = ctx.GM.adminHierarchy.player.divisions[0];
@@ -270,14 +278,18 @@ async function runDynamicLeaseSmokes() {
       ctx.IntegrationBridge.migrateAndRebind({ strict: true });
     }
     const afterTenLoads = gameplayState();
+    ctx.HujiEngine.tick({ turn: ctx.GM.turn, monthRatio: 1, strict: true });
+    const afterHuji = gameplayState();
     ctx.IntegrationBridge.tick({ strict: true });
-    const afterTick = gameplayState();
-    ok(afterTenLoads === stable && afterTick !== stable,
-      '读档—保存循环 10 次不推进人口/腐败/承载，唯一 tick 才推进玩法状态');
+    const afterBridge = gameplayState();
+    ok(afterTenLoads === stable && afterHuji !== stable && afterBridge === afterHuji,
+      '读档—保存循环不推进玩法，Huji 单次推进且 IntegrationBridge 不再重复结算');
   }
   {
     const helpers = [
       sliceFn(lifecycle, 'function _tmStripSaveTransportMetadata('),
+      sliceFn(lifecycle, 'function _tmStableIdMissing('),
+      sliceFn(lifecycle, 'function _tmCollectAdminDivisionEntries('),
       sliceFn(lifecycle, 'function _tmValidateUniqueStableIds('),
       sliceFn(lifecycle, 'function _tmValidateFiniteWorldNumbers('),
       sliceFn(lifecycle, 'function _tmValidateLoadedWorld(')
@@ -669,6 +681,7 @@ async function runDynamicLeaseSmokes() {
         data.__tmDesktopSaveGeneration = data.__tmDesktopSaveGeneration || 'payload-generation-test-0001';
         return { data, generation: data.__tmDesktopSaveGeneration, text: JSON.stringify(data) };
       },
+      async readJsonFileOffMainThread(file) { return JSON.parse(fakeFs.readFileSync(file, 'utf8')); },
       desktopSaveGenerationFromData(data) { return data && data.__tmDesktopSaveGeneration || ''; },
       invalidateDesktopSaveGeneration() {},
       writeDesktopSaveMetadata() {}

--- a/web/scripts/smoke-save-integrity-audit.js
+++ b/web/scripts/smoke-save-integrity-audit.js
@@ -74,9 +74,18 @@ console.log('=== save integrity audit ===');
   const blockEnd = lifecycle.indexOf('\ndoSaveGame=async function', blockStart);
   const snapshot = sliceFn(lifecycle, 'function _autoSaveSnapshotGM(');
   const builder = sliceFn(lifecycle, 'function _buildSaveState(');
+  const stableIdHelpers = [
+    'function _tmStableIdMissing(',
+    'function _tmStableIdHash(',
+    'function _tmCollectAdminDivisionEntries(',
+    'function _tmAssignMissingStableIds(',
+    'function _tmUniqueEntityIdByName(',
+    'function _tmBackfillStableForeignKeys(',
+    'function _tmMigrateCoreStableIds('
+  ].map(function(marker) { return sliceFn(lifecycle, marker); }).join('\n');
   ok(blockStart >= 0 && blockEnd > blockStart && snapshot && builder, '可抽取真实存档准备与 builder');
   const ctx = {
-    console, Date, Math, JSON, Object, Array,
+    console, Date, Math, JSON, Object, Array, Number, String, WeakSet,
     document: { getElementById: function() { return null; } },
     window: { addEventListener: function() {}, _tmNewCampaignId: function() { return 'tmc_test'; } },
     deepClone: function(v) { return JSON.parse(JSON.stringify(v)); },
@@ -97,7 +106,7 @@ console.log('=== save integrity audit ===');
   const gmBefore = JSON.stringify(ctx.GM);
   const pBefore = JSON.stringify(ctx.P);
   vm.createContext(ctx);
-  vm.runInContext(lifecycle.slice(blockStart, blockEnd) + '\n' + snapshot + '\n' + builder
+  vm.runInContext(stableIdHelpers + '\n' + lifecycle.slice(blockStart, blockEnd) + '\n' + snapshot + '\n' + builder
     + '\nthis.OUT=_buildSaveState({format:"idb"});', ctx);
   ok(JSON.stringify(ctx.GM) === gmBefore && JSON.stringify(ctx.P) === pBefore, '完整存档准备不修改 live GM/P');
   ok(!('_postTurnJobs' in ctx.OUT.GM) && ctx.GM._postTurnJobs.pending === true, '临时任务只从快照删除');

--- a/web/scripts/smoke-stable-id-migration.js
+++ b/web/scripts/smoke-stable-id-migration.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const lifecyclePath = path.join(__dirname, '..', 'tm-save-lifecycle.js');
+const lifecycle = fs.readFileSync(lifecyclePath, 'utf8');
+
+function sliceFn(source, marker) {
+  const start = source.indexOf(marker);
+  if (start < 0) throw new Error('missing function: ' + marker);
+  let cursor = source.indexOf('{', start);
+  let depth = 0;
+  for (; cursor < source.length; cursor++) {
+    if (source[cursor] === '{') depth++;
+    else if (source[cursor] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(start, cursor + 1);
+    }
+  }
+  throw new Error('unterminated function: ' + marker);
+}
+
+const functionNames = [
+  '_tmHasOwn',
+  '_tmStableIdMissing',
+  '_tmStableIdHash',
+  '_tmCollectAdminDivisionEntries',
+  '_tmAssignMissingStableIds',
+  '_tmUniqueEntityIdByName',
+  '_tmBackfillStableForeignKeys',
+  '_tmMigrateCoreStableIds',
+  '_tmValidateUniqueStableIds'
+];
+
+const context = { console, Math, Number, Object, Array, String, WeakSet };
+vm.createContext(context);
+for (const name of functionNames) {
+  vm.runInContext(sliceFn(lifecycle, 'function ' + name), context, { filename: name + '.js' });
+}
+
+let pass = 0;
+let fail = 0;
+function ok(condition, message) {
+  if (condition) {
+    pass++;
+    console.log('  PASS - ' + message);
+  } else {
+    fail++;
+    console.error('  FAIL - ' + message);
+  }
+}
+
+function legacyWorld() {
+  return {
+    sid: 'scenario-stable-id-smoke',
+    _campaignId: 'campaign-stable-id-smoke',
+    chars: [
+      { name: '甲', faction: '朝廷' },
+      { name: '乙', faction: '朝廷' }
+    ],
+    facs: [
+      { name: '朝廷', leader: '甲' }
+    ],
+    armies: [
+      { name: '京营', commander: '乙' }
+    ],
+    mapData: {
+      regions: [
+        { name: '京畿', controller: '朝廷' }
+      ]
+    },
+    adminHierarchy: {
+      player: {
+        divisions: [
+          {
+            name: '北直隶',
+            children: [
+              { name: '顺天府' },
+              { name: '保定府' }
+            ]
+          }
+        ]
+      }
+    }
+  };
+}
+
+function ids(world) {
+  return {
+    chars: world.chars.map(item => item.id),
+    facs: world.facs.map(item => item.id),
+    armies: world.armies.map(item => item.id),
+    regions: world.mapData.regions.map(item => item.id),
+    divisions: context._tmCollectAdminDivisionEntries(world).map(entry => entry.item.id)
+  };
+}
+
+console.log('[smoke-stable-id-migration]');
+
+const first = legacyWorld();
+const second = legacyWorld();
+const firstResult = context._tmMigrateCoreStableIds(first);
+context._tmMigrateCoreStableIds(second);
+
+ok(firstResult.total === 8, 'all missing core and nested division IDs are migrated');
+ok(JSON.stringify(ids(first)) === JSON.stringify(ids(second)), 'legacy IDs are deterministic across repeated loads');
+ok(Object.values(ids(first)).every(group => group.every(id => typeof id === 'string' && id.startsWith('tmlegacy_'))),
+  'generated IDs use the stable legacy namespace');
+ok(first.chars.every(ch => ch.factionId === first.facs[0].id), 'character faction names are backfilled to stable faction IDs');
+ok(first.facs[0].leaderId === first.chars[0].id, 'faction leader name is backfilled to a stable character ID');
+ok(first.armies[0].commanderId === first.chars[1].id, 'army commander name is backfilled to a stable character ID');
+ok(first.mapData.regions[0].factionId === first.facs[0].id, 'region controller name is backfilled to a stable faction ID');
+const receiptBeforeRepeat = JSON.stringify(first._stableIdMigration);
+const repeatResult = context._tmMigrateCoreStableIds(first);
+ok(repeatResult.total === 0 && JSON.stringify(first._stableIdMigration) === receiptBeforeRepeat,
+  'repeating the migration is idempotent and does not inflate its receipt');
+
+let validationError = null;
+try {
+  context._tmValidateUniqueStableIds('人物', first.chars);
+  context._tmValidateUniqueStableIds('行政区划', context._tmCollectAdminDivisionEntries(first).map(entry => entry.item));
+} catch (error) {
+  validationError = error;
+}
+ok(validationError === null, 'migrated entities pass strict stable-ID validation');
+
+let missingError = null;
+try { context._tmValidateUniqueStableIds('人物', [{ name: '无编号' }]); } catch (error) { missingError = error; }
+ok(!!missingError && /缺少稳定 id/.test(missingError.message), 'validation rejects a core entity with no ID');
+
+let duplicateError = null;
+try { context._tmValidateUniqueStableIds('人物', [{ id: 'same' }, { id: 'same' }]); } catch (error) { duplicateError = error; }
+ok(!!duplicateError && /重复 id/.test(duplicateError.message), 'validation rejects duplicate stable IDs');
+
+ok(/function _ensureGMDefaults\(GM, P\)[\s\S]*?_tmEnsureTimelineIdentity\(GM\);[\s\S]*?_tmMigrateCoreStableIds\(GM\);/.test(lifecycle),
+  'load defaults run deterministic ID migration before world validation');
+
+console.log('\n[smoke-stable-id-migration] ' + pass + ' passed / ' + fail + ' failed');
+process.exit(fail ? 1 : 0);

--- a/web/tm-endturn-systems.js
+++ b/web/tm-endturn-systems.js
@@ -78,7 +78,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
   // 6.015 户口前移（方案联动总表推荐：腐败→户口→帑廪→内帑→民心→皇权→皇威）
   try {
     if (typeof HujiEngine !== 'undefined') {
-      HujiEngine.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
+      HujiEngine.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio, strict: true });
     }
   } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HujiEngine(early) 失败:') : console.error('[endTurn] HujiEngine(early) 失败:', e); throw e; }
   try {
@@ -190,7 +190,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
   // 6.07 户口系统（已在 6.015 早跑，跳过）
   if (!GM._hujiEarlyTicked) try {
     if (typeof HujiEngine !== 'undefined') {
-      HujiEngine.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
+      HujiEngine.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio, strict: true });
     }
   } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HujiEngine.tick 失败:') : console.error('[endTurn] HujiEngine.tick 失败:', e); throw e; }
 

--- a/web/tm-huji-engine.js
+++ b/web/tm-huji-engine.js
@@ -452,10 +452,17 @@
     var P = global.GM.population;
     if (!P) return;
     _ensureDeepDemographics(P);
-    // S1·人口自下而上(P.conf.populationBottomUpEnabled·默认关)：增长发生在叶·按本地民心·写叶 populationDetail·
-    // national 增量同步、maintain(bridge:377) 之后从 Σ叶 精确重建。详设 docs/population-bottom-up-redesign-2026-06.md
-    if (global.P && global.P.conf && global.P.conf.populationBottomUpEnabled) {
-      return _tickPopulationLeafGrowth(ctx, mr);
+    // 行政区叶子是人口运行态的唯一真值。无论是否启用“自下而上”细算，
+    // 只要叶级户口存在，都必须在叶子上推进；否则先改 national/byRegion，
+    // 随后的 runtime bridge 又从未变化的叶子重建全国账，会把本次增长抹掉。
+    // 选项只决定是否采用地方民心/粮食/灾异修正，不再决定写入哪套账。
+    var leaves = _allLeafDivisions(global.GM);
+    var hasLeafPopulation = leaves.some(function(leaf) {
+      return !!(leaf && leaf.populationDetail && Number(leaf.populationDetail.mouths) > 0);
+    });
+    if (hasLeafPopulation) {
+      var useLocalFactors = !!(global.P && global.P.conf && global.P.conf.populationBottomUpEnabled);
+      return _tickPopulationLeafGrowth(ctx, mr, useLocalFactors, leaves);
     }
     var d = P.dynamics;
     // 年景因子
@@ -472,15 +479,18 @@
     if (war > 0) deathRate += Math.min(0.03, war * 0.01);
     if (environmentLoad > 1.2) deathRate += (environmentLoad - 1.2) * 0.02;
     // 年度净增长 → 月度化
-    var births = Math.round(P.national.mouths * birthRate * mr / 12);
-    var deaths = Math.round(P.national.mouths * deathRate * mr / 12);
+    var oldMouths = Number(P.national.mouths) || 0;
+    var oldHouseholds = Number(P.national.households) || 0;
+    var oldDing = Number(P.national.ding) || 0;
+    var dingRatio = oldDing / Math.max(1, oldMouths);
+    var mphh = oldMouths / Math.max(1, oldHouseholds);
+    var births = Math.round(oldMouths * birthRate * mr / 12);
+    var deaths = Math.round(oldMouths * deathRate * mr / 12);
     var net = births - deaths;
-    P.national.mouths = Math.max(100000, P.national.mouths + net);
+    P.national.mouths = Math.max(100000, oldMouths + net);
     // 丁同比变化
-    var dingRatio = P.national.ding / Math.max(1, P.national.mouths);
     P.national.ding = Math.round(P.national.mouths * dingRatio);
     // 户同比变化
-    var mphh = P.national.mouths / Math.max(1, P.national.households);
     P.national.households = Math.round(P.national.mouths / mphh);
     // 按区域分配同比
     Object.keys(P.byRegion || {}).forEach(function(rid) {
@@ -508,7 +518,12 @@
       d._yearlyAccumBirths = 0;
       d._yearlyAccumDeaths = 0;
     }
-    d.lastYearNet = net * 12;
+    d.lastYearNet = _annualizePopulationNet(net, mr);
+  }
+
+  function _annualizePopulationNet(net, monthRatio) {
+    var mr = Number(monthRatio);
+    return mr > 0 && isFinite(mr) ? net * 12 / mr : net * 12;
   }
 
   // S1-S4·人口自下而上 取叶(2026-06-20 真机修)：getLeafDivisions(ah) 默认只取 'player' faction
@@ -528,7 +543,28 @@
 
   // S1·人口自下而上：叶级增长(先只接本地民心)·写叶 populationDetail·national = Σ叶 增量同步。
   // 详设 docs/population-bottom-up-redesign-2026-06.md §2.1-2.2。S2 再接粮食供需/生活/赋役，S3 调粮。
-  function _tickPopulationLeafGrowth(ctx, mr) {
+  function _syncLeafPopulationMirrors(leaf, detail) {
+    if (!leaf || !detail) return;
+    if (typeof leaf.population === 'number') {
+      leaf.population = detail.mouths;
+    } else if (leaf.population && typeof leaf.population === 'object' && leaf.population !== detail) {
+      leaf.population.mouths = detail.mouths;
+      leaf.population.households = detail.households;
+      leaf.population.ding = detail.ding;
+    }
+    var env = leaf.environment && typeof leaf.environment === 'object' ? leaf.environment : null;
+    var carrying = leaf.carryingCapacity;
+    var cap = Number(env && env.carrying) ||
+      Number(carrying && typeof carrying === 'object' && carrying.historicalCap) ||
+      (typeof carrying === 'number' ? Number(carrying) : 0);
+    if (cap > 0) {
+      var load = Math.max(0, Math.min(1.5, detail.mouths / cap));
+      if (env) env.currentLoad = load;
+      if (carrying && typeof carrying === 'object') carrying.currentLoad = load;
+    }
+  }
+
+  function _tickPopulationLeafGrowth(ctx, mr, useLocalFactors, suppliedLeaves) {
     var P = global.GM.population;
     var G = global.GM;
     var d = P.dynamics;
@@ -542,11 +578,11 @@
     if (disaster > 0.3) baseDeath += disaster * 0.05;
     if (war > 0) baseDeath += Math.min(0.03, war * 0.01);
     if (environmentLoad > 1.2) baseDeath += (environmentLoad - 1.2) * 0.02;
-    // 丁/户比例(叶级先共享全国比例·S2 视需叶级化)
+    // 全国比例仅作叶数据缺项时的 fallback；有叶级户丁账时保留各自历史结构。
     var dingRatio = P.national.ding / Math.max(1, P.national.mouths);
     var mphh = P.national.mouths / Math.max(1, P.national.households);
     // 遍历叶(2026-06-20 真机修：遍历所有 faction·非仅 player)·各叶按本地民心算生死·写叶 populationDetail
-    var leaves = _allLeafDivisions(G);
+    var leaves = suppliedLeaves || _allLeafDivisions(G);
     var totBirths = 0, totDeaths = 0, totNet = 0;
     leaves.forEach(function(leaf) {
       var pd = leaf && leaf.populationDetail;
@@ -571,21 +607,34 @@
       var rd = leaf.recentDisasters;
       var hasDis = Array.isArray(rd) ? rd.length > 0 : !!rd;
       var corvee = rg ? Math.max(0, Math.min(1, Number(rg.corveeRate) || 0)) : 0;
-      var localBirth = baseBirth
-        * (1 + (minxin - 50) / 100 * 0.4)                  // 民心高→生育↑
-        * (1 + lifeLv * 0.3)                               // 生活好→生育↑
-        * Math.max(0.3, Math.min(1.1, 1.1 - load * 0.3))   // 粮紧(load高)→生育↓
-        * (1 - corvee * 0.2);                              // 役重→生育↓
-      var localDeath = baseDeath
-        * (1 - (minxin - 50) / 100 * 0.25)                 // 民心高→死亡↓
-        * (1 + (hasDis ? 0.5 : 0))                         // 灾异→死亡↑
-        * (1 + Math.max(0, load - 1) * 0.6);               // 缺粮(load>1)→饥荒死亡↑
+      var localBirth = baseBirth;
+      var localDeath = baseDeath;
+      if (useLocalFactors) {
+        localBirth = baseBirth
+          * (1 + (minxin - 50) / 100 * 0.4)                  // 民心高→生育↑
+          * (1 + lifeLv * 0.3)                               // 生活好→生育↑
+          * Math.max(0.3, Math.min(1.1, 1.1 - load * 0.3))   // 粮紧(load高)→生育↓
+          * (1 - corvee * 0.2);                              // 役重→生育↓
+        localDeath = baseDeath
+          * (1 - (minxin - 50) / 100 * 0.25)                 // 民心高→死亡↓
+          * (1 + (hasDis ? 0.5 : 0))                         // 灾异→死亡↑
+          * (1 + Math.max(0, load - 1) * 0.6);               // 缺粮(load>1)→饥荒死亡↑
+      }
       var births = Math.round(mouths * localBirth * mr / 12);
       var deaths = Math.round(mouths * localDeath * mr / 12);
       var net = births - deaths;
+      var leafDingRatio = Number(pd.ding) > 0 ? Number(pd.ding) / mouths : dingRatio;
+      var leafMouthsPerHousehold = Number(pd.households) > 0 ? mouths / Number(pd.households) : mphh;
       pd.mouths = Math.max(0, mouths + net);                         // 写叶(增长落点)
-      pd.households = Math.round(pd.mouths / mphh);
-      pd.ding = Math.round(pd.mouths * dingRatio);
+      pd.households = Math.round(pd.mouths / Math.max(1, leafMouthsPerHousehold));
+      pd.ding = Math.round(pd.mouths * leafDingRatio);
+      _syncLeafPopulationMirrors(leaf, pd);
+      var legacyRow = P.byRegion && (P.byRegion[rid] || (leaf.name ? P.byRegion[leaf.name] : null));
+      if (legacyRow && legacyRow !== pd) {
+        legacyRow.mouths = pd.mouths;
+        legacyRow.households = pd.households;
+        legacyRow.ding = pd.ding;
+      }
       leaf.yearlyBirths = (leaf.yearlyBirths || 0) + births;
       leaf.yearlyDeaths = (leaf.yearlyDeaths || 0) + deaths;
       totBirths += births; totDeaths += deaths; totNet += net;
@@ -611,7 +660,7 @@
       d._yearlyAccumBirths = 0;
       d._yearlyAccumDeaths = 0;
     }
-    d.lastYearNet = totNet * 12;
+    d.lastYearNet = _annualizePopulationNet(totNet, mr);
   }
 
   function _deepFieldDiversityPressure(r) {
@@ -1039,14 +1088,27 @@
       var sc = (typeof global.findScenarioById === 'function') ? global.findScenarioById(global.GM.sid) : null;
       init(sc);
     }
-    var mr = ctx.monthRatio || 1;
-    try { _tickPopulationDynamics(ctx, mr); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'huji] dynamics:') : console.error('[huji] dynamics:', e); }
-    try { _tickDeepFieldLinkages(ctx, mr); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'huji] deepFields:') : console.error('[huji] deepFields:', e); }
-    try { _tickCorvee(ctx, mr); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'huji] corvee:') : console.error('[huji] corvee:', e); }
-    try { _tickLargeCorvee(ctx, mr); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'huji] largeCorvee:') : console.error('[huji] largeCorvee:', e); }
-    try { _tickMilitary(ctx, mr); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'huji] military:') : console.error('[huji] military:', e); }
-    try { _tickMigration(ctx, mr); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'huji] migration:') : console.error('[huji] migration:', e); }
-    try { _tickRegistration(ctx); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'huji] registration:') : console.error('[huji] registration:', e); }
+    var rawMr = Number(ctx.monthRatio);
+    var mr = rawMr > 0 && isFinite(rawMr) ? rawMr : 1;
+    var strict = ctx.strict === true;
+    var failures = [];
+    function runStep(label, fn) {
+      try {
+        fn();
+      } catch(e) {
+        (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'huji] ' + label + ':') : console.error('[huji] ' + label + ':', e);
+        if (strict) throw e;
+        failures.push({ step: label, error: String(e && e.message || e) });
+      }
+    }
+    runStep('dynamics', function() { _tickPopulationDynamics(ctx, mr); });
+    runStep('deepFields', function() { _tickDeepFieldLinkages(ctx, mr); });
+    runStep('corvee', function() { _tickCorvee(ctx, mr); });
+    runStep('largeCorvee', function() { _tickLargeCorvee(ctx, mr); });
+    runStep('military', function() { _tickMilitary(ctx, mr); });
+    runStep('migration', function() { _tickMigration(ctx, mr); });
+    runStep('registration', function() { _tickRegistration(ctx); });
+    return { ok: failures.length === 0, failures: failures };
   }
 
   // ═══════════════════════════════════════════════════════════════════

--- a/web/tm-integration-bridge.js
+++ b/web/tm-integration-bridge.js
@@ -401,20 +401,24 @@
   }
 
   function _updateLegacyProxies(G) {
-    // 为旧代码兼容，把 byRegion 对象定义为 division 的代理
+    // 为旧代码兼容，把 byRegion 对象重建为当前 division 的代理。
+    // 必须每次构造新表并原子替换；在旧对象上增量写会让已删除、合并或改 ID
+    // 的区划继续作为“幽灵地区”参与后续户籍与财政结算。
     var topLevel = getTopLevelDivisions(G.adminHierarchy, 'player');
     if (!G.population) G.population = {};
-    if (!G.population.byRegion) G.population.byRegion = {};
     if (!G.minxin) G.minxin = {};
-    if (!G.minxin.byRegion) G.minxin.byRegion = {};
     if (!G.fiscal) G.fiscal = {};
-    if (!G.fiscal.regions) G.fiscal.regions = {};
     if (!G.environment) G.environment = {};
-    if (!G.environment.byRegion) G.environment.byRegion = {};
+    var nextPopulation = {};
+    var nextMinxin = {};
+    var nextFiscal = {};
+    var nextEnvironment = {};
+    var nextRegionMap = {};
 
     topLevel.forEach(function(div) {
+      var id = String(div.id);
       // byRegion.<id> 指向 division
-      G.population.byRegion[div.id] = div.population;
+      nextPopulation[id] = div.population;
       // minxin byRegion 必须包含 .index（热力图读此字段）
       if (div.minxinDetails) {
         if (div.minxinDetails.index === undefined) {
@@ -424,62 +428,22 @@
         var initialMx = _bridgeFiniteNumber(div.minxin, _bridgeFiniteNumber(div.minxinLocal, 60));
         div.minxinDetails = { index: initialMx, trueIndex: initialMx, perceivedIndex: initialMx, trend: 'stable' };
       }
-      G.minxin.byRegion[div.id] = div.minxinDetails;
-      G.fiscal.regions[div.id] = div.fiscal;
-      G.environment.byRegion[div.id] = div.environment;
+      nextMinxin[id] = div.minxinDetails;
+      nextFiscal[id] = div.fiscal;
+      nextEnvironment[id] = div.environment;
+      nextRegionMap[id] = div;
     });
 
-    // regionMap（公库绑定解析用）
-    if (!G.regionMap) G.regionMap = {};
-    topLevel.forEach(function(div) { G.regionMap[div.id] = div; });
+    G.population.byRegion = nextPopulation;
+    G.minxin.byRegion = nextMinxin;
+    G.fiscal.regions = nextFiscal;
+    G.environment.byRegion = nextEnvironment;
+    G.regionMap = nextRegionMap; // 公库绑定解析用
   }
 
   // ═══════════════════════════════════════════════════════════════════
   //  聚合：各区划 → 七变量
   // ═══════════════════════════════════════════════════════════════════
-
-  // NPC 腐败传导：按职位归部门，按私产/integrity 反推
-  function _accumulateCorruptionFromNpcs(G) {
-    if (!Array.isArray(G.chars)) return;
-    var buckets = { central:[], provincial:[], county:[], military:[], palace:[], technical:[] };
-    G.chars.forEach(function(c) {
-      if (!c || c.alive === false || !c.officialTitle) return;
-      var title = c.officialTitle;
-      var dept;
-      if (/节度|布政|巡抚|总督|观察/.test(title)) dept = 'provincial';
-      else if (/知府|知州|通判/.test(title)) dept = 'provincial';
-      else if (/知县|县令|县丞|主簿/.test(title)) dept = 'county';
-      else if (/将军|都督|提督|总兵|副将|参将|游击|守备/.test(title)) dept = 'military';
-      else if (/内.*(监|府|侍)|大内|奉宸|御前|掌印/.test(title)) dept = 'palace';
-      else if (/翰林|钦天|太医|司天|太史|学士/.test(title)) dept = 'technical';
-      else dept = 'central';
-      if (buckets[dept]) buckets[dept].push(c);
-    });
-    // 每部门根据成员 integrity 反推：低 integrity + 高私产 = 腐败 +
-    Object.keys(buckets).forEach(function(d) {
-      var arr = buckets[d];
-      if (arr.length === 0) return;
-      var sumDelta = 0;
-      arr.forEach(function(c) {
-        var integ = c.integrity != null ? c.integrity : 50;
-        var wealthScore = c.resources && c.resources.private ? ((c.resources.private.money||0) / 100000) : 0;
-        // integrity 50 为中位，+1 偏离 → +1 腐败
-        sumDelta += (50 - integ) * 0.02 + Math.min(5, wealthScore) * 0.4;
-      });
-      var avgDelta = sumDelta / arr.length;
-      var current = G.corruption.byDept[d];
-      current = typeof current === 'object'
-        ? (typeof current.true === 'number' ? current.true : (typeof current.overall === 'number' ? current.overall : 30))
-        : (typeof current === 'number' ? current : 30);
-      // 缓慢朝目标靠拢（0.05/tick）
-      var next = Math.max(0, Math.min(100, current + avgDelta * 0.05));
-      G.corruption.byDept[d] = next;
-      if (!G.corruption.subDepts) G.corruption.subDepts = {};
-      var subDept = { palace: 'imperial' }[d] || d;
-      if (!G.corruption.subDepts[subDept]) G.corruption.subDepts[subDept] = {};
-      G.corruption.subDepts[subDept].true = next;
-    });
-  }
 
   // 父节点数据 = 子叶之和（递归）——"父 >= 子之和"约束在实践中退化为等号
   function _reconcileParentToChildren(nodes) {
@@ -550,69 +514,14 @@
     });
   }
 
-  // 人口自然增长（每回合月度漂移；战争/瘟疫/灾荒由 AI 叠加）
-  // 2026-07-03 三重错位根治：旧版①只扫顶层一层不递归——嵌套树增的是省父节点，
-  // 随后 _reconcileParentToChildren 把父=Σ子(未增长)覆盖回去→增长被抹平；
-  // ②只写 div.population 而 aggregate 优先读 div.populationDetail→全国总数不动；
-  // ③households/ding 按 5/0.25 硬比率重算·抹掉剧本自设户丁结构。
-  // 修：递归到叶(无 children 才施增)·population 与 populationDetail 双账同写·
-  // 户/丁按本叶既有数等比缩放；顺带按人口/承载重算 environment.currentLoad(活承载·旧版恒静)。
-  function _naturalPopulationGrowth() {
-    var G = global.GM;
-    if (!G || !G.adminHierarchy) return;
-    function growLeaf(div) {
-      if (!div) return;
-      var kids = div.children || div.divisions;
-      if (kids && kids.length) { kids.forEach(growLeaf); return; }
-      var pop = (div.population && typeof div.population === 'object') ? div.population : null;
-      var pd = (div.populationDetail && typeof div.populationDetail === 'object') ? div.populationDetail : null;
-      var mouths = (pd && pd.mouths > 0) ? pd.mouths : (pop && pop.mouths > 0 ? pop.mouths : 0);
-      if (!(mouths > 0)) return;
-      var base = 0.0008;  // 0.08% / 月（年 ~1%）
-      var mx = _bridgeFiniteNumber(div.minxin, _bridgeFiniteNumber(div.minxinLocal, 60));
-      var cr = (typeof div.corruption === 'number') ? div.corruption : 30;
-      var load = div.environment && typeof div.environment.currentLoad === 'number' ? div.environment.currentLoad : 0.5;
-      // 民心高 +0.0004，腐败高 -0.0003，负载 >0.9 -0.0005
-      var adj = (mx - 50) / 100 * 0.0004 - (cr - 30) / 100 * 0.0003 - (load > 0.9 ? 0.0005 : 0);
-      var rate = Math.max(-0.003, Math.min(0.003, base + adj));
-      [pop, pd].forEach(function (acc) {
-        if (!acc || !(acc.mouths > 0)) return;
-        acc.mouths = Math.max(0, acc.mouths + Math.round(acc.mouths * rate));
-        if (acc.households > 0) acc.households = Math.max(0, acc.households + Math.round(acc.households * rate));
-        if (acc.ding > 0) acc.ding = Math.max(0, acc.ding + Math.round(acc.ding * rate));
-      });
-      // 活承载：负载随人口重算·容量以 environment.carrying / 历史上限为准·无账不动
-      var cc = (div.carryingCapacity && typeof div.carryingCapacity === 'object') ? div.carryingCapacity : null;
-      var cap = Number(div.environment && div.environment.carrying) || Number(cc && cc.historicalCap) || 0;
-      if (cap > 0 && div.environment && typeof div.environment === 'object') {
-        var mNow = (pd && pd.mouths > 0) ? pd.mouths : (pop ? pop.mouths : 0);
-        div.environment.currentLoad = Math.max(0, Math.min(1.5, mNow / cap));
-      }
-    }
-    Object.keys(G.adminHierarchy).forEach(function(fk) {
-      var divs = G.adminHierarchy[fk] && G.adminHierarchy[fk].divisions || [];
-      divs.forEach(growLeaf);
-    });
-  }
-
   function aggregateRegionsToVariables(options) {
     options = options || {};
     var strict = options.strict === true;
-    // 聚合/重绑定必须是幂等操作。只有每回合唯一的 tick() 才能推进人口与
-    // NPC 腐败；读档、首局初始化、UI 刷新和 AI 前后的派生汇总一律不得
-    // 偷走一个“时间步”。旧实现把 strict（错误传播）误当成了模拟开关，
-    // 导致每次读档都增长人口并改变腐败。
-    var advanceSimulation = options.advanceSimulation === true;
+    // 融合桥只做幂等 schema/代理/派生汇总。人口时间推进唯一归 HujiEngine，
+    // 腐败时间推进唯一归 CorruptionEngine；否则同一回合会出现双生产者，且
+    // 融合桥旧固定步长还会无视 daysPerTurn。
     var G = global.GM;
     if (!G) return;
-
-    // 0. 人口自然漂移（在汇总之前）
-    if (advanceSimulation) {
-      try { _naturalPopulationGrowth(); } catch(_e) {
-        (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_e, 'bridge] natPopGrowth') : console.warn('[bridge] natPopGrowth', _e);
-        if (strict) throw _e;
-      }
-    }
 
     var topLevel = getTopLevelDivisions(G.adminHierarchy, 'player');
     if (topLevel.length === 0) return;
@@ -717,11 +626,6 @@
         if (G.corruption.byDept.military === undefined)  G.corruption.byDept.military  = Math.round(avgProvCorr * 0.95);
         if (G.corruption.byDept.palace === undefined)    G.corruption.byDept.palace    = Math.round(avgProvCorr * 1.10);
         if (G.corruption.byDept.technical === undefined) G.corruption.byDept.technical = Math.round(avgProvCorr * 0.55);
-        // 按 NPC 派系/私产向上推高技术官外各部门（每周期）。派生汇总只读
-        // 现值；时间传导只允许 tick() 明确开启。
-        if (advanceSimulation) {
-          try { _accumulateCorruptionFromNpcs(G); } catch(_e) { if (strict) throw _e; }
-        }
         // overall = 6 部门平均
         var deptSum = 0, deptCnt = 0;
         Object.keys(G.corruption.byDept || {}).forEach(function(d) {
@@ -802,6 +706,7 @@
       (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(_syncPhaseE, 'bridge] syncAuthorityPhases') : console.error('[bridge] syncAuthorityPhases', _syncPhaseE);
       if (strict) throw _syncPhaseE;
     }
+    _updateLegacyProxies(G);
   }
 
   // ═══════════════════════════════════════════════════════════════════
@@ -839,7 +744,7 @@
     // 的兼容调用才允许记录后降级。
     var strict = options.strict !== false;
     try {
-      return aggregateRegionsToVariables({ strict: strict, advanceSimulation: true });
+      return aggregateRegionsToVariables({ strict: strict });
     } catch(e) {
       (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'bridge] aggregate:') : console.error('[bridge] aggregate:', e);
       if (strict) throw e;
@@ -851,12 +756,12 @@
     options = options || {};
     if (options.strict === true) {
       initializeFromLegacy();
-      aggregateRegionsToVariables({ strict: true, advanceSimulation: false });
+      aggregateRegionsToVariables({ strict: true });
       return true;
     }
     try { initializeFromLegacy(); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'bridge] init:') : console.error('[bridge] init:', e); }
     // 首次聚合/读档重绑定只对齐 schema、代理与派生汇总，不推进玩法时间。
-    try { aggregateRegionsToVariables({ advanceSimulation: false }); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-integration-bridge');}catch(_){}}
+    try { aggregateRegionsToVariables({ strict: false }); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-integration-bridge');}catch(_){}}
     return true;
   }
 

--- a/web/tm-save-lifecycle.js
+++ b/web/tm-save-lifecycle.js
@@ -120,6 +120,7 @@ function _ensureGMDefaults(GM, P) {
   if (!GM) return;
   _tmEnsureCampaignId(GM);
   _tmEnsureTimelineIdentity(GM);
+  _tmMigrateCoreStableIds(GM);
   if (!GM.shijiHistory) GM.shijiHistory = [];
   if (!GM.allCharacters) GM.allCharacters = [];
   if (!GM.classes) GM.classes = [];
@@ -1115,12 +1116,153 @@ function _tmRebindRuntimeWorld(options) {
   return true;
 }
 
+function _tmStableIdMissing(value) {
+  return value === undefined || value === null || (typeof value === 'string' && value.trim() === '');
+}
+
+function _tmStableIdHash(text) {
+  var hash = 2166136261;
+  text = String(text || '');
+  for (var i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i);
+    hash = typeof Math.imul === 'function' ? Math.imul(hash, 16777619) : hash * 16777619;
+  }
+  return ('00000000' + (hash >>> 0).toString(16)).slice(-8);
+}
+
+function _tmCollectAdminDivisionEntries(targetGM) {
+  var out = [];
+  var hierarchy = targetGM && targetGM.adminHierarchy;
+  if (!hierarchy || typeof hierarchy !== 'object') return out;
+  var visited = typeof WeakSet === 'function' ? new WeakSet() : null;
+  function walk(nodes, path) {
+    (Array.isArray(nodes) ? nodes : []).forEach(function(node, index) {
+      if (!node || typeof node !== 'object') return;
+      if (visited) {
+        if (visited.has(node)) return;
+        visited.add(node);
+      }
+      var nodePath = path + '/' + index;
+      out.push({ item: node, path: nodePath });
+      walk(node.children || node.divisions || node.subdivisions || [], nodePath);
+    });
+  }
+  Object.keys(hierarchy).sort().forEach(function(factionKey) {
+    var branch = hierarchy[factionKey];
+    walk(branch && branch.divisions, 'admin/' + factionKey);
+  });
+  return out;
+}
+
+function _tmAssignMissingStableIds(targetGM, kind, entries) {
+  entries = Array.isArray(entries) ? entries : [];
+  var used = Object.create(null);
+  entries.forEach(function(entry) {
+    var item = entry && entry.item;
+    if (!item || _tmStableIdMissing(item.id)) return;
+    used[String(item.id).trim()] = true;
+  });
+  var assigned = 0;
+  entries.forEach(function(entry, index) {
+    var item = entry && entry.item;
+    if (!item || !_tmStableIdMissing(item.id)) return;
+    var path = String(entry.path || index);
+    var seed = [
+      targetGM && (targetGM.sid || targetGM._campaignId) || '', kind, path,
+      item.sid || '', item.sourceId || '', item.key || '', item.name || '',
+      item.title || '', item.faction || '', item.owner || '', item.type || ''
+    ].join('|');
+    var base = 'tmlegacy_' + kind + '_' + _tmStableIdHash(seed) + _tmStableIdHash(seed.split('').reverse().join(''));
+    var candidate = base;
+    var suffix = 2;
+    while (used[candidate]) candidate = base + '_' + suffix++;
+    item.id = candidate; // arch-ok: 旧存档核心实体稳定 ID 的确定性 schema 迁移
+    used[candidate] = true;
+    assigned++;
+  });
+  return assigned;
+}
+
+function _tmUniqueEntityIdByName(list) {
+  var map = Object.create(null);
+  (Array.isArray(list) ? list : []).forEach(function(item) {
+    if (!item || _tmStableIdMissing(item.id) || !String(item.name || '').trim()) return;
+    var name = String(item.name).trim();
+    if (_tmHasOwn(map, name)) map[name] = null;
+    else map[name] = item.id;
+  });
+  return map;
+}
+
+function _tmBackfillStableForeignKeys(targetGM) {
+  var factionByName = _tmUniqueEntityIdByName(targetGM.facs);
+  var charByName = _tmUniqueEntityIdByName(targetGM.chars);
+  (targetGM.chars || []).forEach(function(ch) {
+    if (!ch || !_tmStableIdMissing(ch.factionId)) return;
+    var id = factionByName[String(ch.faction || '').trim()];
+    if (id != null) ch.factionId = id; // arch-ok: 旧名称外键迁移到稳定势力 ID
+  });
+  (targetGM.facs || []).forEach(function(fac) {
+    if (!fac || !_tmStableIdMissing(fac.leaderId)) return;
+    var id = charByName[String(fac.leader || '').trim()];
+    if (id != null) fac.leaderId = id; // arch-ok: 旧名称外键迁移到稳定人物 ID
+  });
+  (targetGM.armies || []).forEach(function(army) {
+    if (!army || !_tmStableIdMissing(army.commanderId)) return;
+    var commanderName = typeof army.commander === 'string' ? army.commander : (army.commanderName || army.general || army.leader || '');
+    var id = charByName[String(commanderName).trim()];
+    if (id != null) army.commanderId = id; // arch-ok: 旧主将名称迁移到稳定人物 ID
+  });
+  var regions = targetGM.mapData && targetGM.mapData.regions;
+  (Array.isArray(regions) ? regions : []).forEach(function(region) {
+    if (!region || !_tmStableIdMissing(region.factionId)) return;
+    var ownerName = region.currentOwner || region.owner || region.controller || region.factionName || region.ownerName || '';
+    var id = factionByName[String(ownerName).trim()];
+    if (id != null) region.factionId = id; // arch-ok: 旧地图归属名称迁移到稳定势力 ID
+  });
+}
+
+function _tmMigrateCoreStableIds(targetGM) {
+  if (!targetGM || typeof targetGM !== 'object') return { total: 0, byType: {} };
+  var groups = {
+    char: (targetGM.chars || []).map(function(item, index) { return { item: item, path: 'chars/' + index }; }),
+    faction: (targetGM.facs || []).map(function(item, index) { return { item: item, path: 'facs/' + index }; }),
+    army: (targetGM.armies || []).map(function(item, index) { return { item: item, path: 'armies/' + index }; }),
+    region: ((targetGM.mapData && targetGM.mapData.regions) || []).map(function(item, index) { return { item: item, path: 'mapData/regions/' + index }; }),
+    division: _tmCollectAdminDivisionEntries(targetGM)
+  };
+  var result = { total: 0, byType: {} };
+  Object.keys(groups).forEach(function(kind) {
+    var count = _tmAssignMissingStableIds(targetGM, kind, groups[kind]);
+    result.byType[kind] = count;
+    result.total += count;
+  });
+  _tmBackfillStableForeignKeys(targetGM);
+  if (result.total > 0) {
+    if (!targetGM._stableIdMigration || typeof targetGM._stableIdMigration !== 'object') {
+      targetGM._stableIdMigration = { version: 1, totalAssigned: 0, byType: {} }; // arch-ok: schema 迁移收据
+    }
+    targetGM._stableIdMigration.version = 1;
+    targetGM._stableIdMigration.totalAssigned = Number(targetGM._stableIdMigration.totalAssigned || 0) + result.total;
+    Object.keys(result.byType).forEach(function(kind) {
+      targetGM._stableIdMigration.byType[kind] = Number(targetGM._stableIdMigration.byType[kind] || 0) + result.byType[kind];
+    });
+  }
+  return result;
+}
+
 function _tmValidateUniqueStableIds(label, list) {
   if (!Array.isArray(list)) return;
   var seen = Object.create(null);
   list.forEach(function(item, index) {
-    if (!item || item.id === undefined || item.id === null || item.id === '') return;
-    var id = String(item.id);
+    if (!item || typeof item !== 'object' || Array.isArray(item)) throw new Error(label + ' 第 ' + index + ' 项不是合法对象');
+    if (_tmStableIdMissing(item.id)) throw new Error(label + ' 缺少稳定 id（索引 ' + index + '）');
+    var raw = item.id;
+    if (typeof raw !== 'string' && !(typeof raw === 'number' && Number.isSafeInteger(raw) && raw >= 0)) {
+      throw new Error(label + ' id 类型非法（索引 ' + index + '）');
+    }
+    var id = String(raw).trim();
+    if (!id || id.length > 256 || /[\u0000-\u001f\u007f]/.test(id)) throw new Error(label + ' id 格式非法（索引 ' + index + '）');
     if (seen[id] !== undefined) throw new Error(label + ' 存在重复 id: ' + id + '（索引 ' + seen[id] + ' / ' + index + '）');
     seen[id] = index;
   });
@@ -1171,6 +1313,7 @@ function _tmValidateLoadedWorld(targetP, targetGM) {
   _tmValidateUniqueStableIds('势力', targetGM.facs);
   _tmValidateUniqueStableIds('军队', targetGM.armies);
   _tmValidateUniqueStableIds('地图地区', targetGM.mapData && targetGM.mapData.regions);
+  _tmValidateUniqueStableIds('行政区划', _tmCollectAdminDivisionEntries(targetGM).map(function(entry) { return entry.item; }));
   _tmValidateFiniteWorldNumbers(targetP, 'P');
   _tmValidateFiniteWorldNumbers(targetGM, 'GM');
   return true;


### PR DESCRIPTION
## Summary

- make HujiEngine the sole population time authority; keep IntegrationBridge aggregation-only and rebuild legacy region proxies without ghost keys
- propagate every Huji substep failure to the existing end-turn transaction in strict mode; preserve household/ding ratios and annualize by monthRatio
- deterministically migrate missing stable IDs for characters, factions, armies, map regions, and nested administrative divisions, then reject missing/duplicate IDs
- parse large desktop project and autosave JSON in a worker thread and package the worker module
- refresh runtime cache stamps and the full-asset canonical hot baseline

## Verification

- `node web/scripts/ci-smokes.js`: PASS, 850 total / 848 direct / 2 existing missing-asset allowlist exemptions
- `node web/scripts/lint-arch-all.js`: PASS, 8/8
- `node web/scripts/verify-official-scenario-parity.js`: PASS, 27 assertions
- `node scripts/verify-release-contract.js`: PASS, 166 assertions
- `node web/scripts/verify-hot-builder-gates.js`: PASS, 27 assertions
- full-asset hot baseline: PASS, 1082 files with 412 untracked asset overlays
- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities
- 100 MB desktop save worker probe: parsed in about 0.8 s while event-loop heartbeats continued (maximum observed gap 96 ms)

No package, release, Pages deployment, or version bump is included.
