### PR TITLE
fix: close thirteenth-round audit population and identity gaps

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-20T18:11:27.726Z",
+  "generatedAt": "2026-08-21T06:40:39.570Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -2161,8 +2161,8 @@
     },
     {
       "path": "index.html",
-      "sha256": "97de890b0c389a8fe610494ef105adb8dadded4a60e63a4836f433895ba4d17b",
-      "size": 68621
+      "sha256": "c13a5ec36578cc38fb99151434d122335b785c071517c51f0462569aa80d15e9",
+      "size": 68641
     },
     {
       "path": "INDEX.md",
@@ -3821,8 +3821,8 @@
     },
     {
       "path": "tm-economy-engine.js",
-      "sha256": "85fd5d441364b0a429a244074aa35bd967a03c22f16c341ee41fd139a32aa2a3",
-      "size": 105881
+      "sha256": "7619e6a9c583cd6fb8188fe8cb56e079b316789f2e5edf86da97486ae98e569f",
+      "size": 106183
     },
     {
       "path": "tm-economy.js",
@@ -4016,8 +4016,8 @@
     },
     {
       "path": "tm-endturn-systems.js",
-      "sha256": "74a9de8fdf3d76054a6446cdea40d058366e8c5a68fc222f89a8ecf787c09f22",
-      "size": 39462
+      "sha256": "1cb854076f35146fda5f60c94b778c2852df8cd2e7fc3718e8d126b1fef38759",
+      "size": 39490
     },
     {
       "path": "tm-endturn-timing-ledger.js",
@@ -4261,8 +4261,8 @@
     },
     {
       "path": "tm-historical-presets.js",
-      "sha256": "f54439d222370d6fbaa6361ff1e31f09b8e147ec09895c6447634f1fcd197b2a",
-      "size": 45718
+      "sha256": "532d33cb203f8017c3441ac1e90bc7c83d2af100545080cea367c74fc69601b5",
+      "size": 46386
     },
     {
       "path": "tm-history-advisor.js",
@@ -4311,13 +4311,13 @@
     },
     {
       "path": "tm-huji-deep-fill.js",
-      "sha256": "f9ac6d5ec4328b9ccfcc100502ed15c2a85336b3fdc20dd44d66fe3aaa458034",
-      "size": 48854
+      "sha256": "1118a453d002547a12eb95bf415946cb3ed7f9cd9f040fca76aa9f2e904ee439",
+      "size": 49446
     },
     {
       "path": "tm-huji-engine.js",
-      "sha256": "84fdb7a00f7ad58173063c2d5fbe101a7e76f9552604cd509511b712ccd02049",
-      "size": 60871
+      "sha256": "9ed88151000358dd506800755239994d6324bd1941fd39d589e7b8e86a7eff68",
+      "size": 89733
     },
     {
       "path": "tm-huji-governance-loop.js",
@@ -4326,8 +4326,8 @@
     },
     {
       "path": "tm-huji-runtime-bridge.js",
-      "sha256": "b79fb12ae2b66473774d9b6982f7a78dbd088bceb230c79aa6d14795445b93b9",
-      "size": 57168
+      "sha256": "aecb7e09e3b0c29c21f83f0ae5001601a9e457043c10c53986c3e1208148d393",
+      "size": 58145
     },
     {
       "path": "tm-indices.js",
@@ -5036,8 +5036,8 @@
     },
     {
       "path": "tm-region-enrich.js",
-      "sha256": "9ad4ca93591e2d77faa3012d81578c989adffbb7ae5f3c32ee3c06fb896ec3be",
-      "size": 34188
+      "sha256": "e840a216e8f60842db266ca968c399e136e550968c2aca579fbc6a904cb0750e",
+      "size": 34535
     },
     {
       "path": "tm-region-magnate.js",
@@ -5096,8 +5096,8 @@
     },
     {
       "path": "tm-save-lifecycle.js",
-      "sha256": "168d51228342065452ce8c4f250a780d1032ca50921645a778fcafa0ba072e26",
-      "size": 133101
+      "sha256": "3da2cf564ffda2ec39a2fdbab51e96c3b3c2167be1183ac9e26b778dd39898fd",
+      "size": 142328
     },
     {
       "path": "tm-save-manager.js",

--- a/web/index.html
+++ b/web/index.html
@@ -654,7 +654,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-world-digest.js?v=20260630"></script><!-- 天下牵动·因果综述·W1a·把割裂的系统反应重组成连贯因果注入推演 -->
 <script src="tm-benji.js?v=20260707"></script><!-- 帝王本纪·终局回顾式修史(鼎革R1g·每12回合一卷串行修纂·flag benjiEnabled) -->
 <script src="tm-world-reactors.js?v=20260630"></script><!-- 世界反应总线·跨系统reactor·W2a军事→势力·flag-gated默认关 -->
-<script src="tm-endturn-systems.js?v=20260821-auditfix12"></script>
+<script src="tm-endturn-systems.js?v=20260821-auditfix13"></script>
 <script src="tm-endturn-ai-helpers.js?v=2026042714"></script>
 <script src="tm-endturn-ai-context.js?v=2026050401"></script>
 <script src="tm-history-events.js?v=20260719-histanchors"></script>
@@ -838,7 +838,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-bgm-config.js?v=2026051201"></script>
 <!-- R131 (2026-04-25) tm-audio-theme.js 拆分 → audio-theme + save-lifecycle + office-editor -->
 <script src="tm-audio-theme.js?v=20260710-fontscale"></script>
-<script src="tm-save-lifecycle.js?v=20260821-auditfix12"></script>
+<script src="tm-save-lifecycle.js?v=20260821-auditfix13"></script>
 <script src="tm-office-editor.js?v=20260707-nestflat2"></script>
 <script src="tm-topbar-vars.js?v=20260514-phase8-vars-2"></script>
 <!-- R137 (2026-04-25) 拆 shell-extras → shell UI + 时政面板 -->
@@ -872,13 +872,13 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-ceming.js?v=2026042817"></script>
 <script src="tm-char-economy-ui.js?v=2026042714"></script>
 <script src="tm-char-full-schema.js?v=2026042714"></script>
-<script src="tm-economy-engine-currency.js?v=20260706-splitsync"></script><!-- 立项拆分：§A CurrencyUnit+§B CurrencyEngine 两整IIFE·紧挨 economy-engine 之前保序·勿动位置 -->
-<script src="tm-economy-engine.js?v=20260706-splitsync"></script>
+<script src="tm-economy-engine-currency.js?v=20260821-auditfix13"></script><!-- 立项拆分：§A CurrencyUnit+§B CurrencyEngine 两整IIFE·紧挨 economy-engine 之前保序·勿动位置 -->
+<script src="tm-economy-engine.js?v=20260821-auditfix13"></script>
 <script src="tm-central-local-engine.js?v=20260709"></script>
-<script src="tm-huji-engine.js?v=20260821-auditfix12"></script>
+<script src="tm-huji-engine.js?v=20260821-auditfix13"></script>
 <script src="tm-edict-parser.js?v=20260709"></script>
-<script src="tm-huji-deep-fill.js?v=2026042714"></script>
-<script src="tm-huji-runtime-bridge.js?v=20260601-huji-runtime-bridge"></script>
+<script src="tm-huji-deep-fill.js?v=20260821-auditfix13"></script>
+<script src="tm-huji-runtime-bridge.js?v=20260821-auditfix13"></script>
 <script src="tm-huji-governance-loop.js?v=20260602-huji-governance-loop"></script>
 <script src="tm-edict-complete.js?v=2026050701"></script>
 <script src="tm-env-recovery-fill.js?v=20260709"></script>
@@ -898,9 +898,9 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-revolt-inference.js?v=20260721b"></script><!-- 批三·民变演绎层(AI主导)·起号立领袖subcall+逐回合行为subcall(打/占/分合/建国/招抚谈判)·宪法闸落账·AI缺席模板兜底 -->
 <script src="tm-party-inference.js?v=20260722"></script><!-- 批乙·党派/阶层演绎层(AI主导)·forgeIdentity立身份+tickInference逐回合党派行动(联名/清议/杯葛/结盟交恶/议程转向/倒阁/煽动阶层)·宪法闸落账·flag partyInferenceEnabled默认ON·AI缺席模板兜底 -->
 <script src="tm-captive-court.js?v=20260721"></script><!-- 批七·悬朝演绎层(北狩残局朝廷侧)·君被虏朝廷AI当一等演员(观望/监国/立新君)·归銮后复辟旨即夺门谋划·随revoltEntityEnabled -->
-<script src="tm-historical-presets.js?v=2026042816"></script>
+<script src="tm-historical-presets.js?v=20260821-auditfix13"></script>
 <script src="tm-prophecy.js?v=20260709"></script>
-<script src="tm-region-enrich.js?v=2026042714"></script>
+<script src="tm-region-enrich.js?v=20260821-auditfix13"></script>
 <script src="tm-audit.js?v=2026042714"></script>
 <script src="tm-feedback-loops.js?v=20260709"></script>
 <script src="tm-event-bus.js?v=2026050701"></script>

--- a/web/scripts/smoke-dikuai-systems.js
+++ b/web/scripts/smoke-dikuai-systems.js
@@ -81,7 +81,9 @@ console.log('— D2 · 叶级吏治连账(行为) —');
 console.log('— D1 · 人口三重错位根治(契约) —');
 var bridge = read('tm-integration-bridge.js');
 var huji = read('tm-huji-engine.js');
-ok(/function _allLeafDivisions\(G\)/.test(huji) && /IB\.getLeafDivisions\(ah, facId\)/.test(huji), '人口权威递归取得所有行政区叶子');
+ok(/function _walkAdminLeaves\(nodes, out, seen\)/.test(huji)
+  && /function _factionLeafGroups\(G\)/.test(huji)
+  && /_walkAdminLeaves\(roots, leaves, \[\]\)/.test(huji), '人口权威按 faction 递归取得行政区叶子');
 ok(/function _syncLeafPopulationMirrors\(leaf, detail\)/.test(huji)
   && /leaf\.population\.mouths = detail\.mouths/.test(huji), 'Huji 同步 population 与 populationDetail 双账');
 ok(/leafMouthsPerHousehold = Number\(pd\.households\) > 0 \? mouths \/ Number\(pd\.households\)/.test(huji)

--- a/web/scripts/smoke-faction-binding-lint.js
+++ b/web/scripts/smoke-faction-binding-lint.js
@@ -85,6 +85,9 @@ const ALLOW_LINES = [
   // It must not emit membership-change events while an old world is still detached during load.
   { file: 'tm-save-lifecycle.js', match: /ch\.factionId\s*=\s*id/ },
   { file: 'tm-save-lifecycle.js', match: /region\.factionId\s*=\s*id/ },
+  // tm-huji-engine.js: worldPopulationSummary entry is a read-model label,
+  // not a character/army/province membership mutation.
+  { file: 'tm-huji-engine.js', match: /entry\.factionId\s*=\s*group\.factionId/ },
   // tm-endturn-agent-mode.js·d 是维度标志对象(_activeDims)·d.faction=1 是「势力维度有活动」的开关位·非势力归属绑定
   { file: 'tm-endturn-agent-mode.js', match: /d\.faction\s*=\s*1/ },
   // tm-endturn-agent-write-tools.js·change 是工具 schema 透传对象·change.faction 传给 applyAIArmyChange·

--- a/web/scripts/smoke-pop-bottomup-s5.js
+++ b/web/scripts/smoke-pop-bottomup-s5.js
@@ -42,19 +42,28 @@ global.IntegrationBridge = {
 };
 
 function sigma() { return Rich.populationDetail.mouths + Poor.populationDetail.mouths + Fam.populationDetail.mouths + Cap.populationDetail.mouths; }
+function playerSigma() { return Rich.populationDetail.mouths + Cap.populationDetail.mouths; }
 var maxDrift = 0;
-for (var t = 1; t <= 12; t++) { GM.turn = t; HujiEngine.tick({ turn: t, monthRatio: 1, _monthRatio: 1 }); var dr = Math.abs(GM.population.national.mouths - sigma()); if (dr > maxDrift) maxDrift = dr; }
+var maxWorldDrift = 0;
+for (var t = 1; t <= 12; t++) {
+  GM.turn = t;
+  HujiEngine.tick({ turn: t, monthRatio: 1, _monthRatio: 1 });
+  var dr = Math.abs(GM.population.national.mouths - playerSigma());
+  var worldDr = Math.abs(GM.worldPopulationSummary.national.mouths - sigma());
+  if (dr > maxDrift) maxDrift = dr;
+  if (worldDr > maxWorldDrift) maxWorldDrift = worldDr;
+}
 var richNet = Rich.populationDetail.mouths - 400000;
 var poorNet = Poor.populationDetail.mouths - 400000; // NPC「军阀」faction
 var famNet = Fam.populationDetail.mouths - 300000;   // NPC「军阀」faction
 var capMig = Cap.yearlyNetMigration || 0;
-console.log('[S5·12回合·真实多faction] 富安(玩家)净=' + richNet + ' · 困苦(NPC军阀)净=' + poorNet + ' · 饥馑(NPC军阀)净=' + famNet + ' · 京师迁移=' + capMig + ' · 守恒漂移=' + maxDrift);
-var T1 = maxDrift <= 12;
+console.log('[S5·12回合·真实多faction] 富安(玩家)净=' + richNet + ' · 困苦(NPC军阀)净=' + poorNet + ' · 饥馑(NPC军阀)净=' + famNet + ' · 京师迁移=' + capMig + ' · 玩家漂移=' + maxDrift + ' · 世界漂移=' + maxWorldDrift);
+var T1 = maxDrift <= 12 && maxWorldDrift <= 12;
 var T2 = richNet > poorNet && poorNet > famNet;
 var T3 = famNet < 0;
 var T4 = capMig > 0;
 var T5 = (poorNet !== 0 && famNet !== 0); // 关键：NPC「军阀」faction 地块也被处理(取叶修复·非只玩家)
-console.log('  [S5a] 守恒不漂移：' + (T1 ? 'OK' : 'FAIL'));
+console.log('  [S5a] 玩家 national 与世界 summary 分口径守恒：' + (T1 ? 'OK' : 'FAIL'));
 console.log('  [S5b] 地方分化(富>困>饥)：' + (T2 ? 'OK' : 'FAIL'));
 console.log('  [S5c] 饥馑饥荒净减：' + (T3 ? 'OK' : 'FAIL'));
 console.log('  [S5d] 京师虹吸流入：' + (T4 ? 'OK' : 'FAIL'));

--- a/web/scripts/smoke-population-faction-ledger.js
+++ b/web/scripts/smoke-population-faction-ledger.js
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.resolve(__dirname, '..');
+const hujiSource = fs.readFileSync(path.join(ROOT, 'tm-huji-engine.js'), 'utf8');
+const deepSource = fs.readFileSync(path.join(ROOT, 'tm-huji-deep-fill.js'), 'utf8');
+const runtimeBridgeSource = fs.readFileSync(path.join(ROOT, 'tm-huji-runtime-bridge.js'), 'utf8');
+const economySource = fs.readFileSync(path.join(ROOT, 'tm-economy-engine.js'), 'utf8');
+const historicalSource = fs.readFileSync(path.join(ROOT, 'tm-historical-presets.js'), 'utf8');
+const regionEnrichSource = fs.readFileSync(path.join(ROOT, 'tm-region-enrich.js'), 'utf8');
+
+let pass = 0;
+let fail = 0;
+function ok(condition, message) {
+  if (condition) { pass++; console.log('  PASS - ' + message); }
+  else { fail++; console.error('  FAIL - ' + message); }
+}
+function clone(value) { return JSON.parse(JSON.stringify(value)); }
+function makeLeaf(id, name, mouths, capital) {
+  return {
+    id, name, regionType: capital ? 'capital' : 'prefecture', minxin: 50, prosperity: 50,
+    population: { mouths, households: Math.round(mouths / 5), ding: Math.round(mouths * 0.3) },
+    populationDetail: { mouths, households: Math.round(mouths / 5), ding: Math.round(mouths * 0.3) },
+    environment: { carrying: mouths * 2, currentLoad: 0.5 }
+  };
+}
+function totals(leaves) {
+  return leaves.reduce((out, leaf) => {
+    out.mouths += leaf.populationDetail.mouths;
+    out.households += leaf.populationDetail.households;
+    out.ding += leaf.populationDetail.ding;
+    return out;
+  }, { mouths: 0, households: 0, ding: 0 });
+}
+
+function makeRuntime(options = {}) {
+  const math = Object.create(Math);
+  math.random = options.random || (() => 0.9);
+  const playerLeaves = [makeLeaf('player-capital', '京城', 600000, true), makeLeaf('player-south', '江南', 400000, false)];
+  const npcLeaves = [makeLeaf('npc-capital', '沈阳', 3000000, true), makeLeaf('npc-north', '辽北', 2000000, false)];
+  const context = {
+    console, Math: math, Date, JSON, RegExp, Error,
+    Array, Object, String, Number, Boolean, parseInt, parseFloat, isNaN, isFinite,
+    setTimeout() { return 1; }, clearTimeout() {}, addEB() {}, toast() {},
+    P: {
+      id: 'faction-ledger', dynasty: '明', time: { year: options.year || 1627 },
+      conf: { populationBottomUpEnabled: false },
+      populationConfig: {
+        initial: { nationalHouseholds: 200000, nationalMouths: 1000000, nationalDing: 300000 },
+        corveeRules: { annualCorveeDays: 30 }
+      },
+      playerInfo: { factionName: '玩家朝廷', capital: '京城' }
+    },
+    GM: {
+      sid: 'faction-ledger', turn: options.turn || 1, year: options.year || 1627,
+      _campaignId: options.campaignId || 'campaign-a', _capital: '京城',
+      vars: { disasterLevel: 0 }, activeWars: [], chars: [],
+      guoku: { money: 100000000, grain: 100000000 },
+      minxin: { trueIndex: 50 }, huangquan: { index: 50 }, corruption: { trueIndex: 20 },
+      environment: { nationalLoad: 0.5, byRegion: {}, climatePhase: options.climate || 'normal' },
+      facs: [
+        { id: 'fac-player', name: '玩家朝廷', isPlayer: true, capital: '京城' },
+        { id: 'fac-npc', name: '后金', capital: '沈阳' }
+      ],
+      adminHierarchy: {
+        player: { factionId: 'fac-player', factionName: '玩家朝廷', divisions: playerLeaves },
+        npc: { factionId: 'fac-npc', factionName: '后金', divisions: npcLeaves }
+      }
+    },
+    turnsForMonths(months) {
+      const days = options.daysPerTurn || 30;
+      return Math.ceil(months * 30 / days);
+    },
+    _getDaysPerTurn() { return options.daysPerTurn || 30; },
+    calcDateFromTurn(turn) {
+      if (typeof options.dateForTurn === 'function') return options.dateForTurn(turn);
+      return { adYear: context.GM.year, year: context.GM.year };
+    },
+    FiscalEngine: { spendFromGuoku() { return true; }, addToGuoku() { return true; } },
+    TM: { errors: { capture() {}, captureSilent() {} } }
+  };
+  context.window = context;
+  context.global = context;
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(hujiSource, context, { filename: 'tm-huji-engine.js' });
+  vm.runInContext(deepSource, context, { filename: 'tm-huji-deep-fill.js' });
+  vm.runInContext(runtimeBridgeSource, context, { filename: 'tm-huji-runtime-bridge.js' });
+  context.HujiEngine.init(context.P);
+  context.GM.population.corvee.enabled = false;
+  context.GM.population.military.enabled = false;
+  context.GM.population.meta.registrationCycle = 1000;
+  context.HujiDeepFill.init();
+  return { context, playerLeaves, npcLeaves };
+}
+
+console.log('[smoke-population-faction-ledger]');
+
+{
+  const { context, playerLeaves, npcLeaves } = makeRuntime();
+  const playerBefore = totals(playerLeaves).mouths;
+  const npcBefore = totals(npcLeaves).mouths;
+  const expectedPlayerBirths = playerLeaves.reduce((sum, leaf) => sum + Math.round(leaf.populationDetail.mouths * 0.035 / 12), 0);
+  const expectedNpcBirths = npcLeaves.reduce((sum, leaf) => sum + Math.round(leaf.populationDetail.mouths * 0.035 / 12), 0);
+  const npcSourceBefore = npcLeaves[1].populationDetail.mouths;
+  const npcCapitalBefore = npcLeaves[0].populationDetail.mouths;
+  const npcSourceWithoutMigration = npcSourceBefore
+    + Math.round(npcSourceBefore * 0.035 / 12)
+    - Math.round(npcSourceBefore * 0.025 / 12);
+  const npcCapitalWithoutMigration = npcCapitalBefore
+    + Math.round(npcCapitalBefore * 0.035 / 12)
+    - Math.round(npcCapitalBefore * 0.025 / 12);
+  context.HujiEngine.tick({ turn: 1, monthRatio: 1, strict: true });
+  const playerAfter = totals(playerLeaves).mouths;
+  const npcAfter = totals(npcLeaves).mouths;
+  ok(context.GM.population.national.mouths === playerAfter, 'player national contains only player faction leaves');
+  ok(context.GM.population.dynamics._yearlyAccumBirths === expectedPlayerBirths,
+    'player birth ledger excludes NPC births');
+  ok(context.GM.worldPopulationSummary.byFaction.npc.dynamics._yearlyAccumBirths === expectedNpcBirths,
+    'NPC births are retained in a separate faction ledger');
+  ok(context.GM.worldPopulationSummary.byFaction.npc.national.mouths === npcAfter
+    && context.GM.worldPopulationSummary.national.mouths === playerAfter + npcAfter,
+    'world summary is separate from player national while preserving every faction');
+  ok(npcLeaves[1].populationDetail.mouths < npcSourceWithoutMigration
+    && npcLeaves[0].populationDetail.mouths > npcCapitalWithoutMigration,
+    'NPC capital pull stays inside the NPC faction');
+  ok(playerAfter - playerBefore < npcAfter - npcBefore,
+    'larger NPC population growth does not leak into the player national total');
+}
+
+{
+  const { context, playerLeaves, npcLeaves } = makeRuntime();
+  const npcBefore = totals(npcLeaves).mouths;
+  const playerBefore = totals(playerLeaves).mouths;
+  const result = context.HujiEngine.applyPopulationLoss({ cause: 'smoke-corvee', mouths: 8000, ding: 8000 });
+  context.TM.HujiRuntimeBridge.maintain(context.GM, { scenario: context.P, turn: 1 });
+  ok(result.ok && result.mouths === 8000, 'mortality ledger applies the requested player loss');
+  ok(totals(playerLeaves).mouths === playerBefore - 8000
+    && context.GM.population.national.mouths === playerBefore - 8000,
+    'leaf mortality survives RuntimeBridge national aggregation');
+  ok(totals(npcLeaves).mouths === npcBefore, 'player mortality never changes NPC leaves');
+}
+
+{
+  const { context, playerLeaves, npcLeaves } = makeRuntime();
+  const playerBefore = totals(playerLeaves).mouths;
+  const npcCapitalBefore = npcLeaves[0].populationDetail.mouths;
+  const npcRegionBefore = npcLeaves[1].populationDetail.mouths;
+  const playerDeathBefore = context.GM.population.dynamics._yearlyAccumDeaths || 0;
+  const result = context.HujiEngine.applyPopulationLoss({ cause:'smoke-npc-region', regionId:'npc-north', mouths:7000 });
+  ok(result.ok && result.factionId === 'fac-npc'
+    && npcLeaves[1].populationDetail.mouths === npcRegionBefore - 7000
+    && npcLeaves[0].populationDetail.mouths === npcCapitalBefore,
+  'region-targeted mortality changes only the matching faction leaf');
+  ok(totals(playerLeaves).mouths === playerBefore
+    && (context.GM.population.dynamics._yearlyAccumDeaths || 0) === playerDeathBefore,
+  'NPC mortality never enters the player national or death accumulator');
+  ok(context.GM.worldPopulationSummary.byFaction.npc.mortalityLedger.some(row => row.cause === 'smoke-npc-region'),
+    'NPC mortality is retained in the NPC faction ledger');
+}
+
+{
+  const { context, playerLeaves } = makeRuntime({ climate: 'little_ice_age' });
+  const before = totals(playerLeaves).mouths;
+  context.HujiDeepFill.tick({ turn: 2, monthRatio: 1, strict: true });
+  const afterDeep = totals(playerLeaves).mouths;
+  context.TM.HujiRuntimeBridge.maintain(context.GM, { scenario: context.P, turn: 2 });
+  ok(afterDeep < before && context.GM.population.national.mouths === afterDeep,
+    'little-ice-age mortality is written to leaves and survives aggregation');
+  const originalLoss = context.HujiEngine.applyPopulationLoss;
+  context.HujiEngine.applyPopulationLoss = () => { throw new Error('injected mortality-ledger failure'); };
+  let strictFailure = null;
+  try { context.HujiDeepFill.tick({ turn: 3, monthRatio: 1, strict: true }); }
+  catch (error) { strictFailure = error; }
+  context.HujiEngine.applyPopulationLoss = originalLoss;
+  ok(strictFailure && /mortality-ledger failure/.test(strictFailure.message),
+    'strict HujiDeepFill propagates mortality failures to the turn transaction');
+}
+
+{
+  const { context, playerLeaves } = makeRuntime({
+    year: 1200,
+    random: () => 0,
+    dateForTurn(turn) { return { adYear: turn >= 2 ? 1200 : 1199 }; }
+  });
+  const before = totals(playerLeaves).mouths;
+  context.HujiDeepFill.tick({ turn: 2, monthRatio: 1, strict: true });
+  const after = totals(playerLeaves).mouths;
+  context.TM.HujiRuntimeBridge.maintain(context.GM, { scenario: context.P, turn: 2 });
+  const plagueLoss = context.GM.population.mortalityLedger
+    .filter(row => row.cause === 'plague')
+    .reduce((sum, row) => sum + row.mouths, 0);
+  ok(plagueLoss > 0 && after === before - plagueLoss
+    && context.GM.population.national.mouths === after,
+  'plague deaths use the leaf ledger and cannot be erased by national aggregation');
+}
+
+{
+  const runtime = makeRuntime({ year: 1101, campaignId: 'campaign-a' });
+  const { context, playerLeaves } = runtime;
+  playerLeaves[0].name = '中原京城';
+  playerLeaves[1].name = '江南路';
+  context.GM._capital = '中原京城';
+  context.GM.facs[0].capital = '中原京城';
+  context.HujiEngine.tick({ turn: 1, monthRatio: 1, strict: true });
+  const countAfterFirst = context.GM.population.migrationEvents.filter(row => row.id === 'jingkang_nandu').length;
+  const saved = clone(context.GM);
+  context.GM = saved;
+  context.HujiEngine.tick({ turn: 2, monthRatio: 1, strict: true });
+  const countAfterReload = context.GM.population.migrationEvents.filter(row => row.id === 'jingkang_nandu').length;
+  const other = makeRuntime({ year: 1101, campaignId: 'campaign-b' });
+  other.playerLeaves[0].name = '中原京城';
+  other.playerLeaves[1].name = '江南路';
+  other.context.GM._capital = '中原京城';
+  other.context.GM.facs[0].capital = '中原京城';
+  other.context.HujiEngine.tick({ turn: 1, monthRatio: 1, strict: true });
+  const otherCount = other.context.GM.population.migrationEvents.filter(row => row.id === 'jingkang_nandu').length;
+  ok(countAfterFirst === 1 && countAfterReload === 1, 'persisted migration event state prevents restart duplication');
+  ok(otherCount === 1, 'a different campaign can independently trigger the same historical migration');
+  ok(!Object.prototype.hasOwnProperty.call(context.HujiEngine.MIGRATION_EVENTS[0], '_triggered'),
+    'immutable migration presets never carry campaign trigger state');
+}
+
+{
+  const { context } = makeRuntime();
+  context.GM.adminHierarchy = {};
+  context.GM.population.national = { mouths: 20000, households: 4000, ding: 6000 };
+  context.GM.population.dynamics.birthRateBase = 0;
+  context.GM.population.dynamics.deathRateBase = 0.12;
+  context.HujiEngine.tick({ turn: 1, monthRatio: 1, strict: true });
+  ok(context.GM.population.national.mouths > 0 && context.GM.population.national.mouths < 100000,
+    'a legitimate 20,000-person polity is never raised to a hard-coded 100,000 floor');
+}
+
+{
+  const daysPerTurnCases = [1, 10, 30, 90];
+  const triggerResults = daysPerTurnCases.map(daysPerTurn => {
+    const { context } = makeRuntime({ daysPerTurn });
+    const cycleTurns = context.turnsForMonths(12);
+    context.GM.population.meta.registrationCycle = 1;
+    context.GM.population.meta.lastRegistrationTurn = 0;
+    context.HujiEngine.tick({ turn: cycleTurns - 1, monthRatio: daysPerTurn / 30, strict: true });
+    const premature = context.GM.population.meta.lastRegistrationTurn;
+    context.HujiEngine.tick({ turn: cycleTurns, monthRatio: daysPerTurn / 30, strict: true });
+    return { cycleTurns, premature, triggered: context.GM.population.meta.lastRegistrationTurn };
+  });
+  ok(triggerResults.every(result => result.premature === 0 && result.triggered === result.cycleTurns),
+    'registration cycles use canonical elapsed months for every daysPerTurn scale');
+}
+
+{
+  const { context, playerLeaves } = makeRuntime({
+    dateForTurn(turn) { return { adYear: turn >= 13 ? 2 : 1 }; }
+  });
+  const corvee = context.GM.population.corvee;
+  corvee.enabled = true;
+  corvee.currentYear = 1;
+  Object.keys(corvee.byType).forEach(key => {
+    corvee.byType[key].totalDays = 100000000;
+    corvee.byType[key].currentYearDays = 100000000;
+  });
+  const before = totals(playerLeaves).mouths;
+  context.HujiEngine.tick({ turn: 13, monthRatio: 1, strict: true });
+  const junyi = corvee.byType.junyi;
+  const after = totals(playerLeaves).mouths;
+  ok(corvee.currentYear === 2 && junyi.currentYearDays > 0
+    && junyi.currentYearDays < junyi.totalDays / 10,
+  'new calendar year resets corvee pressure while preserving lifetime statistics');
+  ok(corvee.currentYearBurden < 0.1,
+    'fugitive pressure is derived from the current-year window, not lifetime service days');
+  ok(after < before
+    && context.GM.population.mortalityLedger.some(row => /^corvee:/.test(row.cause)),
+  'ordinary corvee mortality reaches the leaf population ledger');
+}
+
+{
+  const { context, playerLeaves } = makeRuntime();
+  const before = totals(playerLeaves).mouths;
+  const expectedWithoutMortality = before + playerLeaves.reduce((sum, leaf) => {
+    const mouths = leaf.populationDetail.mouths;
+    return sum + Math.round(mouths * 0.035 / 12) - Math.round(mouths * 0.025 / 12);
+  }, 0);
+  const started = context.HujiEngine.startLargeCorvee('ming_zijincheng');
+  context.HujiEngine.tick({ turn: 2, monthRatio: 1, strict: true });
+  context.TM.HujiRuntimeBridge.maintain(context.GM, { scenario: context.P, turn: 2 });
+  const after = totals(playerLeaves).mouths;
+  ok(started.ok && after < expectedWithoutMortality
+    && context.GM.population.mortalityLedger.some(row => row.cause === 'large-corvee:ming_zijincheng')
+    && context.GM.population.national.mouths === after,
+  'large-corvee mortality survives the complete leaf-to-national bridge');
+}
+
+ok(/HujiEngine\.applyPopulationLoss\(\{ cause:'environment-crisis:/.test(economySource)
+  && !/target\.mouths\s*=\s*Math\.max\(10000/.test(economySource),
+  'environment crisis mortality is routed through the leaf ledger');
+ok(/HujiEngine\.applyPopulationLoss\(\{ cause:'historical-plague:/.test(historicalSource)
+  && /HujiEngine\.applyPopulationLoss\(\{ cause:'war-casualty:/.test(historicalSource)
+  && !/population\.national\.mouths\s*=\s*Math\.max\(100000/.test(historicalSource),
+  'historical plague and war casualties are routed through the leaf ledger');
+ok(/HujiEngine\.applyPopulationLoss\(\{ cause:'disease-cycle:/.test(regionEnrichSource)
+  && !/population\.national\.mouths\s*=\s*Math\.max\(0/.test(regionEnrichSource),
+  'regional disease mortality is routed through the leaf ledger');
+
+console.log('\n[smoke-population-faction-ledger] ' + pass + ' passed / ' + fail + ' failed');
+process.exit(fail ? 1 : 0);

--- a/web/scripts/smoke-runtime-save-consistency.js
+++ b/web/scripts/smoke-runtime-save-consistency.js
@@ -289,13 +289,16 @@ async function runDynamicLeaseSmokes() {
     const helpers = [
       sliceFn(lifecycle, 'function _tmStripSaveTransportMetadata('),
       sliceFn(lifecycle, 'function _tmStableIdMissing('),
+      sliceFn(lifecycle, 'function _tmStableIdentityParts('),
       sliceFn(lifecycle, 'function _tmCollectAdminDivisionEntries('),
+      sliceFn(lifecycle, 'function _tmEntityIdSet('),
       sliceFn(lifecycle, 'function _tmValidateUniqueStableIds('),
+      sliceFn(lifecycle, 'function _tmValidateStableForeignKeys('),
       sliceFn(lifecycle, 'function _tmValidateFiniteWorldNumbers('),
       sliceFn(lifecycle, 'function _tmValidateLoadedWorld(')
     ].join('\n');
     const ctx = {
-      Number, Object, Array, String, Error, WeakSet,
+      Number, Object, Array, String, Error, WeakSet, JSON,
       _tmEnsureTimelineIdentity(gm) { return !!gm._timelineId; }
     };
     vm.createContext(ctx); vm.runInContext(helpers, ctx);

--- a/web/scripts/smoke-save-integrity-audit.js
+++ b/web/scripts/smoke-save-integrity-audit.js
@@ -77,9 +77,11 @@ console.log('=== save integrity audit ===');
   const stableIdHelpers = [
     'function _tmStableIdMissing(',
     'function _tmStableIdHash(',
+    'function _tmStableIdentityParts(',
     'function _tmCollectAdminDivisionEntries(',
     'function _tmAssignMissingStableIds(',
     'function _tmUniqueEntityIdByName(',
+    'function _tmEntityIdSet(',
     'function _tmBackfillStableForeignKeys(',
     'function _tmMigrateCoreStableIds('
   ].map(function(marker) { return sliceFn(lifecycle, marker); }).join('\n');

--- a/web/scripts/smoke-stable-id-migration.js
+++ b/web/scripts/smoke-stable-id-migration.js
@@ -26,9 +26,11 @@ const functionNames = [
   '_tmHasOwn',
   '_tmStableIdMissing',
   '_tmStableIdHash',
+  '_tmStableIdentityParts',
   '_tmCollectAdminDivisionEntries',
   '_tmAssignMissingStableIds',
   '_tmUniqueEntityIdByName',
+  '_tmEntityIdSet',
   '_tmBackfillStableForeignKeys',
   '_tmMigrateCoreStableIds',
   '_tmValidateUniqueStableIds'

--- a/web/scripts/smoke-stable-id-reference-integrity.js
+++ b/web/scripts/smoke-stable-id-reference-integrity.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.resolve(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'tm-save-lifecycle.js'), 'utf8');
+let pass = 0;
+let fail = 0;
+function ok(condition, message) {
+  if (condition) { pass++; console.log('  PASS - ' + message); }
+  else { fail++; console.error('  FAIL - ' + message); }
+}
+function sliceFn(src, marker) {
+  const start = src.indexOf(marker);
+  if (start < 0) throw new Error('missing helper: ' + marker);
+  let cursor = src.indexOf('{', start);
+  let depth = 0;
+  for (; cursor < src.length; cursor++) {
+    if (src[cursor] === '{') depth++;
+    else if (src[cursor] === '}' && --depth === 0) return src.slice(start, cursor + 1);
+  }
+  throw new Error('unterminated helper: ' + marker);
+}
+
+const helpers = [
+  'function _tmStableIdMissing(',
+  'function _tmStableIdHash(',
+  'function _tmStableIdentityParts(',
+  'function _tmCollectAdminDivisionEntries(',
+  'function _tmAssignMissingStableIds(',
+  'function _tmUniqueEntityIdByName(',
+  'function _tmEntityIdSet(',
+  'function _tmBackfillStableForeignKeys(',
+  'function _tmMigrateCoreStableIds(',
+  'function _tmValidateUniqueStableIds(',
+  'function _tmValidateStableForeignKeys('
+].map(marker => sliceFn(source, marker)).join('\n');
+
+const context = {
+  console, Math, JSON, Number, Object, Array, String, Error, WeakSet,
+  _tmHasOwn(object, key) { return Object.prototype.hasOwnProperty.call(object, key); }
+};
+context.window = context;
+vm.createContext(context);
+vm.runInContext(helpers, context, { filename: 'tm-save-lifecycle-stable-id-slice.js' });
+
+function legacyWorld(charOrder) {
+  const charsByName = {
+    '甲': { name: '甲', gender: '男', birthYear: 1600, faction: '朝廷' },
+    '乙': { name: '乙', gender: '女', birthYear: 1602, faction: '朝廷' }
+  };
+  return {
+    sid: 'same-scenario', _campaignId: 'same-campaign',
+    chars: charOrder.map(name => JSON.parse(JSON.stringify(charsByName[name]))),
+    facs: [{ name: '朝廷', leader: '甲' }],
+    armies: [{ name: '京营', commander: '乙', faction: '朝廷' }],
+    mapData: { regions: [{ name: '京畿', owner: '朝廷' }, { name: '江南', owner: '朝廷' }] },
+    officeTree: [{ name: '中枢', positions: [{ name: '尚书', holder: '甲' }], subs: [] }],
+    adminHierarchy: {
+      player: { divisions: [
+        { name: '北直隶', children: [{ name: '顺天府' }] },
+        { name: '南直隶', children: [{ name: '应天府' }] }
+      ] }
+    }
+  };
+}
+
+console.log('[smoke-stable-id-reference-integrity]');
+
+{
+  const first = legacyWorld(['甲', '乙']);
+  const reordered = legacyWorld(['乙', '甲']);
+  reordered.mapData.regions.reverse();
+  context._tmMigrateCoreStableIds(first);
+  context._tmMigrateCoreStableIds(reordered);
+  const idsA = Object.fromEntries(first.chars.map(char => [char.name, char.id]));
+  const idsB = Object.fromEntries(reordered.chars.map(char => [char.name, char.id]));
+  const regionsA = Object.fromEntries(first.mapData.regions.map(region => [region.name, region.id]));
+  const regionsB = Object.fromEntries(reordered.mapData.regions.map(region => [region.name, region.id]));
+  ok(idsA['甲'] === idsB['甲'] && idsA['乙'] === idsB['乙'],
+    'legacy character IDs remain stable when array order changes');
+  ok(regionsA['京畿'] === regionsB['京畿'] && regionsA['江南'] === regionsB['江南'],
+    'legacy region IDs are based on semantic identity rather than array position');
+  ok(first._stableIdMigration.version === 2, 'order-independent migration records schema version 2');
+}
+
+{
+  const first = legacyWorld(['甲', '乙']);
+  const renamed = legacyWorld(['甲', '乙']);
+  first.chars[0].sourceId = 'char-source-1';
+  renamed.chars[0].sourceId = 'char-source-1';
+  renamed.chars[0].name = '甲改名';
+  context._tmMigrateCoreStableIds(first);
+  context._tmMigrateCoreStableIds(renamed);
+  ok(first.chars[0].id === renamed.chars[0].id,
+    'explicit source identity remains stable across display-name changes');
+}
+
+{
+  const world = legacyWorld(['甲', '乙']);
+  world.adminHierarchy = { divisions: [{ name: '直辖州', children: [{ name: '属县' }] }] };
+  context._tmMigrateCoreStableIds(world);
+  const divisions = context._tmCollectAdminDivisionEntries(world).map(entry => entry.item);
+  ok(divisions.length === 2 && divisions.every(division => typeof division.id === 'string'),
+    'direct adminHierarchy.divisions layouts also receive stable IDs');
+}
+
+{
+  const world = legacyWorld(['甲', '乙']);
+  world.chars[1].factionId = 'dangling-faction';
+  world.armies[0].commanderId = 'dangling-character';
+  world.armies[0].factionId = 'dangling-faction';
+  world.mapData.regions[0].factionId = 'dangling-faction';
+  context._tmMigrateCoreStableIds(world);
+  const factionId = world.facs[0].id;
+  const commanderId = world.chars.find(char => char.name === '乙').id;
+  ok(world.chars[1].factionId === factionId
+    && world.armies[0].factionId === factionId
+    && world.mapData.regions[0].factionId === factionId,
+    'invalid faction references are repaired from unique legacy names');
+  ok(world.armies[0].commanderId === commanderId,
+    'invalid commanderId is repaired from the unique commander name');
+  world.chars[1].father = '甲';
+  world.chars[1].fatherId = 'dangling-relative';
+  world.officeTree[0].positions[0].holderId = 'dangling-holder';
+  context._tmBackfillStableForeignKeys(world);
+  ok(world.chars[1].fatherId === world.chars[0].id
+    && world.officeTree[0].positions[0].holderId === world.chars[0].id,
+  'relative and office-holder IDs are repaired from unique legacy names');
+  let valid = true;
+  try { context._tmValidateStableForeignKeys(world); } catch (_) { valid = false; }
+  ok(valid, 'repaired stable foreign keys pass closure validation');
+}
+
+{
+  const world = legacyWorld(['甲', '乙']);
+  context._tmMigrateCoreStableIds(world);
+  world.armies[0].commander = '不存在的人物';
+  world.armies[0].commanderId = 'missing-character-id';
+  context._tmBackfillStableForeignKeys(world);
+  let rejected = false;
+  try { context._tmValidateStableForeignKeys(world); }
+  catch (error) { rejected = /commanderId.*不存在/.test(error.message); }
+  ok(rejected, 'unrepairable dangling commanderId is rejected before gameplay opens');
+}
+
+{
+  const world = legacyWorld(['甲', '乙']);
+  context._tmMigrateCoreStableIds(world);
+  world.chars[1].spouseId = 'missing-spouse-id';
+  let rejected = false;
+  try { context._tmValidateStableForeignKeys(world); }
+  catch (error) { rejected = /spouseId.*不存在/.test(error.message); }
+  ok(rejected, 'dangling kinship IDs are rejected before gameplay opens');
+}
+
+console.log('\n[smoke-stable-id-reference-integrity] ' + pass + ' passed / ' + fail + ' failed');
+process.exit(fail ? 1 : 0);

--- a/web/tm-economy-engine.js
+++ b/web/tm-economy-engine.js
@@ -453,8 +453,9 @@
         if (P) {
           var target = rid && P.byRegion[rid] ? P.byRegion[rid] : P.national;
           var deaths = Math.round(target.mouths * ef.deathRate);
-          target.mouths = Math.max(10000, target.mouths - deaths);
-          if (P.national !== target) P.national.mouths = Math.max(10000, P.national.mouths - deaths);
+          if (!global.HujiEngine || typeof global.HujiEngine.applyPopulationLoss !== 'function') throw new Error('人口损失账本不可用');
+          var mortality = global.HujiEngine.applyPopulationLoss({ cause:'environment-crisis:' + String(ev.id || 'unknown'), regionId:rid || '', mouths:deaths });
+          if (!mortality || mortality.ok === false) throw new Error('环境危机人口损失落账失败: ' + String(mortality && mortality.reason || 'unknown'));
         }
       }
       if (ef.unrest) {

--- a/web/tm-endturn-systems.js
+++ b/web/tm-endturn-systems.js
@@ -83,7 +83,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
   } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HujiEngine(early) 失败:') : console.error('[endTurn] HujiEngine(early) 失败:', e); throw e; }
   try {
     if (typeof HujiDeepFill !== 'undefined') {
-      HujiDeepFill.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
+      HujiDeepFill.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio, strict: true });
     }
   } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HujiDeepFill(early) 失败:') : console.error('[endTurn] HujiDeepFill(early) 失败:', e); throw e; }
   // 标记已早跑，后文跳过
@@ -211,7 +211,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
   // 6.10 户口深化（已在 6.015 早跑，跳过）
   if (!GM._hujiEarlyTicked) try {
     if (typeof HujiDeepFill !== 'undefined') {
-      HujiDeepFill.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
+      HujiDeepFill.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio, strict: true });
     }
   } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HujiDeepFill.tick 失败:') : console.error('[endTurn] HujiDeepFill.tick 失败:', e); throw e; }
   // 清 early 标记，下回合重新走

--- a/web/tm-historical-presets.js
+++ b/web/tm-historical-presets.js
@@ -442,28 +442,31 @@
   function recordPlague(scale, region, cause) {
     _initPlagueWarFields();
     var G = global.GM;
+    if (!global.HujiEngine || typeof global.HujiEngine.applyPopulationLoss !== 'function') throw new Error('人口损失账本不可用');
+    var mortality = global.HujiEngine.applyPopulationLoss({ cause:'historical-plague:' + String(cause || 'plague'), regionId:region && region !== 'national' ? region : '', mouths:scale });
+    if (!mortality || mortality.ok === false) throw new Error('历史瘟疫人口损失落账失败: ' + String(mortality && mortality.reason || 'unknown'));
     G.population.plagueEvents.push({
       turn: G.turn || 0,
-      scale: scale,
+      scale: mortality.mouths,
       region: region || 'national',
       cause: cause || '瘟疫',
-      deaths: scale
+      deaths: mortality.mouths
     });
-    G.population.national.mouths = Math.max(100000, G.population.national.mouths - scale);
-    if (global.addEB) global.addEB('瘟疫', (region || '各地') + '大疫，殒 ' + Math.round(scale) + ' 口');
+    if (global.addEB) global.addEB('瘟疫', (region || '各地') + '大疫，殒 ' + Math.round(mortality.mouths) + ' 口');
   }
 
   function recordWarCasualty(scale, warName, side) {
     _initPlagueWarFields();
     var G = global.GM;
+    if (!global.HujiEngine || typeof global.HujiEngine.applyPopulationLoss !== 'function') throw new Error('人口损失账本不可用');
+    var mortality = global.HujiEngine.applyPopulationLoss({ cause:'war-casualty:' + String(warName || 'unknown'), mouths:scale, ding:Math.round(scale * 0.6) });
+    if (!mortality || mortality.ok === false) throw new Error('战亡人口损失落账失败: ' + String(mortality && mortality.reason || 'unknown'));
     G.population.warCasualties.push({
       turn: G.turn || 0,
-      scale: scale,
+      scale: mortality.mouths,
       warName: warName || '',
       side: side || 'own'
     });
-    G.population.national.mouths = Math.max(100000, G.population.national.mouths - scale);
-    if (G.population.national.ding) G.population.national.ding = Math.max(0, G.population.national.ding - Math.round(scale * 0.6));
   }
 
   // ═══════════════════════════════════════════════════════════════════

--- a/web/tm-huji-deep-fill.js
+++ b/web/tm-huji-deep-fill.js
@@ -237,7 +237,7 @@
     if (!G.population) return;
     QIAOZHI_HISTORICAL.forEach(function(e) {
       if (G.population._qiaozhi_triggered && G.population._qiaozhi_triggered[e.id]) return;
-      var year = G.year || _yearFromTurn(ctx.turn || G.turn || 1);
+      var year = _yearFromTurn(ctx.turn || G.turn || 1);
       if (year >= e.year && year < e.year + 10 && G.unrest > 70) {
         // 触发
         if (!G.population._qiaozhi_triggered) G.population._qiaozhi_triggered = {};
@@ -714,7 +714,8 @@
       // 产粮降、死亡增
       if (G.guoku) G.guoku.grain = Math.max(0, G.guoku.grain - Math.round(G.population.national.mouths * 0.01 * mr / 12));
       var deaths = Math.round(G.population.national.mouths * 0.0005 * mr);
-      G.population.national.mouths = Math.max(100000, G.population.national.mouths - deaths);
+      if (!global.HujiEngine || typeof global.HujiEngine.applyPopulationLoss !== 'function') throw new Error('人口损失账本不可用');
+      global.HujiEngine.applyPopulationLoss({ cause:'climate:little-ice-age', mouths:deaths });
     } else if (phase === 'medieval_warm') {
       // 产粮升
       if (G.guoku) G.guoku.grain += Math.round(G.population.national.mouths * 0.005 * mr / 12);
@@ -734,7 +735,7 @@
     var G = global.GM;
     if (!G.population) return;
     if (!G.population.cropRevolutions) G.population.cropRevolutions = [];
-    var year = G.year || 1;
+    var year = _yearFromTurn(ctx.turn || G.turn || 1);
     CROP_REVOLUTIONS.forEach(function(c) {
       if (G.population.cropRevolutions.indexOf(c.id) >= 0) return;
       if (year >= c.year && year < c.year + 20) {
@@ -761,14 +762,15 @@
     var G = global.GM;
     if (!G.population) return;
     if (!G.population.plagueEvents) G.population.plagueEvents = [];
-    var year = G.year || 1;
+    var year = _yearFromTurn(ctx.turn || G.turn || 1);
     PLAGUE_CYCLES.forEach(function(p) {
       var phase = year % p.period;
       if (phase === 0 && Math.random() < 0.3) {
         var deaths = Math.round(G.population.national.mouths * p.baseMortality);
-        G.population.national.mouths = Math.max(100000, G.population.national.mouths - deaths);
-        G.population.plagueEvents.push({ turn: ctx.turn, deaths: deaths, region: p.regions[Math.floor(Math.random()*p.regions.length)] });
-        if (global.addEB) global.addEB('瘟疫', '疫病大作，死亡 ' + deaths);
+        if (!global.HujiEngine || typeof global.HujiEngine.applyPopulationLoss !== 'function') throw new Error('人口损失账本不可用');
+        var mortality = global.HujiEngine.applyPopulationLoss({ cause:'plague', mouths:deaths });
+        G.population.plagueEvents.push({ turn: ctx.turn, deaths: mortality.mouths, region: p.regions[Math.floor(Math.random()*p.regions.length)] });
+        if (global.addEB) global.addEB('瘟疫', '疫病大作，死亡 ' + mortality.mouths);
       }
     });
   }
@@ -860,30 +862,61 @@
   //  主 tick
   // ═══════════════════════════════════════════════════════════════════
 
+  function _isCanonicalYearBoundary(ctx) {
+    var turn = Number(ctx && ctx.turn) || 0;
+    try {
+      if (typeof global.calcDateFromTurn === 'function' && turn > 0) {
+        var current = global.calcDateFromTurn(turn) || {};
+        var previous = global.calcDateFromTurn(Math.max(1, turn - 1)) || {};
+        var currentYear = Number(current.adYear != null ? current.adYear : current.year);
+        var previousYear = Number(previous.adYear != null ? previous.adYear : previous.year);
+        if (isFinite(currentYear) && isFinite(previousYear)) return currentYear !== previousYear;
+      }
+    } catch (_) {}
+    var turns = (typeof global.turnsForMonths === 'function') ? Number(global.turnsForMonths(12)) : 12;
+    return turn > 0 && turn % Math.max(1, Math.round(turns) || 12) === 0;
+  }
+
   function tick(ctx) {
     ctx = ctx || {};
-    var mr = ctx.monthRatio || 1;
-    try { _tickClassMobility(mr); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'deep] mobility:') : console.error('[deep] mobility:', e); }
-    try { _tickLandlordAnnexation(mr); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-huji-deep-fill');}catch(_){}}
-    try { _tickMerchantCycle(mr); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-huji-deep-fill');}catch(_){}}
-    try { _tickGentryCycle(mr); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-huji-deep-fill');}catch(_){}}
-    try { _tickClergyCycle(mr); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-huji-deep-fill');}catch(_){}}
-    try { _checkQiaozhiTrigger(ctx); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-huji-deep-fill');}catch(_){}}
-    try { _tickJimiTusi(mr); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-huji-deep-fill');}catch(_){}}
-    try { _tickMilitaryFarms(mr); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-huji-deep-fill');}catch(_){}}
-    try { _tickMilitarySupply(mr); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-huji-deep-fill');}catch(_){}}
-    try { _tickTroopOrders(ctx); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-huji-deep-fill');}catch(_){}}
-    try { _tickHorsePolicy(mr); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-huji-deep-fill');}catch(_){}}
-    try { _assessMilitaryAllegiance(); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-huji-deep-fill');}catch(_){}}
-    try { _tickAgeLayers(mr); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-huji-deep-fill');}catch(_){}}
-    try { _tickGenderRatio(mr); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-huji-deep-fill');}catch(_){}}
-    try { _checkCorveeRevolt(ctx); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-huji-deep-fill');}catch(_){}}
-    try { _tickClimateCoupling(mr); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-huji-deep-fill');}catch(_){}}
-    try { _checkCropRevolution(ctx); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-huji-deep-fill');}catch(_){}}
-    if ((ctx.turn || 0) % 12 === 0) {
-      try { _tickPlague(ctx, mr); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-huji-deep-fill');}catch(_){}}
-      try { _aiGenerateMemorials(ctx); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-huji-deep-fill');}catch(_){}}
+    var rawMr = Number(ctx.monthRatio);
+    var mr = rawMr > 0 && isFinite(rawMr) ? rawMr : 1;
+    var strict = ctx.strict === true;
+    var failures = [];
+    function runStep(label, fn) {
+      try { return fn(); }
+      catch (error) {
+        try {
+          if (window.TM && TM.errors && TM.errors.capture) TM.errors.capture(error, 'huji-deep] ' + label + ':');
+          else console.error('[huji-deep] ' + label + ':', error);
+        } catch (_) {}
+        if (strict) throw error;
+        failures.push({ step:label, error:String(error && error.message || error) });
+        return null;
+      }
     }
+    runStep('class-mobility', function() { _tickClassMobility(mr); });
+    runStep('landlord-annexation', function() { _tickLandlordAnnexation(mr); });
+    runStep('merchant-cycle', function() { _tickMerchantCycle(mr); });
+    runStep('gentry-cycle', function() { _tickGentryCycle(mr); });
+    runStep('clergy-cycle', function() { _tickClergyCycle(mr); });
+    runStep('qiaozhi-trigger', function() { _checkQiaozhiTrigger(ctx); });
+    runStep('jimi-tusi', function() { _tickJimiTusi(mr); });
+    runStep('military-farms', function() { _tickMilitaryFarms(mr); });
+    runStep('military-supply', function() { _tickMilitarySupply(mr); });
+    runStep('troop-orders', function() { _tickTroopOrders(ctx); });
+    runStep('horse-policy', function() { _tickHorsePolicy(mr); });
+    runStep('military-allegiance', function() { _assessMilitaryAllegiance(); });
+    runStep('age-layers', function() { _tickAgeLayers(mr); });
+    runStep('gender-ratio', function() { _tickGenderRatio(mr); });
+    runStep('corvee-revolt', function() { _checkCorveeRevolt(ctx); });
+    runStep('climate-coupling', function() { _tickClimateCoupling(mr); });
+    runStep('crop-revolution', function() { _checkCropRevolution(ctx); });
+    if (_isCanonicalYearBoundary(ctx)) {
+      runStep('plague', function() { _tickPlague(ctx, mr); });
+      runStep('annual-memorials', function() { _aiGenerateMemorials(ctx); });
+    }
+    return { ok:failures.length === 0, failures:failures };
   }
 
   function init() {

--- a/web/tm-huji-engine.js
+++ b/web/tm-huji-engine.js
@@ -128,6 +128,12 @@
     { id:'huguang_tian',   name:'湖广填四川',century:17,scale:2000000, fromRegion:'湖广', toRegion:'四川' },
     { id:'chuang_guandong',name:'闯关东',   century:19, scale:8000000, fromRegion:'山东', toRegion:'东北' }
   ];
+  // 迁徙预设是进程级常量，不得承载某一战役的触发状态。
+  // 旧实现向预设写 _triggered，导致同进程跨档抑制、重启后重复触发。
+  if (typeof Object.freeze === 'function') {
+    MIGRATION_EVENTS.forEach(function(eventPreset) { Object.freeze(eventPreset); });
+    Object.freeze(MIGRATION_EVENTS);
+  }
 
   // ═══════════════════════════════════════════════════════════════════
   //  初始化
@@ -145,6 +151,18 @@
       if (!G.population.corvee) G.population.corvee = _defaultCorvee();
       if (!G.population.military) G.population.military = _defaultMilitary();
       if (!G.population.meta) G.population.meta = _defaultMeta();
+      if (!Array.isArray(G.population.migrationEvents)) G.population.migrationEvents = []; // arch-ok: 户籍权威写口迁移战役事件账本
+      if (!G.population.migrationEventStates || typeof G.population.migrationEventStates !== 'object' || Array.isArray(G.population.migrationEventStates)) {
+        G.population.migrationEventStates = {}; // arch-ok: 户籍权威写口迁移战役事件状态
+      }
+      if (!Array.isArray(G.population.triggeredMigrationEventIds)) G.population.triggeredMigrationEventIds = []; // arch-ok: 户籍权威写口迁移已触发事件集合
+      G.population.migrationEvents.forEach(function(record) {
+        if (!record || !record.id) return;
+        if (G.population.triggeredMigrationEventIds.indexOf(record.id) < 0) G.population.triggeredMigrationEventIds.push(record.id); // arch-ok: 户籍权威写口迁移已触发事件集合
+        if (!G.population.migrationEventStates[record.id]) {
+          G.population.migrationEventStates[record.id] = { status:'triggered', turn:record.turn, scale:record.scale }; // arch-ok: 户籍权威写口迁移事件状态
+        }
+      });
       _ensureDeepDemographics(G.population);
       return;
     }
@@ -178,7 +196,9 @@
       hiddenCount: 0,
       largeCorveeActive: [],    // 正在进行的大徭役
       garrisons: [],            // 卫所
-      migrationEvents: []       // 触发的迁徙事件
+      migrationEvents: [],      // 已成功触发的迁徙事件
+      migrationEventStates: {}, // 战役内的 pending/triggered 状态
+      triggeredMigrationEventIds: []
     };
     _ensureDeepDemographics(G.population);
   }
@@ -374,7 +394,11 @@
   function _defaultCorvee() {
     var byType = {};
     Object.keys(CORVEE_TYPES).forEach(function(k) {
-      byType[k] = { daysPerDing: CORVEE_TYPES[k].daysPerDing, totalDays: 0, fulfilled: 0, commutedRate: 0, deaths: 0 };
+      byType[k] = {
+        daysPerDing: CORVEE_TYPES[k].daysPerDing,
+        totalDays: 0, fulfilled: 0, commutedRate: 0, deaths: 0,
+        currentYearDays: 0, currentYearFulfilled: 0, currentYearDeaths: 0
+      };
     });
     return {
       enabled: true,
@@ -391,7 +415,9 @@
       commutationRate: 0.5,
       fullyCommuted: false,
       proxyRate: 0,
-      burdenThreshold: 0.40
+      burdenThreshold: 0.40,
+      currentYear: null,
+      currentYearBurden: 0
     };
   }
 
@@ -431,7 +457,8 @@
       registrationCycle: 10,
       lastRegistrationTurn: 0,
       registrationAccuracy: 0.85,
-      registrationCost: { money: 0, grain: 0 }
+      registrationCost: { money: 0, grain: 0 },
+      minimumPopulation: 0
     };
   }
 
@@ -456,13 +483,14 @@
     // 只要叶级户口存在，都必须在叶子上推进；否则先改 national/byRegion，
     // 随后的 runtime bridge 又从未变化的叶子重建全国账，会把本次增长抹掉。
     // 选项只决定是否采用地方民心/粮食/灾异修正，不再决定写入哪套账。
-    var leaves = _allLeafDivisions(global.GM);
+    var groups = _factionLeafGroups(global.GM);
+    var leaves = _allLeafDivisions(global.GM, groups);
     var hasLeafPopulation = leaves.some(function(leaf) {
       return !!(leaf && leaf.populationDetail && Number(leaf.populationDetail.mouths) > 0);
     });
     if (hasLeafPopulation) {
       var useLocalFactors = !!(global.P && global.P.conf && global.P.conf.populationBottomUpEnabled);
-      return _tickPopulationLeafGrowth(ctx, mr, useLocalFactors, leaves);
+      return _tickPopulationLeafGrowth(ctx, mr, useLocalFactors, groups);
     }
     var d = P.dynamics;
     // 年景因子
@@ -487,7 +515,7 @@
     var births = Math.round(oldMouths * birthRate * mr / 12);
     var deaths = Math.round(oldMouths * deathRate * mr / 12);
     var net = births - deaths;
-    P.national.mouths = Math.max(100000, oldMouths + net);
+    P.national.mouths = Math.max(_minimumPopulation(P), oldMouths + net);
     // 丁同比变化
     P.national.ding = Math.round(P.national.mouths * dingRatio);
     // 户同比变化
@@ -526,19 +554,182 @@
     return mr > 0 && isFinite(mr) ? net * 12 / mr : net * 12;
   }
 
-  // S1-S4·人口自下而上 取叶(2026-06-20 真机修)：getLeafDivisions(ah) 默认只取 'player' faction
-  // (getTopLevelDivisions: ah[factionId||'player'])·须遍历所有 faction·否则 NPC 势力地块人口静止。
-  function _allLeafDivisions(G) {
-    var ah = G && G.adminHierarchy;
-    if (!ah) return [];
-    var IB = global.IntegrationBridge;
-    if (!IB || typeof IB.getLeafDivisions !== 'function') return [];
+  function _minimumPopulation(P) {
+    var configured = Number(P && P.meta && P.meta.minimumPopulation);
+    return configured >= 0 && isFinite(configured) ? configured : 0;
+  }
+
+  function _walkAdminLeaves(nodes, out, seen) {
+    (Array.isArray(nodes) ? nodes : []).forEach(function(node) {
+      if (!node || typeof node !== 'object') return;
+      if (seen && seen.indexOf(node) >= 0) return;
+      if (seen) seen.push(node);
+      var childGroups = [node.children, node.divisions, node.subdivisions, node.subs]
+        .filter(function(children, index, all) {
+          return Array.isArray(children) && children.length && all.indexOf(children) === index;
+        });
+      if (childGroups.length) {
+        childGroups.forEach(function(children) { _walkAdminLeaves(children, out, seen); });
+      } else out.push(node);
+    });
+  }
+
+  function _normPopulationName(value) {
+    return String(value == null ? '' : value).replace(/[\s·（）()\-—_]/g, '').toLowerCase();
+  }
+
+  function _playerAdminKey(G, hierarchy) {
+    try {
+      if (typeof global._tmResolvePlayerAdminKey === 'function') {
+        var resolved = global._tmResolvePlayerAdminKey(hierarchy, global.P || null);
+        if (resolved && resolved !== 'divisions') return resolved;
+      }
+    } catch (_) {}
+    if (hierarchy && hierarchy.player) return 'player';
+    var keys = Object.keys(hierarchy || {}).filter(function(key) {
+      var branch = hierarchy[key];
+      return Array.isArray(branch) || (branch && Array.isArray(branch.divisions));
+    });
+    if (keys.length === 1) return keys[0];
+    var playerNames = [];
+    function add(value) {
+      var normalized = _normPopulationName(value);
+      if (normalized && playerNames.indexOf(normalized) < 0) playerNames.push(normalized);
+    }
+    add(global.P && global.P.playerInfo && global.P.playerInfo.factionName);
+    add(global.P && global.P.playerFaction);
+    add(G && G.playerFaction);
+    (G && Array.isArray(G.facs) ? G.facs : []).forEach(function(faction) {
+      if (faction && faction.isPlayer) { add(faction.id); add(faction.name); add(faction.key); }
+    });
+    for (var i = 0; i < keys.length; i++) {
+      var branch = hierarchy[keys[i]] || {};
+      var aliases = [keys[i], branch.factionId, branch.factionName, branch.name, branch.key];
+      if (aliases.some(function(alias) { return playerNames.indexOf(_normPopulationName(alias)) >= 0; })) return keys[i];
+    }
+    return null;
+  }
+
+  function _factionForAdminBranch(G, key, branch) {
+    var factions = G && Array.isArray(G.facs) ? G.facs : [];
+    var aliases = [key, branch && branch.factionId, branch && branch.factionName, branch && branch.name]
+      .map(_normPopulationName).filter(Boolean);
+    for (var i = 0; i < factions.length; i++) {
+      var faction = factions[i] || {};
+      var values = [faction.id, faction.key, faction.name, faction.factionName].map(_normPopulationName);
+      if (values.some(function(value) { return value && aliases.indexOf(value) >= 0; })) return faction;
+    }
+    return null;
+  }
+
+  // 每个势力独立持有叶级人口、统计和迁徙范围。玩家 national 仅由玩家分支聚合；
+  // NPC 的人口摘要写入 worldPopulationSummary，不再混进玩家户籍账本。
+  function _factionLeafGroups(G) {
+    var hierarchy = G && G.adminHierarchy;
+    if (!hierarchy || typeof hierarchy !== 'object') return [];
+    if (Array.isArray(hierarchy.divisions)) hierarchy = { player: hierarchy };
+    var playerKey = _playerAdminKey(G, hierarchy);
+    var groups = [];
+    Object.keys(hierarchy).forEach(function(key) {
+      var branch = hierarchy[key];
+      var roots = Array.isArray(branch) ? branch : (branch && branch.divisions);
+      if (!Array.isArray(roots)) return;
+      var leaves = [];
+      _walkAdminLeaves(roots, leaves, []);
+      if (!leaves.length) return;
+      var faction = _factionForAdminBranch(G, key, branch || {});
+      groups.push({
+        key: key,
+        branch: branch || {},
+        leaves: leaves,
+        isPlayer: key === playerKey,
+        faction: faction,
+        factionId: String((faction && faction.id) || (branch && branch.factionId) || key),
+        factionName: String((faction && faction.name) || (branch && (branch.factionName || branch.name)) || key)
+      });
+    });
+    // Old saves and focused subsystem tests may expose the player leaves only
+    // through IntegrationBridge while their hierarchy shell has not yet been
+    // normalized. Preserve that compatibility without ever using it to infer
+    // NPC ownership or combine multiple factions.
+    if (!groups.length && global.IntegrationBridge && typeof global.IntegrationBridge.getLeafDivisions === 'function') {
+      var bridgedLeaves = [];
+      try { bridgedLeaves = global.IntegrationBridge.getLeafDivisions(hierarchy, 'player') || []; } catch (_) {}
+      if (bridgedLeaves.length) {
+        groups.push({
+          key:'player', branch:{}, leaves:bridgedLeaves, isPlayer:true, faction:null,
+          factionId:'player', factionName:String(global.P && global.P.playerInfo && global.P.playerInfo.factionName || 'player')
+        });
+      }
+    }
+    if (groups.length === 1 && !groups[0].isPlayer) groups[0].isPlayer = true;
+    return groups;
+  }
+
+  function _allLeafDivisions(G, suppliedGroups) {
     var leaves = [];
-    Object.keys(ah).forEach(function(facId) {
-      var fl = IB.getLeafDivisions(ah, facId) || [];
-      for (var i = 0; i < fl.length; i++) { if (leaves.indexOf(fl[i]) < 0) leaves.push(fl[i]); }
+    (suppliedGroups || _factionLeafGroups(G)).forEach(function(group) {
+      (group.leaves || []).forEach(function(leaf) { if (leaves.indexOf(leaf) < 0) leaves.push(leaf); });
     });
     return leaves;
+  }
+
+  function _leafPopulationTotals(leaves) {
+    var totals = { mouths:0, households:0, ding:0 };
+    (leaves || []).forEach(function(leaf) {
+      var detail = leaf && leaf.populationDetail;
+      if (!detail) return;
+      totals.mouths += Math.max(0, Number(detail.mouths) || 0);
+      totals.households += Math.max(0, Number(detail.households) || 0);
+      totals.ding += Math.max(0, Number(detail.ding) || 0);
+    });
+    totals.mouths = Math.round(totals.mouths);
+    totals.households = Math.round(totals.households);
+    totals.ding = Math.round(totals.ding);
+    return totals;
+  }
+
+  function _ensureWorldPopulationSummary(G) {
+    if (!G.worldPopulationSummary || typeof G.worldPopulationSummary !== 'object' || Array.isArray(G.worldPopulationSummary)) {
+      G.worldPopulationSummary = { byFaction:{}, national:{ mouths:0, households:0, ding:0 } }; // arch-ok: 户籍权威写口创建世界人口只读汇总
+    }
+    if (!G.worldPopulationSummary.byFaction || typeof G.worldPopulationSummary.byFaction !== 'object') {
+      G.worldPopulationSummary.byFaction = {}; // arch-ok: 户籍权威写口修复世界人口分势力汇总
+    }
+    return G.worldPopulationSummary;
+  }
+
+  function _factionPopulationEntry(G, group) {
+    var world = _ensureWorldPopulationSummary(G);
+    var key = String(group && group.key || 'unknown');
+    var entry = world.byFaction[key];
+    if (!entry || typeof entry !== 'object') entry = world.byFaction[key] = {};
+    entry.factionId = group.factionId;
+    entry.factionName = group.factionName;
+    if (!entry.dynamics || typeof entry.dynamics !== 'object') entry.dynamics = _defaultDynamics();
+    return entry;
+  }
+
+  function _refreshWorldPopulationSummary(G, groups) {
+    var world = _ensureWorldPopulationSummary(G);
+    var aliveKeys = Object.create(null);
+    var total = { mouths:0, households:0, ding:0 };
+    (groups || []).forEach(function(group) {
+      var entry = _factionPopulationEntry(G, group);
+      var national = _leafPopulationTotals(group.leaves);
+      entry.national = national;
+      entry.isPlayer = !!group.isPlayer;
+      aliveKeys[group.key] = true;
+      total.mouths += national.mouths;
+      total.households += national.households;
+      total.ding += national.ding;
+    });
+    Object.keys(world.byFaction).forEach(function(key) {
+      if (!aliveKeys[key]) delete world.byFaction[key];
+    });
+    world.national = total;
+    world.updatedTurn = Number(G && G.turn) || 0;
+    return world;
   }
 
   // S1·人口自下而上：叶级增长(先只接本地民心)·写叶 populationDetail·national = Σ叶 增量同步。
@@ -564,103 +755,304 @@
     }
   }
 
-  function _tickPopulationLeafGrowth(ctx, mr, useLocalFactors, suppliedLeaves) {
-    var P = global.GM.population;
-    var G = global.GM;
-    var d = P.dynamics;
-    // 全国基准率(年景因子全国级·作各叶基准·与原逻辑同源)
-    var environmentLoad = (G.environment && G.environment.nationalLoad) || 0.5;
-    var disaster = (G.vars && G.vars.disasterLevel) || 0;
-    var war = (G.activeWars || []).length;
-    var baseBirth = d.birthRateBase + (d.prosperityBonus || 0) - Math.max(0, environmentLoad - 1) * 0.005;
-    if (disaster > 0.3) baseBirth -= 0.01;
-    var baseDeath = d.deathRateBase + (d.agingPenalty || 0) + (d.diseaseBoost || 0);
-    if (disaster > 0.3) baseDeath += disaster * 0.05;
-    if (war > 0) baseDeath += Math.min(0.03, war * 0.01);
-    if (environmentLoad > 1.2) baseDeath += (environmentLoad - 1.2) * 0.02;
-    // 全国比例仅作叶数据缺项时的 fallback；有叶级户丁账时保留各自历史结构。
-    var dingRatio = P.national.ding / Math.max(1, P.national.mouths);
-    var mphh = P.national.mouths / Math.max(1, P.national.households);
-    // 遍历叶(2026-06-20 真机修：遍历所有 faction·非仅 player)·各叶按本地民心算生死·写叶 populationDetail
-    var leaves = suppliedLeaves || _allLeafDivisions(G);
-    var totBirths = 0, totDeaths = 0, totNet = 0;
-    leaves.forEach(function(leaf) {
-      var pd = leaf && leaf.populationDetail;
-      if (!pd) return;
-      var mouths = Number(pd.mouths) || 0;
-      if (mouths <= 0) return;
-      var minxin = Number(leaf.minxin);
-      if (!isFinite(minxin)) minxin = Number(leaf.minxinLocal);
-      if (!isFinite(minxin)) minxin = 50;
-      // S2·粮食供需(马尔萨斯核心·接 renli)：载力 load = 口粮需求/粮食供给(含调入)·>1 缺粮
-      var rid = String(leaf.id || leaf.name || '');
-      var rg = (G.renli && G.renli.byRegion) ? (G.renli.byRegion[rid] || (leaf.name ? G.renli.byRegion[leaf.name] : null)) : null;
-      var load = 1;  // 无 renli 账(未种子)→中性·走民心/生活驱动
-      if (rg) {
-        var grainSupply = (Number(rg.grainOutput) || 0) + (Number(leaf._grainInflowThisTurn) || 0);  // +调入(S3 填)
-        var grainDemand = Number(rg.foodNeed) || 0;  // renli:282 = mouths×SUBSIST·随人口(马尔萨斯闭环)
-        if (grainDemand > 0) load = grainSupply > 0 ? grainDemand / grainSupply : 2;
-      }
-      // S2·生活水平(prosperity→生育)·灾异(death↑)·赋役(corvee→少生)
-      var prosperity = Number(leaf.prosperity); if (!isFinite(prosperity)) prosperity = 50;
-      var lifeLv = (prosperity - 50) / 100;
-      var rd = leaf.recentDisasters;
-      var hasDis = Array.isArray(rd) ? rd.length > 0 : !!rd;
-      var corvee = rg ? Math.max(0, Math.min(1, Number(rg.corveeRate) || 0)) : 0;
-      var localBirth = baseBirth;
-      var localDeath = baseDeath;
-      if (useLocalFactors) {
-        localBirth = baseBirth
-          * (1 + (minxin - 50) / 100 * 0.4)                  // 民心高→生育↑
-          * (1 + lifeLv * 0.3)                               // 生活好→生育↑
-          * Math.max(0.3, Math.min(1.1, 1.1 - load * 0.3))   // 粮紧(load高)→生育↓
-          * (1 - corvee * 0.2);                              // 役重→生育↓
-        localDeath = baseDeath
-          * (1 - (minxin - 50) / 100 * 0.25)                 // 民心高→死亡↓
-          * (1 + (hasDis ? 0.5 : 0))                         // 灾异→死亡↑
-          * (1 + Math.max(0, load - 1) * 0.6);               // 缺粮(load>1)→饥荒死亡↑
-      }
-      var births = Math.round(mouths * localBirth * mr / 12);
-      var deaths = Math.round(mouths * localDeath * mr / 12);
-      var net = births - deaths;
-      var leafDingRatio = Number(pd.ding) > 0 ? Number(pd.ding) / mouths : dingRatio;
-      var leafMouthsPerHousehold = Number(pd.households) > 0 ? mouths / Number(pd.households) : mphh;
-      pd.mouths = Math.max(0, mouths + net);                         // 写叶(增长落点)
-      pd.households = Math.round(pd.mouths / Math.max(1, leafMouthsPerHousehold));
-      pd.ding = Math.round(pd.mouths * leafDingRatio);
-      _syncLeafPopulationMirrors(leaf, pd);
-      var legacyRow = P.byRegion && (P.byRegion[rid] || (leaf.name ? P.byRegion[leaf.name] : null));
-      if (legacyRow && legacyRow !== pd) {
-        legacyRow.mouths = pd.mouths;
-        legacyRow.households = pd.households;
-        legacyRow.ding = pd.ding;
-      }
-      leaf.yearlyBirths = (leaf.yearlyBirths || 0) + births;
-      leaf.yearlyDeaths = (leaf.yearlyDeaths || 0) + deaths;
-      totBirths += births; totDeaths += deaths; totNet += net;
-      if (leaf._grainInflowThisTurn) leaf._grainInflowThisTurn = 0;  // S3·调粮用后清零(下回合 local action 重计)
-    });
-    // national 增量同步(maintain:377 之后从 Σ叶 精确重建·守恒 Σ叶 = national)
-    P.national.mouths = Math.max(100000, P.national.mouths + totNet);
-    P.national.ding = Math.round(P.national.mouths * dingRatio);
-    P.national.households = Math.round(P.national.mouths / mphh);
-    // 年度日志(复用原·全国口径)
-    if (!d._yearlyAccumBirths) d._yearlyAccumBirths = 0;
-    if (!d._yearlyAccumDeaths) d._yearlyAccumDeaths = 0;
-    d._yearlyAccumBirths += totBirths;
-    d._yearlyAccumDeaths += totDeaths;
-    if (!d._lastLogTurn) d._lastLogTurn = ctx.turn || 0;
+  function _recordPopulationDynamics(d, ctx, G, births, deaths, mr) {
+    if (!d || typeof d !== 'object') return;
+    if (!Array.isArray(d.yearlyLog)) d.yearlyLog = []; // arch-ok: 户籍权威写口维护分势力人口年账
+    d._yearlyAccumBirths = Number(d._yearlyAccumBirths) || 0; // arch-ok: 户籍权威写口维护分势力人口年账
+    d._yearlyAccumDeaths = Number(d._yearlyAccumDeaths) || 0; // arch-ok: 户籍权威写口维护分势力人口年账
+    d._yearlyAccumBirths += births; // arch-ok: 户籍权威写口维护分势力人口年账
+    d._yearlyAccumDeaths += deaths; // arch-ok: 户籍权威写口维护分势力人口年账
+    if (d._lastLogTurn == null) d._lastLogTurn = ctx.turn || 0; // arch-ok: 户籍权威写口维护分势力人口年账
     var yearlyLogTurns = (typeof global.turnsForMonths === 'function') ? global.turnsForMonths(12) : 12;
     if (((ctx.turn || 0) - d._lastLogTurn) >= yearlyLogTurns) {
-      var logYear = (typeof global.calcDateFromTurn === 'function') ? global.calcDateFromTurn(ctx.turn || 1).adYear
-        : ((G.year || ((global.P && global.P.time && global.P.time.year) || 0)) + Math.floor(Math.max(0, (ctx.turn || 1) - 1) * ((typeof global._getDaysPerTurn === 'function') ? global._getDaysPerTurn() : 30) / 365));
-      d.yearlyLog.push({ year: logYear, birth: d._yearlyAccumBirths, death: d._yearlyAccumDeaths, net: d._yearlyAccumBirths - d._yearlyAccumDeaths });
-      if (d.yearlyLog.length > 50) d.yearlyLog.splice(0, d.yearlyLog.length - 50);
-      d._lastLogTurn = ctx.turn || 0;
-      d._yearlyAccumBirths = 0;
-      d._yearlyAccumDeaths = 0;
+      var logYear = _calendarYearForTurn(ctx.turn || 1, G);
+      d.yearlyLog.push({ year:logYear, birth:d._yearlyAccumBirths, death:d._yearlyAccumDeaths, net:d._yearlyAccumBirths - d._yearlyAccumDeaths }); // arch-ok: 户籍权威写口维护分势力人口年账
+      if (d.yearlyLog.length > 50) d.yearlyLog.splice(0, d.yearlyLog.length - 50); // arch-ok: 户籍权威写口裁剪分势力人口年账
+      d._lastLogTurn = ctx.turn || 0; // arch-ok: 户籍权威写口维护分势力人口年账
+      d._yearlyAccumBirths = 0; // arch-ok: 户籍权威写口滚动分势力人口年账
+      d._yearlyAccumDeaths = 0; // arch-ok: 户籍权威写口滚动分势力人口年账
     }
-    d.lastYearNet = _annualizePopulationNet(totNet, mr);
+    d.lastYearNet = _annualizePopulationNet(births - deaths, mr); // arch-ok: 户籍权威写口维护分势力人口年账
+  }
+
+  function _calendarYearForTurn(turn, G) {
+    try {
+      if (typeof global.calcDateFromTurn === 'function') {
+        var date = global.calcDateFromTurn(turn || 1);
+        var year = Number(date && (date.adYear != null ? date.adYear : date.year));
+        if (isFinite(year)) return year;
+      }
+    } catch (_) {}
+    var startYear = Number(G && G.year);
+    if (!isFinite(startYear)) startYear = Number(global.P && global.P.time && global.P.time.year) || 0;
+    var days = (typeof global._getDaysPerTurn === 'function') ? Number(global._getDaysPerTurn()) : 30;
+    if (!(days > 0)) days = 30;
+    return startYear + Math.floor(Math.max(0, Number(turn || 1) - 1) * days / 365);
+  }
+
+  function _syncPlayerLegacyRow(P, leaf, detail) {
+    if (!P || !P.byRegion || !leaf || !detail) return;
+    var rid = String(leaf.id || leaf.name || '');
+    var legacyRow = P.byRegion[rid] || (leaf.name ? P.byRegion[leaf.name] : null);
+    if (legacyRow && legacyRow !== detail) {
+      legacyRow.mouths = detail.mouths;
+      legacyRow.households = detail.households;
+      legacyRow.ding = detail.ding;
+    }
+  }
+
+  function _tickPopulationLeafGrowth(ctx, mr, useLocalFactors, suppliedGroups) {
+    var P = global.GM.population;
+    var G = global.GM;
+    var groups = suppliedGroups || _factionLeafGroups(G);
+    groups.forEach(function(group) {
+      var entry = _factionPopulationEntry(G, group);
+      var d = group.isPlayer ? P.dynamics : entry.dynamics;
+      var beforeTotals = group.isPlayer && P.national
+        ? {
+            mouths:Math.max(0, Number(P.national.mouths) || 0),
+            households:Math.max(0, Number(P.national.households) || 0),
+            ding:Math.max(0, Number(P.national.ding) || 0)
+          }
+        : ((entry.national && Number(entry.national.mouths) > 0) ? entry.national : _leafPopulationTotals(group.leaves));
+      var dingRatio = beforeTotals.ding / Math.max(1, beforeTotals.mouths);
+      var mphh = beforeTotals.mouths / Math.max(1, beforeTotals.households);
+      var environmentLoad = group.isPlayer
+        ? ((G.environment && G.environment.nationalLoad) || 0.5)
+        : Number(group.branch && group.branch.environmentLoad);
+      if (!isFinite(environmentLoad)) environmentLoad = 0.5;
+      var disaster = Number(group.branch && group.branch.disasterLevel);
+      if (!isFinite(disaster)) disaster = group.isPlayer ? Number(G.vars && G.vars.disasterLevel) || 0 : 0;
+      var war = (G.activeWars || []).filter(function(activeWar) {
+        if (!activeWar || group.isPlayer) return group.isPlayer;
+        var refs = [activeWar.factionId, activeWar.attackerId, activeWar.defenderId, activeWar.sourceFactionId, activeWar.targetFactionId]
+          .map(String);
+        return refs.indexOf(group.factionId) >= 0;
+      }).length;
+      var baseBirth = Number(d.birthRateBase); if (!isFinite(baseBirth)) baseBirth = 0.035;
+      baseBirth += Number(d.prosperityBonus) || 0;
+      baseBirth -= Math.max(0, environmentLoad - 1) * 0.005;
+      if (disaster > 0.3) baseBirth -= 0.01;
+      var baseDeath = Number(d.deathRateBase); if (!isFinite(baseDeath)) baseDeath = 0.025;
+      baseDeath += (Number(d.agingPenalty) || 0) + (Number(d.diseaseBoost) || 0);
+      if (disaster > 0.3) baseDeath += disaster * 0.05;
+      if (war > 0) baseDeath += Math.min(0.03, war * 0.01);
+      if (environmentLoad > 1.2) baseDeath += (environmentLoad - 1.2) * 0.02;
+
+      var totBirths = 0, totDeaths = 0;
+      group.leaves.forEach(function(leaf) {
+        var pd = leaf && leaf.populationDetail;
+        if (!pd) return;
+        var mouths = Number(pd.mouths) || 0;
+        if (mouths <= 0) return;
+        var minxin = Number(leaf.minxin);
+        if (!isFinite(minxin)) minxin = Number(leaf.minxinLocal);
+        if (!isFinite(minxin)) minxin = 50;
+        var rid = String(leaf.id || leaf.name || '');
+        var rg = G.renli && G.renli.byRegion
+          ? (G.renli.byRegion[rid] || (leaf.name ? G.renli.byRegion[leaf.name] : null)) : null;
+        var load = 1;
+        if (rg) {
+          var grainSupply = (Number(rg.grainOutput) || 0) + (Number(leaf._grainInflowThisTurn) || 0);
+          var grainDemand = Number(rg.foodNeed) || 0;
+          if (grainDemand > 0) load = grainSupply > 0 ? grainDemand / grainSupply : 2;
+        }
+        var prosperity = Number(leaf.prosperity); if (!isFinite(prosperity)) prosperity = 50;
+        var lifeLv = (prosperity - 50) / 100;
+        var recentDisasters = leaf.recentDisasters;
+        var hasDisaster = Array.isArray(recentDisasters) ? recentDisasters.length > 0 : !!recentDisasters;
+        var corvee = rg ? Math.max(0, Math.min(1, Number(rg.corveeRate) || 0)) : 0;
+        var localBirth = baseBirth;
+        var localDeath = baseDeath;
+        if (useLocalFactors) {
+          localBirth = baseBirth
+            * (1 + (minxin - 50) / 100 * 0.4)
+            * (1 + lifeLv * 0.3)
+            * Math.max(0.3, Math.min(1.1, 1.1 - load * 0.3))
+            * (1 - corvee * 0.2);
+          localDeath = baseDeath
+            * (1 - (minxin - 50) / 100 * 0.25)
+            * (1 + (hasDisaster ? 0.5 : 0))
+            * (1 + Math.max(0, load - 1) * 0.6);
+        }
+        var births = Math.round(mouths * localBirth * mr / 12);
+        var deaths = Math.round(mouths * localDeath * mr / 12);
+        var leafDingRatio = Number(pd.ding) > 0 ? Number(pd.ding) / mouths : dingRatio;
+        var leafMouthsPerHousehold = Number(pd.households) > 0 ? mouths / Number(pd.households) : mphh;
+        pd.mouths = Math.max(0, mouths + births - deaths);
+        pd.households = Math.round(pd.mouths / Math.max(1, leafMouthsPerHousehold));
+        pd.ding = Math.round(pd.mouths * leafDingRatio);
+        _syncLeafPopulationMirrors(leaf, pd);
+        if (group.isPlayer) _syncPlayerLegacyRow(P, leaf, pd);
+        leaf.yearlyBirths = (Number(leaf.yearlyBirths) || 0) + births;
+        leaf.yearlyDeaths = (Number(leaf.yearlyDeaths) || 0) + deaths;
+        totBirths += births;
+        totDeaths += deaths;
+        if (leaf._grainInflowThisTurn) leaf._grainInflowThisTurn = 0;
+      });
+
+      var afterTotals = _leafPopulationTotals(group.leaves);
+      entry.national = afterTotals;
+      _recordPopulationDynamics(d, ctx, G, totBirths, totDeaths, mr);
+      if (group.isPlayer) {
+        // 叶级行政区是运行真值；national 必须始终与叶级合计严格相等。
+        // 可配置下限只约束损失账本，不得凭空在汇总层造人口。
+        P.national.mouths = afterTotals.mouths; // arch-ok: 户籍权威写口由玩家叶级真值聚合全国人口
+        P.national.households = afterTotals.households; // arch-ok: 户籍权威写口由玩家叶级真值聚合全国户数
+        P.national.ding = afterTotals.ding; // arch-ok: 户籍权威写口由玩家叶级真值聚合全国丁口
+      }
+    });
+    _refreshWorldPopulationSummary(G, groups);
+  }
+
+  function _findFactionPopulationGroup(G, options, groups) {
+    options = options || {};
+    groups = groups || _factionLeafGroups(G);
+    var regionId = _normPopulationName(options.regionId || options.regionName);
+    if (regionId) {
+      for (var regionGroupIndex = 0; regionGroupIndex < groups.length; regionGroupIndex++) {
+        var regionGroup = groups[regionGroupIndex];
+        var ownsRegion = (regionGroup.leaves || []).some(function(leaf) {
+          return [leaf && leaf.id, leaf && leaf.name, leaf && leaf.mapRegionId, leaf && leaf.regionId]
+            .map(_normPopulationName).some(function(alias) { return alias && alias === regionId; });
+        });
+        if (ownsRegion) return regionGroup;
+      }
+      return null;
+    }
+    var wanted = [_normPopulationName(options.factionKey), _normPopulationName(options.factionId), _normPopulationName(options.factionName)].filter(Boolean);
+    if (wanted.length) {
+      for (var i = 0; i < groups.length; i++) {
+        var group = groups[i];
+        var aliases = [group.key, group.factionId, group.factionName].map(_normPopulationName);
+        if (aliases.some(function(alias) { return alias && wanted.indexOf(alias) >= 0; })) return group;
+      }
+    }
+    return groups.find(function(group) { return group.isPlayer; }) || null;
+  }
+
+  function _applyPopulationLossToLeaves(group, mouthsRequested, dingRequested, cause, regionId) {
+    var wantedRegion = _normPopulationName(regionId);
+    var groupLeaves = (group && group.leaves || []).filter(function(leaf) {
+      return leaf && leaf.populationDetail && Number(leaf.populationDetail.mouths) > 0;
+    });
+    var leaves = wantedRegion ? groupLeaves.filter(function(leaf) {
+      return [leaf.id, leaf.name, leaf.mapRegionId, leaf.regionId]
+        .map(_normPopulationName).some(function(alias) { return alias && alias === wantedRegion; });
+    }) : groupLeaves;
+    if (!leaves.length) return { mouths:0, ding:0 };
+    var totals = _leafPopulationTotals(leaves);
+    var groupTotals = wantedRegion ? _leafPopulationTotals(groupLeaves) : totals;
+    var minimum = group.isPlayer ? _minimumPopulation(global.GM.population) : 0;
+    var mouthTarget = Math.min(
+      Math.max(0, Math.round(Number(mouthsRequested) || 0)),
+      totals.mouths,
+      Math.max(0, groupTotals.mouths - minimum)
+    );
+    var dingTarget = Number(dingRequested);
+    if (!(dingTarget >= 0) || !isFinite(dingTarget)) dingTarget = mouthTarget * totals.ding / Math.max(1, totals.mouths);
+    dingTarget = Math.min(Math.max(0, Math.round(dingTarget)), totals.ding);
+    var remainingMouthLoss = mouthTarget;
+    var remainingDingLoss = dingTarget;
+    var remainingMouthPool = totals.mouths;
+    var remainingDingPool = totals.ding;
+    var appliedMouths = 0;
+    var appliedDing = 0;
+    leaves.forEach(function(leaf, index) {
+      var detail = leaf.populationDetail;
+      var mouthsBefore = Math.max(0, Math.round(Number(detail.mouths) || 0));
+      var dingBefore = Math.max(0, Math.round(Number(detail.ding) || 0));
+      var mouthsPerHousehold = mouthsBefore / Math.max(1, Number(detail.households) || 0);
+      var mouthLoss = index === leaves.length - 1
+        ? Math.min(mouthsBefore, remainingMouthLoss)
+        : Math.min(mouthsBefore, Math.round(remainingMouthLoss * mouthsBefore / Math.max(1, remainingMouthPool)));
+      var dingLoss = index === leaves.length - 1
+        ? Math.min(dingBefore, remainingDingLoss)
+        : Math.min(dingBefore, Math.round(remainingDingLoss * dingBefore / Math.max(1, remainingDingPool)));
+      detail.mouths = Math.max(0, mouthsBefore - mouthLoss);
+      detail.ding = Math.max(0, dingBefore - dingLoss);
+      detail.households = detail.mouths > 0 ? Math.round(detail.mouths / Math.max(1, mouthsPerHousehold)) : 0;
+      leaf.yearlyDeaths = (Number(leaf.yearlyDeaths) || 0) + mouthLoss;
+      if (!Array.isArray(leaf.populationLossLedger)) leaf.populationLossLedger = [];
+      if (mouthLoss || dingLoss) {
+        leaf.populationLossLedger.push({ turn:Number(global.GM.turn) || 0, cause:String(cause || 'unknown'), mouths:mouthLoss, ding:dingLoss });
+        if (leaf.populationLossLedger.length > 40) leaf.populationLossLedger.splice(0, leaf.populationLossLedger.length - 40);
+      }
+      _syncLeafPopulationMirrors(leaf, detail);
+      if (group.isPlayer) _syncPlayerLegacyRow(global.GM.population, leaf, detail);
+      remainingMouthLoss -= mouthLoss;
+      remainingDingLoss -= dingLoss;
+      remainingMouthPool -= mouthsBefore;
+      remainingDingPool -= dingBefore;
+      appliedMouths += mouthLoss;
+      appliedDing += dingLoss;
+    });
+    return { mouths:appliedMouths, ding:appliedDing };
+  }
+
+  function _applyPopulationLossLegacy(P, mouthsRequested, dingRequested) {
+    var oldMouths = Math.max(0, Math.round(Number(P.national && P.national.mouths) || 0));
+    var oldDing = Math.max(0, Math.round(Number(P.national && P.national.ding) || 0));
+    var oldHouseholds = Math.max(0, Math.round(Number(P.national && P.national.households) || 0));
+    var mouthLoss = Math.min(Math.max(0, Math.round(Number(mouthsRequested) || 0)), Math.max(0, oldMouths - _minimumPopulation(P)));
+    var requestedDing = Number(dingRequested);
+    if (!(requestedDing >= 0) || !isFinite(requestedDing)) requestedDing = mouthLoss * oldDing / Math.max(1, oldMouths);
+    var dingLoss = Math.min(oldDing, Math.max(0, Math.round(requestedDing)));
+    var mouthsPerHousehold = oldMouths / Math.max(1, oldHouseholds);
+    P.national.mouths = oldMouths - mouthLoss; // arch-ok: 无叶级旧档的人口损失兼容写口
+    P.national.ding = oldDing - dingLoss; // arch-ok: 无叶级旧档的丁口损失兼容写口
+    P.national.households = P.national.mouths > 0 ? Math.round(P.national.mouths / Math.max(1, mouthsPerHousehold)) : 0; // arch-ok: 无叶级旧档的户数损失兼容写口
+    return { mouths:mouthLoss, ding:dingLoss };
+  }
+
+  function _appendPopulationLossLedger(owner, row) {
+    if (!owner || typeof owner !== 'object') return;
+    if (!Array.isArray(owner.mortalityLedger)) owner.mortalityLedger = [];
+    owner.mortalityLedger.push(row);
+    if (owner.mortalityLedger.length > 120) owner.mortalityLedger.splice(0, owner.mortalityLedger.length - 120);
+  }
+
+  // 所有人口损失的唯一落点：先写叶级人口真值，再汇总 national。
+  // 供徭役、工程、气候、瘟疫等系统复用，避免“只扣 national 后被 RuntimeBridge 抹掉”。
+  function applyPopulationLoss(options) {
+    options = options || {};
+    var G = global.GM;
+    var P = G && G.population;
+    if (!P || !P.national) return { ok:false, reason:'population-unavailable', mouths:0, ding:0 };
+    var groups = _factionLeafGroups(G);
+    var group = _findFactionPopulationGroup(G, options, groups);
+    if ((options.regionId || options.regionName) && !group) {
+      return { ok:false, reason:'region-not-found', mouths:0, ding:0 };
+    }
+    var applied;
+    var entry = null;
+    if (group && group.leaves.length) {
+      applied = _applyPopulationLossToLeaves(group, options.mouths, options.ding, options.cause, options.regionId || options.regionName);
+      var totals = _leafPopulationTotals(group.leaves);
+      entry = _factionPopulationEntry(G, group);
+      entry.national = totals;
+      if (group.isPlayer) {
+        P.national.mouths = totals.mouths; // arch-ok: 死亡账本由玩家叶级真值聚合全国人口
+        P.national.households = totals.households; // arch-ok: 死亡账本由玩家叶级真值聚合全国户数
+        P.national.ding = totals.ding; // arch-ok: 死亡账本由玩家叶级真值聚合全国丁口
+        if (P.dynamics) P.dynamics._yearlyAccumDeaths = (Number(P.dynamics._yearlyAccumDeaths) || 0) + applied.mouths; // arch-ok: 死亡账本同步玩家年度死亡统计
+      } else if (entry.dynamics) {
+        entry.dynamics._yearlyAccumDeaths = (Number(entry.dynamics._yearlyAccumDeaths) || 0) + applied.mouths;
+      }
+      _refreshWorldPopulationSummary(G, groups);
+    } else {
+      applied = _applyPopulationLossLegacy(P, options.mouths, options.ding);
+      if (P.dynamics) P.dynamics._yearlyAccumDeaths = (Number(P.dynamics._yearlyAccumDeaths) || 0) + applied.mouths; // arch-ok: 旧档死亡账本同步玩家年度死亡统计
+    }
+    var ledgerRow = {
+      turn:Number(G.turn) || 0,
+      factionId:group ? group.factionId : String(options.factionId || 'player'),
+      cause:String(options.cause || 'unknown'),
+      mouths:applied.mouths,
+      ding:applied.ding
+    };
+    _appendPopulationLossLedger(group && !group.isPlayer ? entry : P, ledgerRow);
+    return { ok:true, mouths:applied.mouths, ding:applied.ding, factionId:group && group.factionId };
   }
 
   function _deepFieldDiversityPressure(r) {
@@ -752,10 +1144,32 @@
   //  Ⅴ 徭役征发 + 死亡率 + 逃役
   // ═══════════════════════════════════════════════════════════════════
 
+  function _ensureCorveeAnnualWindow(c, ctx) {
+    var year = _calendarYearForTurn(ctx && ctx.turn || global.GM.turn || 1, global.GM);
+    var firstBinding = c.currentYear === undefined || c.currentYear === null;
+    var changed = !firstBinding && Number(c.currentYear) !== Number(year);
+    Object.keys(c.byType || {}).forEach(function(key) {
+      var type = c.byType[key];
+      if (!type || typeof type !== 'object') return;
+      if (changed || firstBinding) {
+        type.currentYearDays = 0;
+        type.currentYearFulfilled = 0;
+        type.currentYearDeaths = 0;
+      } else {
+        if (!isFinite(Number(type.currentYearDays))) type.currentYearDays = 0;
+        if (!isFinite(Number(type.currentYearFulfilled))) type.currentYearFulfilled = 0;
+        if (!isFinite(Number(type.currentYearDeaths))) type.currentYearDeaths = 0;
+      }
+    });
+    c.currentYear = year; // arch-ok: 户籍权威写口滚动年度徭役窗口
+    return year;
+  }
+
   function _tickCorvee(ctx, mr) {
     var P = global.GM.population;
     if (!P || !P.corvee || !P.corvee.enabled) return;
     var c = P.corvee;
+    _ensureCorveeAnnualWindow(c, ctx);
     // 计算有效丁
     var totalDing = P.national.ding || 0;
     var serviceAgeDing = P.deepFieldEffects && P.deepFieldEffects.serviceAgeDing ? P.deepFieldEffects.serviceAgeDing : _computeDeepServiceDing(P);
@@ -787,18 +1201,22 @@
       var type = c.byType[k];
       if (!type) return;
       var req = effectiveDing * t.daysPerDing * mr / 12;
-      type.totalDays += req;
-      type.fulfilled += req * (1 - (global.GM.population.fugitives || 0) / Math.max(1, totalDing));
+      var fulfilled = req * (1 - (global.GM.population.fugitives || 0) / Math.max(1, totalDing));
+      type.totalDays = (Number(type.totalDays) || 0) + req;
+      type.fulfilled = (Number(type.fulfilled) || 0) + fulfilled;
+      type.currentYearDays = (Number(type.currentYearDays) || 0) + req;
+      type.currentYearFulfilled = (Number(type.currentYearFulfilled) || 0) + fulfilled;
       // 死亡
       var dyingDing = effectiveDing * t.deathRate * mr / 12 * (CATEGORY_TEMPLATES[k] ? CATEGORY_TEMPLATES[k].corveeLevel || 1 : 1);
-      type.deaths += dyingDing;
-      // 汇入全国死亡
-      P.national.ding = Math.max(0, P.national.ding - dyingDing);
-      P.national.mouths = Math.max(0, P.national.mouths - dyingDing);
+      var mortality = applyPopulationLoss({ cause:'corvee:' + k, mouths:dyingDing, ding:dyingDing });
+      type.deaths = (Number(type.deaths) || 0) + mortality.ding;
+      type.currentYearDeaths = (Number(type.currentYearDeaths) || 0) + mortality.ding;
     });
     // 逃役——burden 超过阈值
-    var corveeBurden = c.byType.junyi.totalDays + c.byType.gongyi.totalDays;
+    var corveeBurden = (Number(c.byType.junyi && c.byType.junyi.currentYearDays) || 0)
+      + (Number(c.byType.gongyi && c.byType.gongyi.currentYearDays) || 0);
     corveeBurden = corveeBurden / Math.max(1, effectiveDing * 365);
+    c.currentYearBurden = corveeBurden; // arch-ok: 户籍权威写口记录本年徭役压力
     if (corveeBurden > c.burdenThreshold) {
       var _rlShare = (function(){ var rl = _renli(); return (rl && rl.seededDingShare) ? rl.seededDingShare() : 0; })(); // 已种子地域逃役归 Renli·按未种子丁占比缩减（A2a）
       var newFugitives = Math.round(effectiveDing * (corveeBurden - c.burdenThreshold) * 0.1 * mr * (1 - _rlShare));
@@ -861,9 +1279,8 @@
       var progressPerMonth = 1 / Math.max(1, a.duration * 12);
       a.progress += progressPerMonth * mr;
       var deathsThisMonth = a.laborDemand * a.deathRate * progressPerMonth * mr;
-      a.totalDeaths += deathsThisMonth;
-      P.national.ding = Math.max(0, P.national.ding - deathsThisMonth);
-      P.national.mouths = Math.max(0, P.national.mouths - deathsThisMonth);
+      var mortality = applyPopulationLoss({ cause:'large-corvee:' + String(a.presetId || a.id || 'unknown'), mouths:deathsThisMonth, ding:deathsThisMonth });
+      a.totalDeaths += mortality.ding;
       // 完工
       if (a.progress >= 1.0) {
         a.status = 'completed';
@@ -926,11 +1343,16 @@
   function _tickMigration(ctx, mr) {
     var P = global.GM.population;
     if (!P) return;
-    // 京畿虹吸（S4·人口自下而上：开关开走叶级 populationDetail·否则原 byRegion）
-    var capital = global.GM._capital || '京城';
-    if (global.P && global.P.conf && global.P.conf.populationBottomUpEnabled) {
-      _tickMigrationLeaf(ctx, mr, capital);
-    } else if (P.byRegion && P.byRegion[capital]) {
+    // 行政叶是运行真值时，每个势力只在自己的叶级人口和首都之间迁徙。
+    var groups = _factionLeafGroups(global.GM);
+    var hasLeafPopulation = groups.some(function(group) {
+      return group.leaves.some(function(leaf) { return leaf && leaf.populationDetail && Number(leaf.populationDetail.mouths) > 0; });
+    });
+    if (hasLeafPopulation) {
+      _tickMigrationLeaf(ctx, mr, groups);
+    } else {
+      var capital = global.GM._capital || '京城';
+      if (P.byRegion && P.byRegion[capital]) {
       Object.keys(P.byRegion).forEach(function(rid) {
         if (rid === capital) return;
         var r = P.byRegion[rid];
@@ -943,73 +1365,176 @@
           P.byRegion[capital].yearlyNetMigration = (P.byRegion[capital].yearlyNetMigration || 0) + flow;
         }
       });
+      }
     }
     // 历史大迁徙事件——按 turn/century 触发
-    var currentYear = global.GM.year || 1;
-    var century = Math.floor(currentYear / 100);
+    if (!P.migrationEventStates || typeof P.migrationEventStates !== 'object' || Array.isArray(P.migrationEventStates)) P.migrationEventStates = {}; // arch-ok: 户籍权威写口创建战役迁徙状态
+    if (!Array.isArray(P.triggeredMigrationEventIds)) P.triggeredMigrationEventIds = []; // arch-ok: 户籍权威写口创建已触发迁徙集合
+    (P.migrationEvents || []).forEach(function(record) {
+      if (record && record.id && P.triggeredMigrationEventIds.indexOf(record.id) < 0) P.triggeredMigrationEventIds.push(record.id); // arch-ok: 户籍权威写口迁移旧事件收据
+    });
+    var currentYear = _calendarYearForTurn(ctx.turn || global.GM.turn || 1, global.GM);
+    var century = Math.floor((currentYear - 1) / 100) + 1;
     MIGRATION_EVENTS.forEach(function(e) {
-      if (e._triggered) return;
-      if (century >= e.century && !e._triggered && currentYear % 100 < 30) {
-        // 触发
-        e._triggered = true;
-        _executeMigrationEvent(e);
+      var state = P.migrationEventStates[e.id];
+      if ((state && state.status === 'triggered') || P.triggeredMigrationEventIds.indexOf(e.id) >= 0) return;
+      if (!(century >= e.century && currentYear % 100 < 30)) return;
+      var result = _executeMigrationEvent(e, groups);
+      if (result && result.ok) {
+        P.migrationEventStates[e.id] = { status:'triggered', turn:Number(global.GM.turn) || 0, scale:result.scale }; // arch-ok: 户籍权威写口提交战役迁徙状态
+        if (P.triggeredMigrationEventIds.indexOf(e.id) < 0) P.triggeredMigrationEventIds.push(e.id); // arch-ok: 户籍权威写口提交已触发迁徙 ID
+      } else {
+        P.migrationEventStates[e.id] = { // arch-ok: 户籍权威写口记录待处理迁徙状态
+          status:'pending',
+          lastAttemptTurn:Number(global.GM.turn) || 0,
+          reason:String(result && result.reason || 'region-match-failed')
+        };
       }
     });
   }
 
-  // S4·人口自下而上：京畿虹吸叶级化(非首都叶 → 首都叶·守恒叶间转移·写 populationDetail·与增长同源)
-  function _tickMigrationLeaf(ctx, mr, capital) {
+  function _capitalCandidatesForGroup(group) {
     var G = global.GM;
     var P = G.population;
-    var leaves = _allLeafDivisions(G);  // (2026-06-20 真机修：遍历所有 faction)
-    if (!leaves.length) return;
-    var dingRatio = P.national.ding / Math.max(1, P.national.mouths);
-    var mphh = P.national.mouths / Math.max(1, P.national.households);
-    var capLeaf = null;
-    for (var i = 0; i < leaves.length; i++) {
-      var lid = String(leaves[i].id || leaves[i].name || '');
-      if (lid === capital || leaves[i].name === capital) { capLeaf = leaves[i]; break; }
+    var values = [];
+    function add(value) {
+      var text = String(value == null ? '' : value).trim();
+      if (text && values.indexOf(text) < 0) values.push(text);
     }
-    if (!capLeaf) return;  // 无首都叶→不虹吸(避免流出无接收·破坏守恒·对齐原 byRegion 的 if(P.byRegion[capital]) 守卫)
-    var pullRate = 0.0001 * mr;  // 月千分之一流入京畿(与原 byRegion 逻辑同率)
-    var totalFlow = 0;
-    leaves.forEach(function(l) {
-      if (l === capLeaf) return;
-      var pd = l.populationDetail; if (!pd) return;
-      var mouths = Number(pd.mouths) || 0;
-      if (mouths <= 10000) return;
-      var flow = Math.round(mouths * pullRate);
-      if (flow > 0) {
-        pd.mouths = mouths - flow;
-        pd.households = Math.round(pd.mouths / mphh);
-        pd.ding = Math.round(pd.mouths * dingRatio);
-        l.yearlyNetMigration = (l.yearlyNetMigration || 0) - flow;
-        totalFlow += flow;
-      }
-    });
-    if (capLeaf && capLeaf.populationDetail && totalFlow > 0) {
-      var cpd = capLeaf.populationDetail;
-      cpd.mouths = (Number(cpd.mouths) || 0) + totalFlow;
-      cpd.households = Math.round(cpd.mouths / mphh);
-      cpd.ding = Math.round(cpd.mouths * dingRatio);
-      capLeaf.yearlyNetMigration = (capLeaf.yearlyNetMigration || 0) + totalFlow;
+    if (group.isPlayer) {
+      add(G._capital); add(G.capital); add(global.P && global.P.playerInfo && global.P.playerInfo.capital);
+      add(global.P && global.P.playerInfo && global.P.playerInfo.capitalName);
+      add(P && P.capital);
     }
+    add(group.branch && group.branch.capital);
+    add(group.branch && group.branch.capitalName);
+    add(group.branch && group.branch.capitalChildId);
+    add(group.faction && group.faction.capital);
+    add(group.faction && group.faction.capitalName);
+    return values;
   }
 
-  function _executeMigrationEvent(e) {
+  function _findCapitalLeaf(group) {
+    var candidates = _capitalCandidatesForGroup(group).map(_normPopulationName).filter(Boolean);
+    for (var i = 0; i < group.leaves.length; i++) {
+      var leaf = group.leaves[i];
+      if (leaf && (leaf.isCapital || leaf.regionType === 'capital' || leaf.type === 'capital')) return leaf;
+    }
+    for (var j = 0; j < group.leaves.length; j++) {
+      var current = group.leaves[j];
+      var aliases = [current && current.id, current && current.name, current && current.capital, current && current.mapRegionId]
+        .map(_normPopulationName).filter(Boolean);
+      if (aliases.some(function(alias) {
+        return candidates.some(function(candidate) { return alias === candidate || alias.indexOf(candidate) >= 0 || candidate.indexOf(alias) >= 0; });
+      })) return current;
+    }
+    return null;
+  }
+
+  // S4·京畿虹吸按 faction 分账；任何来源与目标都必须属于同一 group。
+  function _tickMigrationLeaf(ctx, mr, suppliedGroups) {
+    var G = global.GM;
+    var P = G.population;
+    var groups = suppliedGroups || _factionLeafGroups(G);
+    groups.forEach(function(group) {
+      var capLeaf = _findCapitalLeaf(group);
+      if (!capLeaf || !capLeaf.populationDetail) return;
+      var totals = _leafPopulationTotals(group.leaves);
+      var dingRatio = totals.ding / Math.max(1, totals.mouths);
+      var mphh = totals.mouths / Math.max(1, totals.households);
+      var pullRate = 0.0001 * mr;
+      var totalFlow = 0;
+      group.leaves.forEach(function(leaf) {
+        if (leaf === capLeaf) return;
+        var detail = leaf && leaf.populationDetail;
+        if (!detail) return;
+        var mouths = Number(detail.mouths) || 0;
+        if (mouths <= 10000) return;
+        var flow = Math.round(mouths * pullRate);
+        if (flow > 0) {
+          var localDingRatio = Number(detail.ding) > 0 ? Number(detail.ding) / mouths : dingRatio;
+          var localMphh = Number(detail.households) > 0 ? mouths / Number(detail.households) : mphh;
+          detail.mouths = mouths - flow;
+          detail.households = Math.round(detail.mouths / Math.max(1, localMphh));
+          detail.ding = Math.round(detail.mouths * localDingRatio);
+          _syncLeafPopulationMirrors(leaf, detail);
+          if (group.isPlayer) _syncPlayerLegacyRow(P, leaf, detail);
+          leaf.yearlyNetMigration = (Number(leaf.yearlyNetMigration) || 0) - flow;
+          totalFlow += flow;
+        }
+      });
+      if (totalFlow > 0) {
+        var capitalDetail = capLeaf.populationDetail;
+        var capitalMouths = Number(capitalDetail.mouths) || 0;
+        var capitalDingRatio = Number(capitalDetail.ding) > 0 ? Number(capitalDetail.ding) / Math.max(1, capitalMouths) : dingRatio;
+        var capitalMphh = Number(capitalDetail.households) > 0 ? capitalMouths / Number(capitalDetail.households) : mphh;
+        capitalDetail.mouths = capitalMouths + totalFlow;
+        capitalDetail.households = Math.round(capitalDetail.mouths / Math.max(1, capitalMphh));
+        capitalDetail.ding = Math.round(capitalDetail.mouths * capitalDingRatio);
+        _syncLeafPopulationMirrors(capLeaf, capitalDetail);
+        if (group.isPlayer) _syncPlayerLegacyRow(P, capLeaf, capitalDetail);
+        capLeaf.yearlyNetMigration = (Number(capLeaf.yearlyNetMigration) || 0) + totalFlow;
+      }
+    });
+    var playerGroup = groups.find(function(group) { return group.isPlayer; });
+    if (playerGroup) {
+      var playerTotals = _leafPopulationTotals(playerGroup.leaves);
+      P.national.mouths = playerTotals.mouths; // arch-ok: 户籍权威写口由玩家叶级真值聚合全国人口
+      P.national.households = playerTotals.households; // arch-ok: 户籍权威写口由玩家叶级真值聚合全国户数
+      P.national.ding = playerTotals.ding; // arch-ok: 户籍权威写口由玩家叶级真值聚合全国丁口
+    }
+    _refreshWorldPopulationSummary(G, groups);
+  }
+
+  function _executeMigrationEvent(e, suppliedGroups) {
     var P = global.GM.population;
-    if (!P || !P.byRegion) return;
-    // 找对应区域
-    var fromKey = Object.keys(P.byRegion).find(function(k) { return k.indexOf(e.fromRegion) >= 0; });
-    var toKey = Object.keys(P.byRegion).find(function(k) { return k.indexOf(e.toRegion) >= 0; });
-    if (!fromKey || !toKey) return;
-    var from = P.byRegion[fromKey];
-    var to = P.byRegion[toKey];
-    var scale = Math.min(e.scale, from.mouths * 0.3);
-    from.mouths -= scale;
-    to.mouths += scale;
+    if (!P) return { ok:false, reason:'population-unavailable' };
+    if (!Array.isArray(P.migrationEvents)) P.migrationEvents = [];
+    var groups = suppliedGroups || _factionLeafGroups(global.GM);
+    var playerGroup = groups.find(function(group) { return group.isPlayer; });
+    var from = null, to = null;
+    if (playerGroup) {
+      from = playerGroup.leaves.find(function(leaf) { return _normPopulationName(leaf && (leaf.name || leaf.id)).indexOf(_normPopulationName(e.fromRegion)) >= 0; });
+      to = playerGroup.leaves.find(function(leaf) { return _normPopulationName(leaf && (leaf.name || leaf.id)).indexOf(_normPopulationName(e.toRegion)) >= 0; });
+    }
+    if (from && to && from.populationDetail && to.populationDetail) {
+      var fromDetail = from.populationDetail;
+      var toDetail = to.populationDetail;
+      var fromMouths = Math.max(0, Number(fromDetail.mouths) || 0);
+      var toMouths = Math.max(0, Number(toDetail.mouths) || 0);
+      var scale = Math.max(0, Math.round(Math.min(e.scale, fromMouths * 0.3)));
+      if (!scale) return { ok:false, reason:'source-population-empty' };
+      var fromMphh = fromMouths / Math.max(1, Number(fromDetail.households) || 0);
+      var fromDingRatio = Number(fromDetail.ding) / Math.max(1, fromMouths);
+      var toMphh = toMouths / Math.max(1, Number(toDetail.households) || 0);
+      var toDingRatio = Number(toDetail.ding) / Math.max(1, toMouths);
+      fromDetail.mouths = fromMouths - scale;
+      fromDetail.households = Math.round(fromDetail.mouths / Math.max(1, fromMphh));
+      fromDetail.ding = Math.round(fromDetail.mouths * fromDingRatio);
+      toDetail.mouths = toMouths + scale;
+      toDetail.households = Math.round(toDetail.mouths / Math.max(1, toMphh));
+      toDetail.ding = Math.round(toDetail.mouths * toDingRatio);
+      _syncLeafPopulationMirrors(from, fromDetail);
+      _syncLeafPopulationMirrors(to, toDetail);
+      _syncPlayerLegacyRow(P, from, fromDetail);
+      _syncPlayerLegacyRow(P, to, toDetail);
+      from.yearlyNetMigration = (Number(from.yearlyNetMigration) || 0) - scale;
+      to.yearlyNetMigration = (Number(to.yearlyNetMigration) || 0) + scale;
+    } else {
+      if (!P.byRegion) return { ok:false, reason:'regions-unavailable' };
+      var fromKey = Object.keys(P.byRegion).find(function(k) { return _normPopulationName(k).indexOf(_normPopulationName(e.fromRegion)) >= 0; });
+      var toKey = Object.keys(P.byRegion).find(function(k) { return _normPopulationName(k).indexOf(_normPopulationName(e.toRegion)) >= 0; });
+      if (!fromKey || !toKey) return { ok:false, reason:'region-match-failed' };
+      from = P.byRegion[fromKey];
+      to = P.byRegion[toKey];
+      var scale = Math.max(0, Math.round(Math.min(e.scale, (Number(from.mouths) || 0) * 0.3)));
+      if (!scale) return { ok:false, reason:'source-population-empty' };
+      from.mouths -= scale;
+      to.mouths += scale;
+    }
     P.migrationEvents.push({ id: e.id, name: e.name, turn: global.GM.turn, scale: scale });
     if (global.addEB) global.addEB('迁徙', e.name + '：' + e.fromRegion + ' → ' + e.toRegion + ' 约 ' + Math.round(scale/10000) + ' 万口');
+    return { ok:true, scale:scale };
   }
 
   // ═══════════════════════════════════════════════════════════════════
@@ -1020,7 +1545,9 @@
     var P = global.GM.population;
     if (!P || !P.meta) return;
     var turnsSince = (ctx.turn || 0) - (P.meta.lastRegistrationTurn || 0);
-    if (turnsSince < P.meta.registrationCycle * 12) return;
+    var cycleMonths = Math.max(0, Number(P.meta.registrationCycle) || 0) * 12;
+    var cycleTurns = (typeof global.turnsForMonths === 'function') ? global.turnsForMonths(cycleMonths) : cycleMonths;
+    if (turnsSince < Math.max(1, Number(cycleTurns) || 1)) return;
     // 触发造册
     var cost = Math.round(P.national.households * 0.05);
     if (global.GM.guoku && global.GM.guoku.money !== undefined && global.GM.guoku.money >= cost) {
@@ -1118,6 +1645,7 @@
   global.HujiEngine = {
     init: init,
     tick: tick,
+    applyPopulationLoss: applyPopulationLoss,
     startLargeCorvee: startLargeCorvee,
     getAIContext: getAIContext,
     CATEGORY_TEMPLATES: CATEGORY_TEMPLATES,

--- a/web/tm-huji-runtime-bridge.js
+++ b/web/tm-huji-runtime-bridge.js
@@ -182,9 +182,25 @@
         try { leaves = global.IntegrationBridge.getLeafDivisions(root.adminHierarchy) || []; } catch (_) { leaves = []; }
       }
       if (!leaves.length) {
-        Object.keys(root.adminHierarchy || {}).forEach(function(k) {
-          walkAdminNode(root.adminHierarchy[k], leaves);
-        });
+        var hierarchy = root.adminHierarchy || {};
+        var playerKey = null;
+        if (typeof global._tmResolvePlayerAdminKey === 'function') {
+          try { playerKey = global._tmResolvePlayerAdminKey(hierarchy) || null; } catch (_) {}
+        }
+        if (!playerKey && Object.prototype.hasOwnProperty.call(hierarchy, 'player')) playerKey = 'player';
+        if (!playerKey && Array.isArray(hierarchy.divisions)) {
+          walkAdminNode(hierarchy.divisions, leaves);
+        } else if (!playerKey) {
+          var candidateKeys = Object.keys(hierarchy).filter(function(k) {
+            var branch = hierarchy[k];
+            return Array.isArray(branch) || (branch && Array.isArray(branch.divisions));
+          });
+          if (candidateKeys.length === 1) playerKey = candidateKeys[0];
+        }
+        // Compatibility aggregation must never silently turn a multi-faction
+        // world into the player's national ledger. If ownership is ambiguous,
+        // leave the fallback empty instead of summing every faction together.
+        if (playerKey) walkAdminNode(hierarchy[playerKey], leaves);
       }
     }
     if (!leaves.length && Array.isArray(root.regions)) leaves = root.regions.slice();

--- a/web/tm-region-enrich.js
+++ b/web/tm-region-enrich.js
@@ -573,8 +573,10 @@
       var seasonMult = (profile.seasonBoost && profile.seasonBoost[season]) || 1.0;
       e.affected = Math.floor(e.affected * (1 + profile.spread * seasonMult * mr));
       var deaths = Math.floor(e.affected * profile.mortality * 0.05 * mr);
-      e.deaths = (e.deaths || 0) + deaths;
-      if (G.population.national) G.population.national.mouths = Math.max(0, G.population.national.mouths - deaths);
+      if (!global.HujiEngine || typeof global.HujiEngine.applyPopulationLoss !== 'function') throw new Error('人口损失账本不可用');
+      var mortality = global.HujiEngine.applyPopulationLoss({ cause:'disease-cycle:' + String(e.disease || 'unknown'), regionId:e.region || '', mouths:deaths });
+      if (!mortality || mortality.ok === false) throw new Error('疫病人口损失落账失败: ' + String(mortality && mortality.reason || 'unknown'));
+      e.deaths = (e.deaths || 0) + mortality.mouths;
       if ((G.turn - e.startTurn) > _turnsForMonthsLocal(24) || Math.random() < 0.02 * mr) e.status = 'ended';
     });
     // 新疫病触发（低概率）

--- a/web/tm-save-lifecycle.js
+++ b/web/tm-save-lifecycle.js
@@ -1130,12 +1130,44 @@ function _tmStableIdHash(text) {
   return ('00000000' + (hash >>> 0).toString(16)).slice(-8);
 }
 
+function _tmStableIdentityParts(kind, item) {
+  item = item || {};
+  var sourceIdentity = [item.sourceId, item.sourceKey, item.uuid, item.legacyId, item.originalId]
+    .map(function(value) { return value === undefined || value === null ? '' : String(value).trim(); })
+    .filter(Boolean);
+  // 显式来源身份单独构成种子；若再拼入可改名的显示字段，同一 sourceId
+  // 在旧档分支改名后仍会生成不同 ID。
+  if (sourceIdentity.length) return ['source'].concat(sourceIdentity);
+  var semanticIdentity;
+  if (kind === 'char') {
+    semanticIdentity = [item.sid, item.key, item.name, item.zi, item.courtesyName, item.birthDate, item.birthYear, item.birthplace, item.gender];
+  } else if (kind === 'faction') {
+    semanticIdentity = [item.sid, item.key, item.name, item.foundedYear, item.dynasty, item.culture, item.faith];
+  } else if (kind === 'army') {
+    semanticIdentity = [item.sid, item.key, item.name, item.createdTurn, item.foundedYear, item.homeRegionId, item.homeRegion];
+  } else if (kind === 'region' || kind === 'division') {
+    semanticIdentity = [item.sid, item.key, item.mapRegionId, item.regionId, item.name, item.level, item.parentId, item.longitude, item.latitude];
+  } else {
+    semanticIdentity = [item.name, item.title, item.type, item.kind];
+  }
+  // Only immutable/source-like attributes participate. Faction, owner,
+  // location, commander and composition are gameplay state and would make a
+  // legacy entity change identity across save branches.
+  return semanticIdentity.map(function(value) {
+    if (value === undefined || value === null) return '';
+    if (typeof value === 'object') {
+      try { return JSON.stringify(value); } catch (_) { return ''; }
+    }
+    return String(value).trim();
+  }).filter(Boolean);
+}
+
 function _tmCollectAdminDivisionEntries(targetGM) {
   var out = [];
   var hierarchy = targetGM && targetGM.adminHierarchy;
   if (!hierarchy || typeof hierarchy !== 'object') return out;
   var visited = typeof WeakSet === 'function' ? new WeakSet() : null;
-  function walk(nodes, path) {
+  function walk(nodes, path, identityPath) {
     (Array.isArray(nodes) ? nodes : []).forEach(function(node, index) {
       if (!node || typeof node !== 'object') return;
       if (visited) {
@@ -1143,14 +1175,23 @@ function _tmCollectAdminDivisionEntries(targetGM) {
         visited.add(node);
       }
       var nodePath = path + '/' + index;
-      out.push({ item: node, path: nodePath });
-      walk(node.children || node.divisions || node.subdivisions || [], nodePath);
+      var identityToken = _tmStableIdentityParts('division', node).join('|') || ('index:' + index);
+      var nodeIdentityPath = identityPath + '/' + identityToken;
+      out.push({ item: node, path: nodePath, identityPath: nodeIdentityPath });
+      [node.children, node.divisions, node.subdivisions, node.subs].forEach(function(children) {
+        if (Array.isArray(children)) walk(children, nodePath, nodeIdentityPath);
+      });
     });
   }
-  Object.keys(hierarchy).sort().forEach(function(factionKey) {
-    var branch = hierarchy[factionKey];
-    walk(branch && branch.divisions, 'admin/' + factionKey);
-  });
+  if (Array.isArray(hierarchy.divisions)) {
+    walk(hierarchy.divisions, 'admin/player', 'admin/player');
+  } else {
+    Object.keys(hierarchy).sort().forEach(function(factionKey) {
+      var branch = hierarchy[factionKey];
+      var roots = Array.isArray(branch) ? branch : (branch && branch.divisions);
+      walk(roots, 'admin/' + factionKey, 'admin/' + factionKey);
+    });
+  }
   return out;
 }
 
@@ -1167,15 +1208,19 @@ function _tmAssignMissingStableIds(targetGM, kind, entries) {
     var item = entry && entry.item;
     if (!item || !_tmStableIdMissing(item.id)) return;
     var path = String(entry.path || index);
-    var seed = [
-      targetGM && (targetGM.sid || targetGM._campaignId) || '', kind, path,
-      item.sid || '', item.sourceId || '', item.key || '', item.name || '',
-      item.title || '', item.faction || '', item.owner || '', item.type || ''
-    ].join('|');
+    var identityParts = _tmStableIdentityParts(kind, item);
+    // 数组位置只在实体完全没有语义身份，或同指纹碰撞时作最后消歧；
+    // 常规人物/势力/军队/地区在重排、删除前置项后仍生成同一 ID。
+    var semanticIdentity = identityParts.length ? identityParts.join('|') : String(entry.identityPath || path);
+    var seed = [targetGM && (targetGM.sid || targetGM._campaignId) || '', kind, semanticIdentity].join('|');
     var base = 'tmlegacy_' + kind + '_' + _tmStableIdHash(seed) + _tmStableIdHash(seed.split('').reverse().join(''));
     var candidate = base;
-    var suffix = 2;
-    while (used[candidate]) candidate = base + '_' + suffix++;
+    if (used[candidate]) {
+      var disambiguator = String(entry.identityPath || path);
+      candidate = base + '_' + _tmStableIdHash(seed + '|collision|' + disambiguator);
+      var suffix = 2;
+      while (used[candidate]) candidate = base + '_' + _tmStableIdHash(seed + '|collision|' + disambiguator) + '_' + suffix++;
+    }
     item.id = candidate; // arch-ok: 旧存档核心实体稳定 ID 的确定性 schema 迁移
     used[candidate] = true;
     assigned++;
@@ -1194,32 +1239,80 @@ function _tmUniqueEntityIdByName(list) {
   return map;
 }
 
+function _tmEntityIdSet(list) {
+  var set = Object.create(null);
+  (Array.isArray(list) ? list : []).forEach(function(item) {
+    if (!item || _tmStableIdMissing(item.id)) return;
+    set[String(item.id).trim()] = true;
+  });
+  return set;
+}
+
 function _tmBackfillStableForeignKeys(targetGM) {
   var factionByName = _tmUniqueEntityIdByName(targetGM.facs);
   var charByName = _tmUniqueEntityIdByName(targetGM.chars);
+  var factionIds = _tmEntityIdSet(targetGM.facs);
+  var charIds = _tmEntityIdSet(targetGM.chars);
+  function repairNamedRef(owner, idField, nameValue, idSet, nameMap) {
+    if (!owner || (!_tmStableIdMissing(owner[idField]) && idSet[String(owner[idField]).trim()])) return;
+    var name = typeof nameValue === 'string' ? nameValue.trim() : '';
+    var id = name && nameMap[name];
+    if (id != null) owner[idField] = id; // arch-ok: 旧名称外键迁移到稳定实体 ID
+  }
   (targetGM.chars || []).forEach(function(ch) {
-    if (!ch || !_tmStableIdMissing(ch.factionId)) return;
-    var id = factionByName[String(ch.faction || '').trim()];
-    if (id != null) ch.factionId = id; // arch-ok: 旧名称外键迁移到稳定势力 ID
+    if (!ch) return;
+    repairNamedRef(ch, 'factionId', ch.faction, factionIds, factionByName);
+    repairNamedRef(ch, 'fatherId', ch.father, charIds, charByName);
+    repairNamedRef(ch, 'motherId', ch.mother, charIds, charByName);
+    repairNamedRef(ch, 'spouseId', ch.spouse, charIds, charByName);
+    repairNamedRef(ch, 'mentorId', ch.mentor, charIds, charByName);
+    (Array.isArray(ch.familyMembers) ? ch.familyMembers : []).forEach(function(member) {
+      if (!member || typeof member !== 'object') return;
+      repairNamedRef(member, 'characterId', member.name, charIds, charByName);
+      repairNamedRef(member, 'personId', member.name, charIds, charByName);
+    });
   });
   (targetGM.facs || []).forEach(function(fac) {
-    if (!fac || !_tmStableIdMissing(fac.leaderId)) return;
-    var id = charByName[String(fac.leader || '').trim()];
-    if (id != null) fac.leaderId = id; // arch-ok: 旧名称外键迁移到稳定人物 ID
+    if (!fac) return;
+    repairNamedRef(fac, 'leaderId', fac.leader, charIds, charByName);
+    repairNamedRef(fac, 'coLeaderId', fac.coLeader, charIds, charByName);
+    repairNamedRef(fac, 'heirId', fac.heir, charIds, charByName);
   });
   (targetGM.armies || []).forEach(function(army) {
-    if (!army || !_tmStableIdMissing(army.commanderId)) return;
+    if (!army) return;
     var commanderName = typeof army.commander === 'string' ? army.commander : (army.commanderName || army.general || army.leader || '');
-    var id = charByName[String(commanderName).trim()];
-    if (id != null) army.commanderId = id; // arch-ok: 旧主将名称迁移到稳定人物 ID
+    repairNamedRef(army, 'commanderId', commanderName, charIds, charByName);
+    repairNamedRef(army, 'factionId', army.faction || army.factionName || army.owner || '', factionIds, factionByName);
   });
   var regions = targetGM.mapData && targetGM.mapData.regions;
   (Array.isArray(regions) ? regions : []).forEach(function(region) {
-    if (!region || !_tmStableIdMissing(region.factionId)) return;
+    if (!region) return;
     var ownerName = region.currentOwner || region.owner || region.controller || region.factionName || region.ownerName || '';
-    var id = factionByName[String(ownerName).trim()];
-    if (id != null) region.factionId = id; // arch-ok: 旧地图归属名称迁移到稳定势力 ID
+    repairNamedRef(region, 'factionId', ownerName, factionIds, factionByName);
+    repairNamedRef(region, 'governorId', region.governor, charIds, charByName);
   });
+  _tmCollectAdminDivisionEntries(targetGM).forEach(function(entry) {
+    var division = entry && entry.item;
+    if (division) repairNamedRef(division, 'governorId', division.governor, charIds, charByName);
+  });
+  (function walkOffices(nodes) {
+    (Array.isArray(nodes) ? nodes : []).forEach(function(node) {
+      (Array.isArray(node && node.positions) ? node.positions : []).forEach(function(position) {
+        if (!position) return;
+        repairNamedRef(position, 'holderId', position.holder, charIds, charByName);
+        (Array.isArray(position.actualHolders) ? position.actualHolders : []).forEach(function(holder) {
+          if (!holder || typeof holder !== 'object') return;
+          repairNamedRef(holder, 'characterId', holder.name, charIds, charByName);
+          repairNamedRef(holder, 'personId', holder.name, charIds, charByName);
+          repairNamedRef(holder, 'holderId', holder.name, charIds, charByName);
+        });
+      });
+      var subs = Array.isArray(node && node.subs) ? node.subs : [];
+      var children = Array.isArray(node && node.children) && node.children !== subs ? node.children : [];
+      walkOffices(subs);
+      walkOffices(children);
+    });
+  })(targetGM.officeTree);
 }
 
 function _tmMigrateCoreStableIds(targetGM) {
@@ -1240,9 +1333,9 @@ function _tmMigrateCoreStableIds(targetGM) {
   _tmBackfillStableForeignKeys(targetGM);
   if (result.total > 0) {
     if (!targetGM._stableIdMigration || typeof targetGM._stableIdMigration !== 'object') {
-      targetGM._stableIdMigration = { version: 1, totalAssigned: 0, byType: {} }; // arch-ok: schema 迁移收据
+      targetGM._stableIdMigration = { version: 2, totalAssigned: 0, byType: {} }; // arch-ok: schema 迁移收据
     }
-    targetGM._stableIdMigration.version = 1;
+    targetGM._stableIdMigration.version = 2;
     targetGM._stableIdMigration.totalAssigned = Number(targetGM._stableIdMigration.totalAssigned || 0) + result.total;
     Object.keys(result.byType).forEach(function(kind) {
       targetGM._stableIdMigration.byType[kind] = Number(targetGM._stableIdMigration.byType[kind] || 0) + result.byType[kind];
@@ -1266,6 +1359,76 @@ function _tmValidateUniqueStableIds(label, list) {
     if (seen[id] !== undefined) throw new Error(label + ' 存在重复 id: ' + id + '（索引 ' + seen[id] + ' / ' + index + '）');
     seen[id] = index;
   });
+}
+
+function _tmValidateStableForeignKeys(targetGM) {
+  var factionIds = _tmEntityIdSet(targetGM.facs);
+  var charIds = _tmEntityIdSet(targetGM.chars);
+  function requireExisting(label, value, set) {
+    if (_tmStableIdMissing(value)) return;
+    var key = String(value).trim();
+    if (!set[key]) throw new Error(label + ' 指向不存在的稳定 id: ' + key);
+  }
+  (targetGM.chars || []).forEach(function(ch, index) {
+    if (!ch) return;
+    requireExisting('人物[' + index + '].factionId', ch.factionId, factionIds);
+    ['fatherId', 'motherId', 'spouseId', 'mentorId'].forEach(function(field) {
+      requireExisting('人物[' + index + '].' + field, ch[field], charIds);
+    });
+    ['childrenIds', 'studentIds', 'studentsIds', 'relativeIds'].forEach(function(field) {
+      (Array.isArray(ch[field]) ? ch[field] : []).forEach(function(id, refIndex) {
+        requireExisting('人物[' + index + '].' + field + '[' + refIndex + ']', id, charIds);
+      });
+    });
+    (Array.isArray(ch.familyMembers) ? ch.familyMembers : []).forEach(function(member, memberIndex) {
+      if (!member || typeof member !== 'object') return;
+      requireExisting('人物[' + index + '].familyMembers[' + memberIndex + '].characterId', member.characterId, charIds);
+      requireExisting('人物[' + index + '].familyMembers[' + memberIndex + '].personId', member.personId, charIds);
+    });
+  });
+  (targetGM.facs || []).forEach(function(faction, index) {
+    if (!faction) return;
+    requireExisting('势力[' + index + '].leaderId', faction.leaderId, charIds);
+    requireExisting('势力[' + index + '].coLeaderId', faction.coLeaderId, charIds);
+    requireExisting('势力[' + index + '].heirId', faction.heirId, charIds);
+    (Array.isArray(faction.memberIds) ? faction.memberIds : []).forEach(function(id, memberIndex) {
+      requireExisting('势力[' + index + '].memberIds[' + memberIndex + ']', id, charIds);
+    });
+  });
+  (targetGM.armies || []).forEach(function(army, index) {
+    if (!army) return;
+    requireExisting('军队[' + index + '].commanderId', army.commanderId, charIds);
+    requireExisting('军队[' + index + '].factionId', army.factionId, factionIds);
+  });
+  var regions = targetGM.mapData && targetGM.mapData.regions;
+  (Array.isArray(regions) ? regions : []).forEach(function(region, index) {
+    if (!region) return;
+    requireExisting('地图地区[' + index + '].factionId', region.factionId, factionIds);
+    requireExisting('地图地区[' + index + '].governorId', region.governorId, charIds);
+  });
+  _tmCollectAdminDivisionEntries(targetGM).forEach(function(entry, index) {
+    if (entry && entry.item) requireExisting('行政区划[' + index + '].governorId', entry.item.governorId, charIds);
+  });
+  (function walkOffices(nodes, path) {
+    (Array.isArray(nodes) ? nodes : []).forEach(function(node, nodeIndex) {
+      var nodePath = path + '[' + nodeIndex + ']';
+      (Array.isArray(node && node.positions) ? node.positions : []).forEach(function(position, positionIndex) {
+        if (!position) return;
+        var positionPath = nodePath + '.positions[' + positionIndex + ']';
+        requireExisting(positionPath + '.holderId', position.holderId, charIds);
+        (Array.isArray(position.actualHolders) ? position.actualHolders : []).forEach(function(holder, holderIndex) {
+          if (!holder || typeof holder !== 'object') return;
+          requireExisting(positionPath + '.actualHolders[' + holderIndex + '].characterId', holder.characterId, charIds);
+          requireExisting(positionPath + '.actualHolders[' + holderIndex + '].personId', holder.personId, charIds);
+          requireExisting(positionPath + '.actualHolders[' + holderIndex + '].holderId', holder.holderId, charIds);
+        });
+      });
+      var subs = Array.isArray(node && node.subs) ? node.subs : [];
+      var children = Array.isArray(node && node.children) && node.children !== subs ? node.children : [];
+      walkOffices(subs, nodePath + '.subs');
+      walkOffices(children, nodePath + '.children');
+    });
+  })(targetGM.officeTree, 'officeTree');
 }
 
 function _tmValidateFiniteWorldNumbers(root, label) {
@@ -1314,6 +1477,7 @@ function _tmValidateLoadedWorld(targetP, targetGM) {
   _tmValidateUniqueStableIds('军队', targetGM.armies);
   _tmValidateUniqueStableIds('地图地区', targetGM.mapData && targetGM.mapData.regions);
   _tmValidateUniqueStableIds('行政区划', _tmCollectAdminDivisionEntries(targetGM).map(function(entry) { return entry.item; }));
+  _tmValidateStableForeignKeys(targetGM);
   _tmValidateFiniteWorldNumbers(targetP, 'P');
   _tmValidateFiniteWorldNumbers(targetGM, 'GM');
   return true;


### PR DESCRIPTION
## Summary

- isolate Huji population growth, summaries, and capital migration by faction
- route corvee, plague, climate, war, and regional mortality through leaf population ledgers
- persist historical migration state per campaign and use canonical calendar/yearly burden windows
- make legacy stable IDs order-independent where source identity exists and validate/repair core foreign keys
- add focused regression coverage and refresh cache stamps plus the full hot-update baseline

## Verification

- `npm ci --ignore-scripts`
- `node web/scripts/ci-smokes.js` — 852 total: 850 direct pass, 2 existing missing-asset exemptions
- `node web/scripts/lint-arch-all.js` — 8/8
- `node web/scripts/verify-official-scenario-parity.js` — 27 assertions
- `node scripts/verify-release-contract.js` — 166 assertions
- `node web/scripts/verify-hot-builder-gates.js` — 27 assertions
- `node scripts/sync-hot-baseline.js --check --version 1.3.4.11`
- `npm audit --omit=dev --audit-level=high --registry=https://registry.npmjs.org` — 0 vulnerabilities
- `git diff --check origin/main...HEAD`

No package, publish, or release action was performed.