### PR TITLE
fix: close fourteenth-round audit population routing gaps

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-21T06:40:39.570Z",
+  "generatedAt": "2026-08-22T08:29:33.572Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -2161,7 +2161,7 @@
     },
     {
       "path": "index.html",
-      "sha256": "c13a5ec36578cc38fb99151434d122335b785c071517c51f0462569aa80d15e9",
+      "sha256": "e8ac0c577eceb55d2c6fcd60132e90c6339e42299878cfdf117964dc89a698c0",
       "size": 68641
     },
     {
@@ -4016,8 +4016,8 @@
     },
     {
       "path": "tm-endturn-systems.js",
-      "sha256": "1cb854076f35146fda5f60c94b778c2852df8cd2e7fc3718e8d126b1fef38759",
-      "size": 39490
+      "sha256": "7b9dd289b65b694c94e1bf8cefac0764ded466dc582d6d3d9b5c9d4dafe2a715",
+      "size": 39504
     },
     {
       "path": "tm-endturn-timing-ledger.js",
@@ -4261,8 +4261,8 @@
     },
     {
       "path": "tm-historical-presets.js",
-      "sha256": "532d33cb203f8017c3441ac1e90bc7c83d2af100545080cea367c74fc69601b5",
-      "size": 46386
+      "sha256": "113111a061ed2a4496f178007538feb5830e99ad697f13e8867dfee7add7ad03",
+      "size": 47077
     },
     {
       "path": "tm-history-advisor.js",
@@ -4311,13 +4311,13 @@
     },
     {
       "path": "tm-huji-deep-fill.js",
-      "sha256": "1118a453d002547a12eb95bf415946cb3ed7f9cd9f040fca76aa9f2e904ee439",
-      "size": 49446
+      "sha256": "401eaca24df793a1b44d62eb2cf50188568fe32787ca5a72a060682b3c30aa4e",
+      "size": 48443
     },
     {
       "path": "tm-huji-engine.js",
-      "sha256": "9ed88151000358dd506800755239994d6324bd1941fd39d589e7b8e86a7eff68",
-      "size": 89733
+      "sha256": "02dda09004299fab809094e8b3c1ceacd80093cca5c21633d3cd3649a2d34ffa",
+      "size": 111835
     },
     {
       "path": "tm-huji-governance-loop.js",
@@ -4326,8 +4326,8 @@
     },
     {
       "path": "tm-huji-runtime-bridge.js",
-      "sha256": "aecb7e09e3b0c29c21f83f0ae5001601a9e457043c10c53986c3e1208148d393",
-      "size": 58145
+      "sha256": "4868c879c2e322eb1ea6286df4eecba33ecd4e97bea32f8eb21c2b0cf19b482e",
+      "size": 60911
     },
     {
       "path": "tm-indices.js",
@@ -5096,8 +5096,8 @@
     },
     {
       "path": "tm-save-lifecycle.js",
-      "sha256": "3da2cf564ffda2ec39a2fdbab51e96c3b3c2167be1183ac9e26b778dd39898fd",
-      "size": 142328
+      "sha256": "87bd2c826108fca5c191227ee8aea115f599f37817d8741fd31139b620eedd8f",
+      "size": 143250
     },
     {
       "path": "tm-save-manager.js",

--- a/web/index.html
+++ b/web/index.html
@@ -654,7 +654,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-world-digest.js?v=20260630"></script><!-- 天下牵动·因果综述·W1a·把割裂的系统反应重组成连贯因果注入推演 -->
 <script src="tm-benji.js?v=20260707"></script><!-- 帝王本纪·终局回顾式修史(鼎革R1g·每12回合一卷串行修纂·flag benjiEnabled) -->
 <script src="tm-world-reactors.js?v=20260630"></script><!-- 世界反应总线·跨系统reactor·W2a军事→势力·flag-gated默认关 -->
-<script src="tm-endturn-systems.js?v=20260821-auditfix13"></script>
+<script src="tm-endturn-systems.js?v=20260822-auditfix14"></script>
 <script src="tm-endturn-ai-helpers.js?v=2026042714"></script>
 <script src="tm-endturn-ai-context.js?v=2026050401"></script>
 <script src="tm-history-events.js?v=20260719-histanchors"></script>
@@ -838,7 +838,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-bgm-config.js?v=2026051201"></script>
 <!-- R131 (2026-04-25) tm-audio-theme.js 拆分 → audio-theme + save-lifecycle + office-editor -->
 <script src="tm-audio-theme.js?v=20260710-fontscale"></script>
-<script src="tm-save-lifecycle.js?v=20260821-auditfix13"></script>
+<script src="tm-save-lifecycle.js?v=20260822-auditfix14"></script>
 <script src="tm-office-editor.js?v=20260707-nestflat2"></script>
 <script src="tm-topbar-vars.js?v=20260514-phase8-vars-2"></script>
 <!-- R137 (2026-04-25) 拆 shell-extras → shell UI + 时政面板 -->
@@ -875,10 +875,10 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-economy-engine-currency.js?v=20260821-auditfix13"></script><!-- 立项拆分：§A CurrencyUnit+§B CurrencyEngine 两整IIFE·紧挨 economy-engine 之前保序·勿动位置 -->
 <script src="tm-economy-engine.js?v=20260821-auditfix13"></script>
 <script src="tm-central-local-engine.js?v=20260709"></script>
-<script src="tm-huji-engine.js?v=20260821-auditfix13"></script>
+<script src="tm-huji-engine.js?v=20260822-auditfix14"></script>
 <script src="tm-edict-parser.js?v=20260709"></script>
-<script src="tm-huji-deep-fill.js?v=20260821-auditfix13"></script>
-<script src="tm-huji-runtime-bridge.js?v=20260821-auditfix13"></script>
+<script src="tm-huji-deep-fill.js?v=20260822-auditfix14"></script>
+<script src="tm-huji-runtime-bridge.js?v=20260822-auditfix14"></script>
 <script src="tm-huji-governance-loop.js?v=20260602-huji-governance-loop"></script>
 <script src="tm-edict-complete.js?v=2026050701"></script>
 <script src="tm-env-recovery-fill.js?v=20260709"></script>
@@ -898,7 +898,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-revolt-inference.js?v=20260721b"></script><!-- 批三·民变演绎层(AI主导)·起号立领袖subcall+逐回合行为subcall(打/占/分合/建国/招抚谈判)·宪法闸落账·AI缺席模板兜底 -->
 <script src="tm-party-inference.js?v=20260722"></script><!-- 批乙·党派/阶层演绎层(AI主导)·forgeIdentity立身份+tickInference逐回合党派行动(联名/清议/杯葛/结盟交恶/议程转向/倒阁/煽动阶层)·宪法闸落账·flag partyInferenceEnabled默认ON·AI缺席模板兜底 -->
 <script src="tm-captive-court.js?v=20260721"></script><!-- 批七·悬朝演绎层(北狩残局朝廷侧)·君被虏朝廷AI当一等演员(观望/监国/立新君)·归銮后复辟旨即夺门谋划·随revoltEntityEnabled -->
-<script src="tm-historical-presets.js?v=20260821-auditfix13"></script>
+<script src="tm-historical-presets.js?v=20260822-auditfix14"></script>
 <script src="tm-prophecy.js?v=20260709"></script>
 <script src="tm-region-enrich.js?v=20260821-auditfix13"></script>
 <script src="tm-audit.js?v=2026042714"></script>

--- a/web/scripts/smoke-huji-deep-fields-and-presets.js
+++ b/web/scripts/smoke-huji-deep-fields-and-presets.js
@@ -114,7 +114,7 @@ assert(P.deepFieldEffects.serviceAgeDing > 0, 'age/gender fields should compute 
 assert(P.deepFieldEffects.serviceAgeDing < before.serviceDing, 'service-age ding should constrain national ding/pool');
 assert(P.corvee.deepFieldEffects && P.corvee.deepFieldEffects.effectiveDing <= P.deepFieldEffects.serviceAgeDing, 'corvee should use service-age ding');
 assert(P.military.deepFieldEffects && P.military.totalPool <= P.deepFieldEffects.serviceAgeDing, 'military pool should use service-age ding');
-assert(P.byRegion.frontier.byGender.male < before.maleFrontier, 'active war should reduce male population through gender field');
+assert(P.byRegion.frontier.byGender.male === before.maleFrontier, 'legacy gender proxy must not become a second war-mortality producer');
 assert(P.byRegion.capital.hidden < before.hiddenCapital, 'baojia should reduce hidden households in covered region');
 assert(P.byRegion.capital.fugitives < before.fugitivesCapital, 'baojia should reduce fugitives in covered region');
 assert(P.byRegion.frontier.fugitives > before.fugitivesFrontier, 'low-trust heterogeneous frontier should create fugitive pressure');

--- a/web/scripts/smoke-population-faction-ledger.js
+++ b/web/scripts/smoke-population-faction-ledger.js
@@ -90,11 +90,13 @@ function makeRuntime(options = {}) {
   vm.runInContext(hujiSource, context, { filename: 'tm-huji-engine.js' });
   vm.runInContext(deepSource, context, { filename: 'tm-huji-deep-fill.js' });
   vm.runInContext(runtimeBridgeSource, context, { filename: 'tm-huji-runtime-bridge.js' });
+  vm.runInContext(historicalSource, context, { filename: 'tm-historical-presets.js' });
   context.HujiEngine.init(context.P);
   context.GM.population.corvee.enabled = false;
   context.GM.population.military.enabled = false;
   context.GM.population.meta.registrationCycle = 1000;
   context.HujiDeepFill.init();
+  context.HistoricalPresets.init();
   return { context, playerLeaves, npcLeaves };
 }
 
@@ -120,9 +122,9 @@ console.log('[smoke-population-faction-ledger]');
   ok(context.GM.population.national.mouths === playerAfter, 'player national contains only player faction leaves');
   ok(context.GM.population.dynamics._yearlyAccumBirths === expectedPlayerBirths,
     'player birth ledger excludes NPC births');
-  ok(context.GM.worldPopulationSummary.byFaction.npc.dynamics._yearlyAccumBirths === expectedNpcBirths,
+  ok(context.GM.worldPopulationSummary.byFaction['fac-npc'].dynamics._yearlyAccumBirths === expectedNpcBirths,
     'NPC births are retained in a separate faction ledger');
-  ok(context.GM.worldPopulationSummary.byFaction.npc.national.mouths === npcAfter
+  ok(context.GM.worldPopulationSummary.byFaction['fac-npc'].national.mouths === npcAfter
     && context.GM.worldPopulationSummary.national.mouths === playerAfter + npcAfter,
     'world summary is separate from player national while preserving every faction');
   ok(npcLeaves[1].populationDetail.mouths < npcSourceWithoutMigration
@@ -159,8 +161,67 @@ console.log('[smoke-population-faction-ledger]');
   ok(totals(playerLeaves).mouths === playerBefore
     && (context.GM.population.dynamics._yearlyAccumDeaths || 0) === playerDeathBefore,
   'NPC mortality never enters the player national or death accumulator');
-  ok(context.GM.worldPopulationSummary.byFaction.npc.mortalityLedger.some(row => row.cause === 'smoke-npc-region'),
+  ok(context.GM.worldPopulationSummary.byFaction['fac-npc'].mortalityLedger.some(row => row.cause === 'smoke-npc-region'),
     'NPC mortality is retained in the NPC faction ledger');
+}
+
+{
+  const { context, playerLeaves, npcLeaves } = makeRuntime();
+  const playerBefore = totals(playerLeaves);
+  const npcBefore = totals(npcLeaves);
+  const result = context.HujiEngine.applyPopulationLoss({
+    factionId: 'missing-faction', cause: 'smoke-unresolved-faction', mouths: 10000
+  });
+  ok(result.ok === false && result.reason === 'faction-not-found'
+    && JSON.stringify(totals(playerLeaves)) === JSON.stringify(playerBefore)
+    && JSON.stringify(totals(npcLeaves)) === JSON.stringify(npcBefore),
+  'an unresolved explicit faction fails closed without harming the player');
+}
+
+{
+  const baseline = makeRuntime();
+  baseline.context.HujiEngine.tick({ turn: 1, monthRatio: 1, strict: true });
+  const baselinePlayerDeaths = baseline.context.GM.population.dynamics._yearlyAccumDeaths;
+  const baselineNpcDeaths = baseline.context.GM.worldPopulationSummary.byFaction['fac-npc'].dynamics._yearlyAccumDeaths;
+
+  const npcWar = makeRuntime();
+  npcWar.context.GM.activeWars = [{ id:'npc-war', attacker:'fac-npc', defender:'fac-other' }];
+  npcWar.context.HujiEngine.tick({ turn: 1, monthRatio: 1, strict: true });
+  ok(npcWar.context.GM.population.dynamics._yearlyAccumDeaths === baselinePlayerDeaths
+    && npcWar.context.GM.worldPopulationSummary.byFaction['fac-npc'].dynamics._yearlyAccumDeaths > baselineNpcDeaths,
+  'an NPC-only war raises mortality only for the participating NPC faction');
+
+  const playerWar = makeRuntime();
+  playerWar.context.GM.activeWars = [{ id:'player-war', attackerId:'fac-player', defenderId:'fac-npc' }];
+  playerWar.context.HujiEngine.tick({ turn: 1, monthRatio: 1, strict: true });
+  ok(playerWar.context.GM.population.dynamics._yearlyAccumDeaths > baselinePlayerDeaths
+    && playerWar.context.GM.worldPopulationSummary.byFaction['fac-npc'].dynamics._yearlyAccumDeaths > baselineNpcDeaths,
+  'a player war raises mortality for both actual participants');
+}
+
+{
+  const { context, npcLeaves } = makeRuntime();
+  context.GM.adminHierarchy.player.divisions = [];
+  context.GM.population.national = { mouths:0, households:0, ding:0 };
+  context.HujiEngine.tick({ turn: 1, monthRatio: 1, strict: true });
+  ok(context.GM.population.national.mouths === 0
+    && context.GM.worldPopulationSummary.byFaction['fac-npc'].isPlayer === false
+    && context.GM.worldPopulationSummary.byFaction['fac-npc'].national.mouths === totals(npcLeaves).mouths,
+  'territorial extinction never reclassifies the sole remaining NPC faction as player');
+}
+
+{
+  const { context } = makeRuntime();
+  context.HujiEngine.tick({ turn: 1, monthRatio: 1, strict: true });
+  const entry = context.GM.worldPopulationSummary.byFaction['fac-npc'];
+  const births = entry.dynamics._yearlyAccumBirths;
+  context.GM.adminHierarchy.renamedNpcBranch = context.GM.adminHierarchy.npc;
+  delete context.GM.adminHierarchy.npc;
+  context.HujiEngine.tick({ turn: 2, monthRatio: 1, strict: true });
+  ok(context.GM.worldPopulationSummary.byFaction['fac-npc'] === entry
+    && entry.dynamics._yearlyAccumBirths > births
+    && !context.GM.worldPopulationSummary.byFaction.renamedNpcBranch,
+  'world population history is keyed by stable factionId across branch renames');
 }
 
 {
@@ -188,6 +249,8 @@ console.log('[smoke-population-faction-ledger]');
     dateForTurn(turn) { return { adYear: turn >= 2 ? 1200 : 1199 }; }
   });
   const before = totals(playerLeaves).mouths;
+  const capitalBefore = playerLeaves[0].populationDetail.mouths;
+  const southBefore = playerLeaves[1].populationDetail.mouths;
   context.HujiDeepFill.tick({ turn: 2, monthRatio: 1, strict: true });
   const after = totals(playerLeaves).mouths;
   context.TM.HujiRuntimeBridge.maintain(context.GM, { scenario: context.P, turn: 2 });
@@ -195,8 +258,79 @@ console.log('[smoke-population-faction-ledger]');
     .filter(row => row.cause === 'plague')
     .reduce((sum, row) => sum + row.mouths, 0);
   ok(plagueLoss > 0 && after === before - plagueLoss
-    && context.GM.population.national.mouths === after,
-  'plague deaths use the leaf ledger and cannot be erased by national aggregation');
+    && context.GM.population.national.mouths === after
+    && playerLeaves[0].populationDetail.mouths === capitalBefore
+    && playerLeaves[1].populationDetail.mouths === southBefore - plagueLoss
+    && context.GM.population.plagueEvents.every(event => event.regionId === 'player-south'),
+  'regional plague deaths hit the matched leaf only and survive national aggregation');
+}
+
+{
+  const { context, playerLeaves } = makeRuntime();
+  const before = totals(playerLeaves).mouths;
+  const mortality = context.HujiEngine.applyPopulationLoss({
+    factionId:'fac-player', regionId:'player-south', cause:'smoke-demographic-loss', mortalityRate:0.30
+  });
+  context.TM.HujiRuntimeBridge.maintain(context.GM, { scenario:context.P, turn:2 });
+  const region = context.GM.population.byRegion['player-south'];
+  const sum = object => Object.values(object || {}).reduce((total, value) => total + Number(value || 0), 0);
+  ok(mortality.ok && mortality.mouths === Math.round(400000 * 0.30)
+    && sum(region.byAge) === region.mouths
+    && sum(region.byGender) === region.mouths
+    && context.GM.population.national.ding === totals(playerLeaves).ding
+    && totals(playerLeaves).mouths === before - mortality.mouths,
+  'leaf mortality keeps age, gender, mouths and ding on one authoritative ledger');
+}
+
+{
+  const { context, playerLeaves } = makeRuntime({ year:1127 });
+  context.GM.unrest = 80;
+  playerLeaves[0].name = '京东路';
+  context.GM._capital = '京东路';
+  context.GM.facs[0].capital = '京东路';
+  const before = totals(playerLeaves).mouths;
+  context.HujiDeepFill.tick({ turn:2, monthRatio:1, strict:true });
+  context.TM.HujiRuntimeBridge.maintain(context.GM, { scenario:context.P, turn:2 });
+  const leaves = context.GM.adminHierarchy.player.divisions;
+  const qiaozhi = leaves.filter(leaf => leaf && leaf.isQiaozhi && leaf.parentHistoric === 'jingkang_qiao');
+  const qiaozhiMouths = totals(qiaozhi).mouths;
+  const materialized = qiaozhi.length === 3 && qiaozhiMouths > 0
+    && totals(leaves).mouths === before
+    && context.GM.population.national.mouths === before
+    && context.GM.population.byLegalStatus.qiaozhi.mouths === qiaozhiMouths
+    && context.GM.population._qiaozhi_triggered.jingkang_qiao === 2;
+  context.HujiEngine.tick({ turn:3, monthRatio:1, strict:true });
+  context.TM.HujiRuntimeBridge.maintain(context.GM, { scenario:context.P, turn:3 });
+  const qiaozhiAfterGrowth = totals(qiaozhi).mouths;
+  ok(materialized && context.GM.population.byLegalStatus.qiaozhi.mouths === qiaozhiAfterGrowth,
+  'qiaozhi creates authoritative leaves, transfers population, and survives RuntimeBridge');
+}
+
+{
+  const { context, playerLeaves, npcLeaves } = makeRuntime();
+  const playerBefore = totals(playerLeaves).mouths;
+  const npcBefore = totals(npcLeaves).mouths;
+  const unresolved = context.HistoricalPresets.recordWarCasualty(50000, '北境会战', 'enemy');
+  const applied = context.HistoricalPresets.recordWarCasualty({
+    mouths:50000, warName:'北境会战', factionId:'fac-npc', regionId:'npc-north'
+  });
+  ok(unresolved.ok === false && unresolved.reason === 'faction-target-required'
+    && totals(playerLeaves).mouths === playerBefore
+    && applied.ok && applied.factionId === 'fac-npc'
+    && totals(npcLeaves).mouths === npcBefore - 50000,
+  'war casualties require a stable side target and never default enemy losses to the player');
+}
+
+{
+  const { context } = makeRuntime();
+  const originalSync = context.HujiEngine.syncDemographicViews;
+  context.HujiEngine.syncDemographicViews = () => { throw new Error('injected historical demographic failure'); };
+  let strictFailure = null;
+  try { context.HistoricalPresets.tick({ turn:2, monthRatio:1, strict:true }); }
+  catch (error) { strictFailure = error; }
+  context.HujiEngine.syncDemographicViews = originalSync;
+  ok(strictFailure && /historical demographic failure/.test(strictFailure.message),
+    'strict historical demographic failures propagate to the end-turn transaction');
 }
 
 {
@@ -297,8 +431,8 @@ console.log('[smoke-population-faction-ledger]');
 ok(/HujiEngine\.applyPopulationLoss\(\{ cause:'environment-crisis:/.test(economySource)
   && !/target\.mouths\s*=\s*Math\.max\(10000/.test(economySource),
   'environment crisis mortality is routed through the leaf ledger');
-ok(/HujiEngine\.applyPopulationLoss\(\{ cause:'historical-plague:/.test(historicalSource)
-  && /HujiEngine\.applyPopulationLoss\(\{ cause:'war-casualty:/.test(historicalSource)
+ok(/HujiEngine\.applyPopulationLoss\(Object\.assign\(target/.test(historicalSource)
+  && /faction-target-required/.test(historicalSource)
   && !/population\.national\.mouths\s*=\s*Math\.max\(100000/.test(historicalSource),
   'historical plague and war casualties are routed through the leaf ledger');
 ok(/HujiEngine\.applyPopulationLoss\(\{ cause:'disease-cycle:/.test(regionEnrichSource)

--- a/web/scripts/smoke-population-single-authority.js
+++ b/web/scripts/smoke-population-single-authority.js
@@ -131,9 +131,14 @@ console.log('[smoke-population-single-authority]');
   const afterBridge = world.leaves.map(leaf => leaf.populationDetail.mouths);
   ok(JSON.stringify(afterBridge) === JSON.stringify(afterHuji), 'IntegrationBridge does not advance leaf population after Huji');
   ok(JSON.stringify(ctx.GM.corruption.byDept) === corruptionAfterHuji, 'IntegrationBridge does not apply a second corruption tick');
+  const sumBuckets = buckets => Object.values(buckets || {}).reduce((sum, value) => sum + Number(value || 0), 0);
+  const leafDing = world.leaves.reduce((sum, leaf) => sum + leaf.populationDetail.ding, 0);
   ok(Math.abs(world.leaves[1].populationDetail.households / world.leaves[1].populationDetail.mouths - leafHouseholdRatio) < 0.000001
-    && Math.abs(world.leaves[1].populationDetail.ding / world.leaves[1].populationDetail.mouths - leafDingRatio) < 0.000001,
-  'leaf household and ding ratios remain local instead of being replaced by national defaults');
+    && Math.abs(world.leaves[1].populationDetail.ding / world.leaves[1].populationDetail.mouths - leafDingRatio) > 0
+    && ctx.GM.population.national.ding === leafDing
+    && world.leaves.every(leaf => sumBuckets(leaf.populationDetail.byAge) === leaf.populationDetail.mouths
+      && sumBuckets(leaf.populationDetail.byGender) === leaf.populationDetail.mouths),
+  'leaf household ratios stay local while age transitions update leaf-authoritative ding and demographics');
   ok(!Object.prototype.hasOwnProperty.call(ctx.GM.population.byRegion, 'ghost')
     && !Object.prototype.hasOwnProperty.call(ctx.GM.minxin.byRegion, 'ghost')
     && !Object.prototype.hasOwnProperty.call(ctx.GM.fiscal.regions, 'ghost')

--- a/web/scripts/smoke-stable-id-reference-integrity.js
+++ b/web/scripts/smoke-stable-id-reference-integrity.js
@@ -84,7 +84,7 @@ console.log('[smoke-stable-id-reference-integrity]');
     'legacy character IDs remain stable when array order changes');
   ok(regionsA['京畿'] === regionsB['京畿'] && regionsA['江南'] === regionsB['江南'],
     'legacy region IDs are based on semantic identity rather than array position');
-  ok(first._stableIdMigration.version === 2, 'order-independent migration records schema version 2');
+  ok(first._stableIdMigration.version === 3, 'order-independent migration records schema version 3');
 }
 
 {
@@ -155,6 +155,19 @@ console.log('[smoke-stable-id-reference-integrity]');
   try { context._tmValidateStableForeignKeys(world); }
   catch (error) { rejected = /spouseId.*不存在/.test(error.message); }
   ok(rejected, 'dangling kinship IDs are rejected before gameplay opens');
+}
+
+{
+  const world = legacyWorld(['甲', '乙']);
+  world.chars = [
+    { name:'张三', gender:'男', faction:'朝廷' },
+    { name:'张三', gender:'男', faction:'朝廷' }
+  ];
+  let rejected = false;
+  try { context._tmMigrateCoreStableIds(world); }
+  catch (error) { rejected = /身份歧义/.test(error.message); }
+  ok(rejected && world.chars.every(char => !char.id),
+    'indistinguishable legacy entities are rejected before path order can become identity');
 }
 
 console.log('\n[smoke-stable-id-reference-integrity] ' + pass + ' passed / ' + fail + ' failed');

--- a/web/tm-endturn-systems.js
+++ b/web/tm-endturn-systems.js
@@ -248,7 +248,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
   // 6.15 历史补完（年龄金字塔精细化+疫病战亡字段维护）
   try {
     if (typeof HistoricalPresets !== 'undefined') {
-      HistoricalPresets.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
+      HistoricalPresets.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio, strict: true });
     }
   } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] HistoricalPresets.tick 失败:') : console.error('[endTurn] HistoricalPresets.tick 失败:', e); throw e; }
 

--- a/web/tm-historical-presets.js
+++ b/web/tm-historical-presets.js
@@ -348,37 +348,15 @@
   function _initAgePyramidFine() {
     var G = global.GM;
     if (!G.population) return;
-    if (G.population.agePyramidFine) return;
-    var total = G.population.national.mouths;
-    // 11 层（0-10 / 11-20 / ... / 71+）
-    var distribution = [0.20, 0.18, 0.15, 0.13, 0.11, 0.10, 0.08, 0.05];
-    var layers = ['age_0_10','age_11_20','age_21_30','age_31_40','age_41_50','age_51_60','age_61_70','age_71_plus'];
-    G.population.agePyramidFine = {};
-    layers.forEach(function(k, i) { G.population.agePyramidFine[k] = Math.round(total * distribution[i]); });
-    G.population.agePyramidFine._newlyAdult = 0;   // 本回合新达丁龄
-    G.population.agePyramidFine._leavingDing = 0;  // 本回合满 60 脱丁
+    if (!global.HujiEngine || typeof global.HujiEngine.syncDemographicViews !== 'function') {
+      throw new Error('叶级人口结构账本不可用');
+    }
+    global.HujiEngine.syncDemographicViews();
   }
 
-  function tickAgePyramidFine(mr) {
+  function tickAgePyramidFine() {
     _initAgePyramidFine();
-    var G = global.GM;
-    var pyramid = G.population.agePyramidFine;
-    if (!pyramid) return;
-    // 0.5 岁 / 月（简化）
-    var totalMouths = G.population.national.mouths;
-    var dingAgeMin = (G.population.corvee && G.population.corvee.dingAgeMin) || 16;
-    // 计算新成丁（age_11_20 层中达到 dingAgeMin 的比例）
-    var newlyAdultRate = mr / 120;
-    var newlyAdult = Math.round(pyramid.age_11_20 * newlyAdultRate);
-    pyramid._newlyAdult = newlyAdult;
-    // 脱丁（age_51_60 层每月有部分满 60）
-    var leavingDing = Math.round(pyramid.age_51_60 * (mr / 120));
-    pyramid._leavingDing = leavingDing;
-    // 更新总丁（如 G.population.ding 存在）
-    if (G.population.national.ding !== undefined) {
-      G.population.national.ding += newlyAdult - leavingDing;
-      G.population.national.ding = Math.max(0, G.population.national.ding);
-    }
+    return global.GM.population.agePyramidFine;
   }
 
   // ═══════════════════════════════════════════════════════════════════
@@ -443,30 +421,60 @@
     _initPlagueWarFields();
     var G = global.GM;
     if (!global.HujiEngine || typeof global.HujiEngine.applyPopulationLoss !== 'function') throw new Error('人口损失账本不可用');
-    var mortality = global.HujiEngine.applyPopulationLoss({ cause:'historical-plague:' + String(cause || 'plague'), regionId:region && region !== 'national' ? region : '', mouths:scale });
+    var target = region && typeof region === 'object' ? Object.assign({}, region) : {};
+    if (typeof region === 'string' && region && region !== 'national') target.regionCandidates = [region];
+    var mortality = global.HujiEngine.applyPopulationLoss(Object.assign(target, {
+      cause:'historical-plague:' + String(cause || 'plague'),
+      mouths:scale
+    }));
     if (!mortality || mortality.ok === false) throw new Error('历史瘟疫人口损失落账失败: ' + String(mortality && mortality.reason || 'unknown'));
     G.population.plagueEvents.push({
       turn: G.turn || 0,
       scale: mortality.mouths,
-      region: region || 'national',
+      factionId:mortality.factionId,
+      regionId:mortality.regionId || '',
+      region:mortality.regionName || (typeof region === 'string' ? region : 'national'),
       cause: cause || '瘟疫',
       deaths: mortality.mouths
     });
-    if (global.addEB) global.addEB('瘟疫', (region || '各地') + '大疫，殒 ' + Math.round(mortality.mouths) + ' 口');
+    if (global.addEB) global.addEB('瘟疫', (mortality.regionName || (typeof region === 'string' ? region : '各地')) + '大疫，殒 ' + Math.round(mortality.mouths) + ' 口');
+    return mortality;
   }
 
   function recordWarCasualty(scale, warName, side) {
     _initPlagueWarFields();
     var G = global.GM;
     if (!global.HujiEngine || typeof global.HujiEngine.applyPopulationLoss !== 'function') throw new Error('人口损失账本不可用');
-    var mortality = global.HujiEngine.applyPopulationLoss({ cause:'war-casualty:' + String(warName || 'unknown'), mouths:scale, ding:Math.round(scale * 0.6) });
+    var spec = scale && typeof scale === 'object' && !Array.isArray(scale)
+      ? Object.assign({}, scale)
+      : { mouths:scale, warName:warName, side:side };
+    var sideTarget = spec.side && typeof spec.side === 'object' && !Array.isArray(spec.side)
+      ? spec.side
+      : null;
+    var sideName = sideTarget ? '' : String(spec.side || 'own').trim().toLowerCase();
+    if (!sideTarget && sideName !== 'own' && sideName !== 'player' && sideName !== 'self') {
+      return { ok:false, reason:'faction-target-required', mouths:0, ding:0 };
+    }
+    var target = Object.assign({}, sideTarget || {}, {
+      factionId:spec.factionId != null ? spec.factionId : sideTarget && sideTarget.factionId,
+      regionId:spec.regionId != null ? spec.regionId : sideTarget && sideTarget.regionId,
+      cause:'war-casualty:' + String(spec.warName || warName || 'unknown'),
+      mouths:spec.mouths,
+      ding:spec.ding != null ? spec.ding : Math.round((Number(spec.mouths) || 0) * 0.6)
+    });
+    if (target.factionId == null) delete target.factionId;
+    if (target.regionId == null) delete target.regionId;
+    var mortality = global.HujiEngine.applyPopulationLoss(target);
     if (!mortality || mortality.ok === false) throw new Error('战亡人口损失落账失败: ' + String(mortality && mortality.reason || 'unknown'));
     G.population.warCasualties.push({
       turn: G.turn || 0,
       scale: mortality.mouths,
-      warName: warName || '',
-      side: side || 'own'
+      factionId:mortality.factionId,
+      regionId:mortality.regionId || '',
+      warName:spec.warName || warName || '',
+      side:spec.side && typeof spec.side !== 'object' ? spec.side : (mortality.factionId || 'own')
     });
+    return mortality;
   }
 
   // ═══════════════════════════════════════════════════════════════════
@@ -502,8 +510,23 @@
   function tick(ctx) {
     ctx = ctx || {};
     var mr = ctx.monthRatio || 1;
-    try { tickAgePyramidFine(mr); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'hist] agePyramid:') : console.error('[hist] agePyramid:', e); }
-    try { _initPlagueWarFields(); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-historical-presets');}catch(_){}}
+    var strict = ctx.strict === true;
+    var failures = [];
+    function runStep(label, fn) {
+      try { return fn(); }
+      catch (error) {
+        try {
+          if (window.TM && TM.errors && TM.errors.capture) TM.errors.capture(error, 'hist] ' + label + ':');
+          else console.error('[hist] ' + label + ':', error);
+        } catch (_) {}
+        if (strict) throw error;
+        failures.push({ step:label, error:String(error && error.message || error) });
+        return null;
+      }
+    }
+    runStep('agePyramid', function() { tickAgePyramidFine(mr); });
+    runStep('plagueWarFields', _initPlagueWarFields);
+    return { ok:failures.length === 0, failures:failures };
   }
 
   function init() {

--- a/web/tm-huji-deep-fill.js
+++ b/web/tm-huji-deep-fill.js
@@ -227,9 +227,9 @@
   // ═══════════════════════════════════════════════════════════════════
 
   var QIAOZHI_HISTORICAL = [
-    { id:'yongjia_qiao', name:'永嘉侨置', year:317, scale:500000, newRegions:['侨豫州','侨徐州','侨荆州','侨青州'] },
-    { id:'anshi_qiao',   name:'安史侨置', year:755, scale:300000, newRegions:['侨河北','侨关中'] },
-    { id:'jingkang_qiao',name:'靖康侨置', year:1127,scale:1500000,newRegions:['侨京西','侨京东','侨河北'] }
+    { id:'yongjia_qiao', name:'永嘉侨置', year:317, scale:500000, sourceCandidates:['中原','河南','河北','北方','洛阳'], newRegions:['侨豫州','侨徐州','侨荆州','侨青州'] },
+    { id:'anshi_qiao',   name:'安史侨置', year:755, scale:300000, sourceCandidates:['河北','关中','中原','北方'], newRegions:['侨河北','侨关中'] },
+    { id:'jingkang_qiao',name:'靖康侨置', year:1127,scale:1500000,sourceCandidates:['京东','京西','河北','中原','北方'],newRegions:['侨京西','侨京东','侨河北'] }
   ];
 
   function _checkQiaozhiTrigger(ctx) {
@@ -239,28 +239,27 @@
       if (G.population._qiaozhi_triggered && G.population._qiaozhi_triggered[e.id]) return;
       var year = _yearFromTurn(ctx.turn || G.turn || 1);
       if (year >= e.year && year < e.year + 10 && G.unrest > 70) {
-        // 触发
+        if (!global.HujiEngine || typeof global.HujiEngine.materializeQiaozhiResettlement !== 'function') {
+          throw new Error('侨置人口权威账本不可用');
+        }
+        var result = global.HujiEngine.materializeQiaozhiResettlement({
+          eventId:e.id,
+          mouths:e.scale,
+          sourceCandidates:e.sourceCandidates,
+          targetNames:e.newRegions
+        });
+        if (!result || result.ok === false) {
+          G.population._qiaozhi_pending = G.population._qiaozhi_pending || {};
+          G.population._qiaozhi_pending[e.id] = {
+            turn:Number(ctx.turn || G.turn) || 0,
+            reason:String(result && result.reason || 'qiaozhi-materialization-failed')
+          };
+          return;
+        }
         if (!G.population._qiaozhi_triggered) G.population._qiaozhi_triggered = {};
         G.population._qiaozhi_triggered[e.id] = ctx.turn;
-        // 创建侨置 region
-        e.newRegions.forEach(function(rn) {
-          if (!G.population.byRegion[rn]) {
-            G.population.byRegion[rn] = {
-              households: Math.round(e.scale / e.newRegions.length / 5),
-              mouths: Math.round(e.scale / e.newRegions.length),
-              ding: Math.round(e.scale / e.newRegions.length * 0.3),
-              byCategory:{}, byLegalStatus:{}, byGrade:{},
-              fugitives:0, hidden:0, isQiaozhi: true, parentHistoric: e.id
-            };
-          }
-        });
-        // 加入 byLegalStatus.qiaozhi
-        if (G.population.byLegalStatus.qiaozhi) {
-          G.population.byLegalStatus.qiaozhi.households += Math.round(e.scale / 5);
-          G.population.byLegalStatus.qiaozhi.mouths += e.scale;
-          G.population.byLegalStatus.qiaozhi.ding += Math.round(e.scale * 0.3);
-        }
-        if (global.addEB) global.addEB('侨置', e.name + '：流民约 ' + (e.scale/10000).toFixed(0) + ' 万侨置于新区');
+        if (G.population._qiaozhi_pending) delete G.population._qiaozhi_pending[e.id];
+        if (global.addEB) global.addEB('侨置', e.name + '：流民约 ' + (result.scale/10000).toFixed(0) + ' 万迁置于新区');
       }
     });
   }
@@ -606,38 +605,18 @@
   // ═══════════════════════════════════════════════════════════════════
 
   function _initAgeLayers() {
-    var G = global.GM;
-    if (!G.population) return;
-    if (G.population.ageLayers) return;
-    G.population.ageLayers = {
-      age_0_10:   Math.round(G.population.national.mouths * 0.20),
-      age_11_20:  Math.round(G.population.national.mouths * 0.18),
-      age_21_30:  Math.round(G.population.national.mouths * 0.15),
-      age_31_40:  Math.round(G.population.national.mouths * 0.13),
-      age_41_50:  Math.round(G.population.national.mouths * 0.11),
-      age_51_60:  Math.round(G.population.national.mouths * 0.10),
-      age_61_70:  Math.round(G.population.national.mouths * 0.08),
-      age_71_plus:Math.round(G.population.national.mouths * 0.05)
-    };
+    _syncAuthoritativeDemographics();
   }
 
-  function _tickAgeLayers(mr) {
-    var G = global.GM;
-    if (!G.population || !G.population.ageLayers) return;
-    var al = G.population.ageLayers;
-    // 按年递增（简化：每月）
-    var fractionMove = mr / 120; // 10 年
-    var keys = ['age_0_10','age_11_20','age_21_30','age_31_40','age_41_50','age_51_60','age_61_70','age_71_plus'];
-    for (var i = keys.length - 1; i > 0; i--) {
-      var move = Math.round(al[keys[i-1]] * fractionMove);
-      al[keys[i]] += move;
-      al[keys[i-1]] -= move;
+  function _syncAuthoritativeDemographics() {
+    if (!global.HujiEngine || typeof global.HujiEngine.syncDemographicViews !== 'function') {
+      throw new Error('叶级人口结构账本不可用');
     }
-    // 71+ 衰减
-    al.age_71_plus = Math.max(0, al.age_71_plus - Math.round(al.age_71_plus * 0.001 * mr));
-    // 新生注入 age_0_10
-    var newBorn = Math.round(G.population.national.mouths * 0.035 * mr / 12);
-    al.age_0_10 += newBorn;
+    return global.HujiEngine.syncDemographicViews();
+  }
+
+  function _tickAgeLayers() {
+    _syncAuthoritativeDemographics();
   }
 
   // ═══════════════════════════════════════════════════════════════════
@@ -645,36 +624,20 @@
   // ═══════════════════════════════════════════════════════════════════
 
   function _initGenderRatio() {
-    var G = global.GM;
-    if (!G.population) return;
-    if (G.population.gender) return;
-    G.population.gender = {
-      male: Math.round(G.population.national.mouths * 0.52),
-      female: Math.round(G.population.national.mouths * 0.48),
-      ratio: 52/48 // 男/女
-    };
+    _syncAuthoritativeDemographics();
   }
 
-  function _tickGenderRatio(mr) {
+  function _tickGenderRatio() {
     var G = global.GM;
-    if (!G.population || !G.population.gender) return;
-    var g = G.population.gender;
-    // 战争 → 男女比下降（男丁损失）
-    if (G.activeWars && G.activeWars.length > 0) {
-      var loss = Math.round(g.male * 0.002 * mr);
-      g.male = Math.max(0, g.male - loss);
-    }
-    // 溺女政策（明清某些地区）→ 男女比上升
-    if (G.policies && G.policies.preferMale) {
-      var femaleLoss = Math.round(g.female * 0.001 * mr);
-      g.female = Math.max(0, g.female - femaleLoss);
-    }
-    g.ratio = g.male / Math.max(1, g.female);
-    g.total = g.male + g.female;
+    var synced = _syncAuthoritativeDemographics();
+    var g = G.population && G.population.gender;
+    if (!g) return synced;
     // 男多于女 → 难以婚配 → 盗贼兴
     if (g.ratio > 1.15) {
+      var mr = arguments.length ? Number(arguments[0]) || 1 : 1;
       if (typeof G.unrest === 'number') G.unrest = Math.min(100, G.unrest + 0.3 * mr);
     }
+    return synced;
   }
 
   // ═══════════════════════════════════════════════════════════════════
@@ -715,7 +678,8 @@
       if (G.guoku) G.guoku.grain = Math.max(0, G.guoku.grain - Math.round(G.population.national.mouths * 0.01 * mr / 12));
       var deaths = Math.round(G.population.national.mouths * 0.0005 * mr);
       if (!global.HujiEngine || typeof global.HujiEngine.applyPopulationLoss !== 'function') throw new Error('人口损失账本不可用');
-      global.HujiEngine.applyPopulationLoss({ cause:'climate:little-ice-age', mouths:deaths });
+      var mortality = global.HujiEngine.applyPopulationLoss({ cause:'climate:little-ice-age', mouths:deaths });
+      if (!mortality || mortality.ok === false) throw new Error('小冰期人口损失落账失败: ' + String(mortality && mortality.reason || 'unknown'));
     } else if (phase === 'medieval_warm') {
       // 产粮升
       if (G.guoku) G.guoku.grain += Math.round(G.population.national.mouths * 0.005 * mr / 12);
@@ -766,10 +730,27 @@
     PLAGUE_CYCLES.forEach(function(p) {
       var phase = year % p.period;
       if (phase === 0 && Math.random() < 0.3) {
-        var deaths = Math.round(G.population.national.mouths * p.baseMortality);
         if (!global.HujiEngine || typeof global.HujiEngine.applyPopulationLoss !== 'function') throw new Error('人口损失账本不可用');
-        var mortality = global.HujiEngine.applyPopulationLoss({ cause:'plague', mouths:deaths });
-        G.population.plagueEvents.push({ turn: ctx.turn, deaths: mortality.mouths, region: p.regions[Math.floor(Math.random()*p.regions.length)] });
+        var mortality = null;
+        for (var i = 0; i < p.regions.length; i++) {
+          var attempt = global.HujiEngine.applyPopulationLoss({
+            cause:'plague',
+            regionCandidates:[p.regions[i]],
+            mortalityRate:p.baseMortality
+          });
+          if (attempt && attempt.ok) {
+            mortality = attempt;
+            break;
+          }
+        }
+        if (!mortality || mortality.ok === false) return;
+        G.population.plagueEvents.push({
+          turn:ctx.turn,
+          deaths:mortality.mouths,
+          factionId:mortality.factionId,
+          regionId:mortality.regionId,
+          region:mortality.regionName || mortality.regionId
+        });
         if (global.addEB) global.addEB('瘟疫', '疫病大作，死亡 ' + mortality.mouths);
       }
     });

--- a/web/tm-huji-engine.js
+++ b/web/tm-huji-engine.js
@@ -324,16 +324,18 @@
     return out;
   }
 
+  var AGE_BUCKET_TEMPLATE = {
+    age_0_10:0.20, age_11_20:0.18, age_21_30:0.15, age_31_40:0.13,
+    age_41_50:0.11, age_51_60:0.10, age_61_70:0.08, age_71_plus:0.05
+  };
+  var GENDER_BUCKET_TEMPLATE = { male:0.52, female:0.48 };
+
   function _ensureRegionDeepFields(r) {
     if (!r) return;
     var mouths = Math.max(0, Math.round(r.mouths || 0));
-    var ageTemplate = {
-      age_0_10:0.20, age_11_20:0.18, age_21_30:0.15, age_31_40:0.13,
-      age_41_50:0.11, age_51_60:0.10, age_61_70:0.08, age_71_plus:0.05
-    };
-    r.byAge = _scaleBucketsToTotal(r.byAge || r.ageLayers, mouths, ageTemplate);
+    r.byAge = _scaleBucketsToTotal(r.byAge || r.ageLayers, mouths, AGE_BUCKET_TEMPLATE);
     var gender = r.byGender || r.gender || {};
-    r.byGender = _scaleBucketsToTotal(gender, mouths, { male:0.52, female:0.48 });
+    r.byGender = _scaleBucketsToTotal(gender, mouths, GENDER_BUCKET_TEMPLATE);
     if (!r.byEthnicity || !Object.keys(r.byEthnicity).length) r.byEthnicity = Object.assign({}, r.ethnicity || { han:0.95, other:0.05 });
     if (!r.byFaith || !Object.keys(r.byFaith).length) r.byFaith = Object.assign({}, r.religion || r.byReligion || { confucian:0.6, buddhist:0.2, taoist:0.15, folk:0.05 });
     r.ethnicity = Object.assign({}, r.byEthnicity);
@@ -368,11 +370,8 @@
       Object.keys(r.byGender || {}).forEach(function(k) { byGender[k] = (byGender[k] || 0) + (r.byGender[k] || 0); });
     });
     if (!Object.keys(byAge).length && P.national) {
-      byAge = _scaleBucketsToTotal({}, P.national.mouths || 0, {
-        age_0_10:0.20, age_11_20:0.18, age_21_30:0.15, age_31_40:0.13,
-        age_41_50:0.11, age_51_60:0.10, age_61_70:0.08, age_71_plus:0.05
-      });
-      byGender = _scaleBucketsToTotal({}, P.national.mouths || 0, { male:0.52, female:0.48 });
+      byAge = _scaleBucketsToTotal({}, P.national.mouths || 0, AGE_BUCKET_TEMPLATE);
+      byGender = _scaleBucketsToTotal({}, P.national.mouths || 0, GENDER_BUCKET_TEMPLATE);
     }
     P.byAge = byAge;
     P.byGender = byGender;
@@ -662,7 +661,6 @@
         });
       }
     }
-    if (groups.length === 1 && !groups[0].isPlayer) groups[0].isPlayer = true;
     return groups;
   }
 
@@ -699,13 +697,33 @@
     return G.worldPopulationSummary;
   }
 
+  function _factionSummaryKey(group) {
+    return String(group && (group.factionId || group.key) || 'unknown');
+  }
+
   function _factionPopulationEntry(G, group) {
     var world = _ensureWorldPopulationSummary(G);
-    var key = String(group && group.key || 'unknown');
+    var key = _factionSummaryKey(group);
     var entry = world.byFaction[key];
+    var legacyKey = String(group && group.key || '');
+    if (!entry && legacyKey && legacyKey !== key && world.byFaction[legacyKey]) {
+      entry = world.byFaction[legacyKey];
+      delete world.byFaction[legacyKey];
+    }
+    if (!entry) {
+      Object.keys(world.byFaction).some(function(existingKey) {
+        var existing = world.byFaction[existingKey];
+        if (!existing || _normPopulationName(existing.factionId) !== _normPopulationName(group && group.factionId)) return false;
+        entry = existing;
+        if (existingKey !== key) delete world.byFaction[existingKey];
+        return true;
+      });
+    }
     if (!entry || typeof entry !== 'object') entry = world.byFaction[key] = {};
+    else world.byFaction[key] = entry;
     entry.factionId = group.factionId;
     entry.factionName = group.factionName;
+    entry.branchKey = group.key;
     if (!entry.dynamics || typeof entry.dynamics !== 'object') entry.dynamics = _defaultDynamics();
     return entry;
   }
@@ -717,9 +735,12 @@
     (groups || []).forEach(function(group) {
       var entry = _factionPopulationEntry(G, group);
       var national = _leafPopulationTotals(group.leaves);
+      var demographic = _leafDemographicTotals(group.leaves);
       entry.national = national;
+      entry.byAge = demographic.byAge;
+      entry.byGender = demographic.byGender;
       entry.isPlayer = !!group.isPlayer;
-      aliveKeys[group.key] = true;
+      aliveKeys[_factionSummaryKey(group)] = true;
       total.mouths += national.mouths;
       total.households += national.households;
       total.ding += national.ding;
@@ -743,6 +764,15 @@
       leaf.population.households = detail.households;
       leaf.population.ding = detail.ding;
     }
+    if (leaf.isQiaozhi || leaf.regionType === 'qiaozhi') {
+      leaf.byLegalStatus = leaf.byLegalStatus && typeof leaf.byLegalStatus === 'object' ? leaf.byLegalStatus : {};
+      leaf.byLegalStatus.qiaozhi = {
+        households:detail.households,
+        mouths:detail.mouths,
+        ding:detail.ding
+      };
+      detail.byLegalStatus = leaf.byLegalStatus;
+    }
     var env = leaf.environment && typeof leaf.environment === 'object' ? leaf.environment : null;
     var carrying = leaf.carryingCapacity;
     var cap = Number(env && env.carrying) ||
@@ -753,6 +783,148 @@
       if (env) env.currentLoad = load;
       if (carrying && typeof carrying === 'object') carrying.currentLoad = load;
     }
+  }
+
+  function _legacyPopulationRowForLeaf(P, leaf) {
+    if (!P || !P.byRegion || !leaf) return null;
+    var aliases = [leaf.id, leaf.name, leaf.mapRegionId, leaf.regionId].filter(function(value) {
+      return value !== undefined && value !== null && String(value) !== '';
+    });
+    for (var i = 0; i < aliases.length; i++) {
+      if (P.byRegion[String(aliases[i])]) return P.byRegion[String(aliases[i])];
+    }
+    return null;
+  }
+
+  function _ensureLeafDemographicBuckets(leaf, detail) {
+    detail = detail || (leaf && leaf.populationDetail);
+    if (!leaf || !detail) return { byAge:{}, byGender:{} };
+    var mouths = Math.max(0, Math.round(Number(detail.mouths) || 0));
+    var legacy = _legacyPopulationRowForLeaf(global.GM && global.GM.population, leaf);
+    var byAge = _scaleBucketsToTotal(
+      detail.byAge || leaf.byAge || (legacy && legacy.byAge) || {},
+      mouths,
+      AGE_BUCKET_TEMPLATE
+    );
+    var byGender = _scaleBucketsToTotal(
+      detail.byGender || leaf.byGender || (legacy && legacy.byGender) || {},
+      mouths,
+      GENDER_BUCKET_TEMPLATE
+    );
+    detail.byAge = byAge;
+    detail.byGender = byGender;
+    leaf.byAge = byAge;
+    leaf.byGender = byGender;
+    if (legacy) {
+      legacy.byAge = byAge;
+      legacy.byGender = byGender;
+    }
+    return { byAge:byAge, byGender:byGender };
+  }
+
+  function _resizeLeafDemographicBuckets(leaf, detail, mouths) {
+    var buckets = _ensureLeafDemographicBuckets(leaf, detail);
+    var nextAge = _scaleBucketsToTotal(buckets.byAge, mouths, AGE_BUCKET_TEMPLATE);
+    var nextGender = _scaleBucketsToTotal(buckets.byGender, mouths, GENDER_BUCKET_TEMPLATE);
+    detail.byAge = nextAge;
+    detail.byGender = nextGender;
+    leaf.byAge = nextAge;
+    leaf.byGender = nextGender;
+    var legacy = _legacyPopulationRowForLeaf(global.GM && global.GM.population, leaf);
+    if (legacy) {
+      legacy.byAge = nextAge;
+      legacy.byGender = nextGender;
+    }
+    return { byAge:nextAge, byGender:nextGender };
+  }
+
+  function _advanceLeafDemographicBuckets(leaf, detail, births, deaths, mr) {
+    // The caller has already normalized these buckets against the pre-growth
+    // population. Do not normalize them again after detail.mouths changes or
+    // births would be counted once by resizing and a second time below.
+    var age = Object.assign({}, detail.byAge || leaf.byAge || {});
+    var gender = Object.assign({}, detail.byGender || leaf.byGender || {});
+    var ageKeys = Object.keys(AGE_BUCKET_TEMPLATE);
+    var fractionMove = Math.max(0, Number(mr) || 0) / 120;
+    var newlyAdult = Math.round((Number(age.age_11_20) || 0) * fractionMove);
+    var leavingDing = Math.round((Number(age.age_51_60) || 0) * fractionMove);
+    for (var i = ageKeys.length - 1; i > 0; i--) {
+      var move = Math.min(Number(age[ageKeys[i - 1]]) || 0, Math.round((Number(age[ageKeys[i - 1]]) || 0) * fractionMove));
+      age[ageKeys[i - 1]] = Math.max(0, (Number(age[ageKeys[i - 1]]) || 0) - move);
+      age[ageKeys[i]] = (Number(age[ageKeys[i]]) || 0) + move;
+    }
+    age.age_0_10 = (Number(age.age_0_10) || 0) + Math.max(0, Math.round(Number(births) || 0));
+    var maleBirths = Math.round(Math.max(0, Number(births) || 0) * 0.52);
+    gender.male = (Number(gender.male) || 0) + maleBirths;
+    gender.female = (Number(gender.female) || 0) + Math.max(0, Math.round(Number(births) || 0)) - maleBirths;
+    // Natural and explicit mortality already changed detail.mouths. Scaling the
+    // buckets to that authoritative total removes deaths without inventing a
+    // second population producer.
+    age = _scaleBucketsToTotal(age, detail.mouths, AGE_BUCKET_TEMPLATE);
+    gender = _scaleBucketsToTotal(gender, detail.mouths, GENDER_BUCKET_TEMPLATE);
+    var maleShare = (Number(gender.male) || 0) / Math.max(1, _sumObj(gender));
+    detail.ding = Math.max(0, Math.min(detail.mouths,
+      Math.round((Number(detail.ding) || 0) + (newlyAdult - leavingDing) * maleShare)));
+    detail.byAge = age;
+    detail.byGender = gender;
+    leaf.byAge = age;
+    leaf.byGender = gender;
+    leaf._newlyAdult = newlyAdult;
+    leaf._leavingDing = leavingDing;
+    var legacy = _legacyPopulationRowForLeaf(global.GM && global.GM.population, leaf);
+    if (legacy) {
+      legacy.byAge = age;
+      legacy.byGender = gender;
+      legacy.ding = detail.ding;
+    }
+  }
+
+  function _leafDemographicTotals(leaves) {
+    var out = { byAge:{}, byGender:{}, newlyAdult:0, leavingDing:0 };
+    (leaves || []).forEach(function(leaf) {
+      if (!leaf || !leaf.populationDetail) return;
+      var buckets = _ensureLeafDemographicBuckets(leaf, leaf.populationDetail);
+      Object.keys(buckets.byAge).forEach(function(key) {
+        out.byAge[key] = (Number(out.byAge[key]) || 0) + (Number(buckets.byAge[key]) || 0);
+      });
+      Object.keys(buckets.byGender).forEach(function(key) {
+        out.byGender[key] = (Number(out.byGender[key]) || 0) + (Number(buckets.byGender[key]) || 0);
+      });
+      out.newlyAdult += Number(leaf._newlyAdult) || 0;
+      out.leavingDing += Number(leaf._leavingDing) || 0;
+    });
+    return out;
+  }
+
+  function syncDemographicViews() {
+    var G = global.GM;
+    var P = G && G.population;
+    if (!P) return { ok:false, reason:'population-unavailable' };
+    var groups = _factionLeafGroups(G);
+    var playerGroup = groups.find(function(group) { return group.isPlayer; });
+    if (!playerGroup) {
+      _ensureDeepDemographics(P);
+      return { ok:true, legacy:true };
+    }
+    var totals = _leafPopulationTotals(playerGroup.leaves);
+    var demographic = _leafDemographicTotals(playerGroup.leaves);
+    P.national.mouths = totals.mouths; // arch-ok: 叶级人口结构聚合玩家全国人口
+    P.national.households = totals.households; // arch-ok: 叶级人口结构聚合玩家全国户数
+    P.national.ding = totals.ding; // arch-ok: 叶级人口结构聚合玩家全国丁口
+    P.byAge = demographic.byAge; // arch-ok: 叶级人口结构派生全国年龄视图
+    P.ageLayers = Object.assign({}, demographic.byAge); // arch-ok: 叶级人口结构派生兼容年龄视图
+    P.agePyramidFine = Object.assign({}, demographic.byAge, { // arch-ok: 叶级人口结构派生精细年龄视图
+      _newlyAdult:demographic.newlyAdult,
+      _leavingDing:demographic.leavingDing
+    }); // arch-ok: 叶级人口结构派生精细年龄视图
+    P.byGender = demographic.byGender; // arch-ok: 叶级人口结构派生全国性别视图
+    P.gender = { // arch-ok: 叶级人口结构派生兼容性别视图
+      male:Number(demographic.byGender.male) || 0,
+      female:Number(demographic.byGender.female) || 0,
+      total:_sumObj(demographic.byGender),
+      ratio:(Number(demographic.byGender.male) || 0) / Math.max(1, Number(demographic.byGender.female) || 0)
+    }; // arch-ok: 叶级人口结构派生兼容性别视图
+    return { ok:true, national:totals, byAge:demographic.byAge, byGender:demographic.byGender };
   }
 
   function _recordPopulationDynamics(d, ctx, G, births, deaths, mr) {
@@ -824,10 +996,7 @@
       var disaster = Number(group.branch && group.branch.disasterLevel);
       if (!isFinite(disaster)) disaster = group.isPlayer ? Number(G.vars && G.vars.disasterLevel) || 0 : 0;
       var war = (G.activeWars || []).filter(function(activeWar) {
-        if (!activeWar || group.isPlayer) return group.isPlayer;
-        var refs = [activeWar.factionId, activeWar.attackerId, activeWar.defenderId, activeWar.sourceFactionId, activeWar.targetFactionId]
-          .map(String);
-        return refs.indexOf(group.factionId) >= 0;
+        return _warAffectsFaction(activeWar, group);
       }).length;
       var baseBirth = Number(d.birthRateBase); if (!isFinite(baseBirth)) baseBirth = 0.035;
       baseBirth += Number(d.prosperityBonus) || 0;
@@ -845,6 +1014,7 @@
         if (!pd) return;
         var mouths = Number(pd.mouths) || 0;
         if (mouths <= 0) return;
+        _ensureLeafDemographicBuckets(leaf, pd);
         var minxin = Number(leaf.minxin);
         if (!isFinite(minxin)) minxin = Number(leaf.minxinLocal);
         if (!isFinite(minxin)) minxin = 50;
@@ -882,6 +1052,7 @@
         pd.mouths = Math.max(0, mouths + births - deaths);
         pd.households = Math.round(pd.mouths / Math.max(1, leafMouthsPerHousehold));
         pd.ding = Math.round(pd.mouths * leafDingRatio);
+        _advanceLeafDemographicBuckets(leaf, pd, births, deaths, mr);
         _syncLeafPopulationMirrors(leaf, pd);
         if (group.isPlayer) _syncPlayerLegacyRow(P, leaf, pd);
         leaf.yearlyBirths = (Number(leaf.yearlyBirths) || 0) + births;
@@ -903,32 +1074,105 @@
       }
     });
     _refreshWorldPopulationSummary(G, groups);
+    syncDemographicViews();
   }
 
-  function _findFactionPopulationGroup(G, options, groups) {
+  function _populationGroupAliases(group) {
+    return [group && group.key, group && group.factionId, group && group.factionName,
+      group && group.faction && group.faction.key, group && group.faction && group.faction.id,
+      group && group.faction && group.faction.name]
+      .map(_normPopulationName).filter(Boolean);
+  }
+
+  function _appendWarParticipantRefs(out, value) {
+    if (value === undefined || value === null || value === '') return;
+    if (Array.isArray(value)) {
+      value.forEach(function(item) { _appendWarParticipantRefs(out, item); });
+      return;
+    }
+    if (typeof value === 'object') {
+      [value.id, value.key, value.name, value.factionId, value.factionName].forEach(function(item) {
+        _appendWarParticipantRefs(out, item);
+      });
+      return;
+    }
+    var normalized = _normPopulationName(value);
+    if (normalized && out.indexOf(normalized) < 0) out.push(normalized);
+  }
+
+  function _warAffectsFaction(activeWar, group) {
+    if (!activeWar || !group) return false;
+    var refs = [];
+    ['factionId', 'attackerId', 'defenderId', 'sourceFactionId', 'targetFactionId',
+      'attacker', 'defender', 'sourceFaction', 'targetFaction', 'attackerFaction',
+      'defenderFaction', 'faction', 'participants', 'participantIds'].forEach(function(field) {
+      _appendWarParticipantRefs(refs, activeWar[field]);
+    });
+    var aliases = _populationGroupAliases(group);
+    if (refs.some(function(ref) { return aliases.indexOf(ref) >= 0; })) return true;
+    // A small set of legacy player-war rows stored only an enemy/opponent label.
+    // Treat those as player wars only when no participant fields exist; never
+    // turn an explicitly NPC-vs-NPC war into a player war.
+    return !!(group.isPlayer && refs.length === 0 && (activeWar.enemy || activeWar.opponent));
+  }
+
+  function _hasExplicitFactionTarget(options) {
+    return ['factionKey', 'factionId', 'factionName'].some(function(field) {
+      return options && options[field] !== undefined && options[field] !== null && String(options[field]).trim() !== '';
+    });
+  }
+
+  function _leafPopulationAliases(leaf) {
+    return [leaf && leaf.id, leaf && leaf.name, leaf && leaf.mapRegionId, leaf && leaf.regionId]
+      .map(_normPopulationName).filter(Boolean);
+  }
+
+  function _resolvePopulationTarget(G, options, groups) {
     options = options || {};
     groups = groups || _factionLeafGroups(G);
-    var regionId = _normPopulationName(options.regionId || options.regionName);
-    if (regionId) {
-      for (var regionGroupIndex = 0; regionGroupIndex < groups.length; regionGroupIndex++) {
-        var regionGroup = groups[regionGroupIndex];
-        var ownsRegion = (regionGroup.leaves || []).some(function(leaf) {
-          return [leaf && leaf.id, leaf && leaf.name, leaf && leaf.mapRegionId, leaf && leaf.regionId]
-            .map(_normPopulationName).some(function(alias) { return alias && alias === regionId; });
-        });
-        if (ownsRegion) return regionGroup;
-      }
-      return null;
-    }
+    var explicitFaction = _hasExplicitFactionTarget(options);
     var wanted = [_normPopulationName(options.factionKey), _normPopulationName(options.factionId), _normPopulationName(options.factionName)].filter(Boolean);
+    var factionGroup = null;
     if (wanted.length) {
-      for (var i = 0; i < groups.length; i++) {
-        var group = groups[i];
-        var aliases = [group.key, group.factionId, group.factionName].map(_normPopulationName);
-        if (aliases.some(function(alias) { return alias && wanted.indexOf(alias) >= 0; })) return group;
-      }
+      factionGroup = groups.find(function(group) {
+        return _populationGroupAliases(group).some(function(alias) { return wanted.indexOf(alias) >= 0; });
+      }) || null;
+      if (!factionGroup) return { ok:false, reason:'faction-not-found', group:null, leaf:null };
     }
-    return groups.find(function(group) { return group.isPlayer; }) || null;
+
+    var directRegion = _normPopulationName(options.regionId || options.regionName);
+    var candidateRegions = (Array.isArray(options.regionCandidates) ? options.regionCandidates : [])
+      .map(_normPopulationName).filter(Boolean);
+    if (directRegion || candidateRegions.length) {
+      var searchGroups = factionGroup ? [factionGroup] : groups;
+      var matches = [];
+      searchGroups.forEach(function(regionGroup) {
+        (regionGroup.leaves || []).forEach(function(leaf) {
+          var aliases = _leafPopulationAliases(leaf);
+          var exact = directRegion && aliases.indexOf(directRegion) >= 0;
+          var candidate = candidateRegions.some(function(wantedRegion) {
+            return aliases.some(function(alias) {
+              return alias === wantedRegion || alias.indexOf(wantedRegion) >= 0 || wantedRegion.indexOf(alias) >= 0;
+            });
+          });
+          if (exact || candidate) matches.push({ group:regionGroup, leaf:leaf });
+        });
+      });
+      if (!matches.length) return { ok:false, reason:'region-not-found', group:factionGroup, leaf:null };
+      if (matches.length > 1) {
+        var exactMatches = directRegion ? matches.filter(function(match) {
+          return _leafPopulationAliases(match.leaf).indexOf(directRegion) >= 0;
+        }) : [];
+        if (exactMatches.length === 1) matches = exactMatches;
+        else return { ok:false, reason:'region-ambiguous', group:factionGroup, leaf:null };
+      }
+      return { ok:true, group:matches[0].group, leaf:matches[0].leaf };
+    }
+    if (factionGroup) return { ok:true, group:factionGroup, leaf:null };
+    var playerGroup = groups.find(function(group) { return group.isPlayer; }) || null;
+    if (playerGroup) return { ok:true, group:playerGroup, leaf:null };
+    if (explicitFaction) return { ok:false, reason:'faction-not-found', group:null, leaf:null };
+    return { ok:groups.length === 0, reason:groups.length ? 'player-faction-not-found' : '', group:null, leaf:null };
   }
 
   function _applyPopulationLossToLeaves(group, mouthsRequested, dingRequested, cause, regionId) {
@@ -972,6 +1216,7 @@
       detail.mouths = Math.max(0, mouthsBefore - mouthLoss);
       detail.ding = Math.max(0, dingBefore - dingLoss);
       detail.households = detail.mouths > 0 ? Math.round(detail.mouths / Math.max(1, mouthsPerHousehold)) : 0;
+      _resizeLeafDemographicBuckets(leaf, detail, detail.mouths);
       leaf.yearlyDeaths = (Number(leaf.yearlyDeaths) || 0) + mouthLoss;
       if (!Array.isArray(leaf.populationLossLedger)) leaf.populationLossLedger = [];
       if (mouthLoss || dingLoss) {
@@ -1020,14 +1265,22 @@
     var P = G && G.population;
     if (!P || !P.national) return { ok:false, reason:'population-unavailable', mouths:0, ding:0 };
     var groups = _factionLeafGroups(G);
-    var group = _findFactionPopulationGroup(G, options, groups);
-    if ((options.regionId || options.regionName) && !group) {
-      return { ok:false, reason:'region-not-found', mouths:0, ding:0 };
+    var target = _resolvePopulationTarget(G, options, groups);
+    if (!target.ok) return { ok:false, reason:target.reason || 'population-target-not-found', mouths:0, ding:0 };
+    var group = target.group;
+    var regionLeaf = target.leaf;
+    var requestedMouths = options.mouths;
+    if (!(Number(requestedMouths) >= 0) && Number(options.mortalityRate) >= 0) {
+      var baseMouths = regionLeaf && regionLeaf.populationDetail
+        ? Number(regionLeaf.populationDetail.mouths) || 0
+        : (group ? _leafPopulationTotals(group.leaves).mouths : Number(P.national.mouths) || 0);
+      requestedMouths = Math.round(baseMouths * Math.max(0, Number(options.mortalityRate) || 0));
     }
     var applied;
     var entry = null;
     if (group && group.leaves.length) {
-      applied = _applyPopulationLossToLeaves(group, options.mouths, options.ding, options.cause, options.regionId || options.regionName);
+      var resolvedRegion = regionLeaf && (regionLeaf.id || regionLeaf.name || regionLeaf.mapRegionId || regionLeaf.regionId);
+      applied = _applyPopulationLossToLeaves(group, requestedMouths, options.ding, options.cause, resolvedRegion || options.regionId || options.regionName);
       var totals = _leafPopulationTotals(group.leaves);
       entry = _factionPopulationEntry(G, group);
       entry.national = totals;
@@ -1040,8 +1293,9 @@
         entry.dynamics._yearlyAccumDeaths = (Number(entry.dynamics._yearlyAccumDeaths) || 0) + applied.mouths;
       }
       _refreshWorldPopulationSummary(G, groups);
+      syncDemographicViews();
     } else {
-      applied = _applyPopulationLossLegacy(P, options.mouths, options.ding);
+      applied = _applyPopulationLossLegacy(P, requestedMouths, options.ding);
       if (P.dynamics) P.dynamics._yearlyAccumDeaths = (Number(P.dynamics._yearlyAccumDeaths) || 0) + applied.mouths; // arch-ok: 旧档死亡账本同步玩家年度死亡统计
     }
     var ledgerRow = {
@@ -1052,7 +1306,14 @@
       ding:applied.ding
     };
     _appendPopulationLossLedger(group && !group.isPlayer ? entry : P, ledgerRow);
-    return { ok:true, mouths:applied.mouths, ding:applied.ding, factionId:group && group.factionId };
+    return {
+      ok:true,
+      mouths:applied.mouths,
+      ding:applied.ding,
+      factionId:group && group.factionId,
+      regionId:regionLeaf && String(regionLeaf.id || regionLeaf.name || ''),
+      regionName:regionLeaf && String(regionLeaf.name || regionLeaf.id || '')
+    };
   }
 
   function _deepFieldDiversityPressure(r) {
@@ -1081,20 +1342,9 @@
     var _rlSeeded = (function(){ var rl = _renli(); return (rl && rl.seededRegionKeySet) ? rl.seededRegionKeySet() : {}; })(); // 已种子地域逃亡归 Renli·deep-field 此处让出（A2a）
     var minxin = G.minxin && typeof G.minxin === 'object' ? (G.minxin.trueIndex || G.minxin.index || 50) : (G.minxin || 50);
     var huangquan = G.huangquan && typeof G.huangquan === 'object' ? (G.huangquan.index || 50) : (G.huangquan || 50);
-    var activeWar = Array.isArray(G.activeWars) && G.activeWars.length > 0;
-
     Object.keys(P.byRegion).forEach(function(rid) {
       var r = P.byRegion[rid];
       _ensureRegionDeepFields(r);
-
-      if (activeWar && r.byGender && typeof r.byGender.male === 'number') {
-        var maleLoss = Math.round(r.byGender.male * 0.002 * mr);
-        if (maleLoss > 0) {
-          r.byGender.male = Math.max(0, r.byGender.male - maleLoss);
-          r.yearlyDeaths = (r.yearlyDeaths || 0) + maleLoss;
-          ledger.push({ kind:'gender-war-loss', regionId:rid, maleLoss:maleLoss });
-        }
-      }
 
       var households = Math.max(1, r.households || Math.round((r.mouths || 0) / 5));
       var baojiaCoverage = Math.max(0, Math.min(1, (r.baojiaUnits || 0) * 10 / households));
@@ -1457,6 +1707,7 @@
           detail.mouths = mouths - flow;
           detail.households = Math.round(detail.mouths / Math.max(1, localMphh));
           detail.ding = Math.round(detail.mouths * localDingRatio);
+          _resizeLeafDemographicBuckets(leaf, detail, detail.mouths);
           _syncLeafPopulationMirrors(leaf, detail);
           if (group.isPlayer) _syncPlayerLegacyRow(P, leaf, detail);
           leaf.yearlyNetMigration = (Number(leaf.yearlyNetMigration) || 0) - flow;
@@ -1471,6 +1722,7 @@
         capitalDetail.mouths = capitalMouths + totalFlow;
         capitalDetail.households = Math.round(capitalDetail.mouths / Math.max(1, capitalMphh));
         capitalDetail.ding = Math.round(capitalDetail.mouths * capitalDingRatio);
+        _resizeLeafDemographicBuckets(capLeaf, capitalDetail, capitalDetail.mouths);
         _syncLeafPopulationMirrors(capLeaf, capitalDetail);
         if (group.isPlayer) _syncPlayerLegacyRow(P, capLeaf, capitalDetail);
         capLeaf.yearlyNetMigration = (Number(capLeaf.yearlyNetMigration) || 0) + totalFlow;
@@ -1484,6 +1736,216 @@
       P.national.ding = playerTotals.ding; // arch-ok: 户籍权威写口由玩家叶级真值聚合全国丁口
     }
     _refreshWorldPopulationSummary(G, groups);
+    syncDemographicViews();
+  }
+
+  function _leafMatchesPopulationCandidates(leaf, candidates) {
+    var aliases = _leafPopulationAliases(leaf);
+    return (candidates || []).map(_normPopulationName).filter(Boolean).some(function(candidate) {
+      return aliases.some(function(alias) {
+        return alias === candidate || alias.indexOf(candidate) >= 0 || candidate.indexOf(alias) >= 0;
+      });
+    });
+  }
+
+  function _populationDivisionContainer(group) {
+    if (!group) return null;
+    if (Array.isArray(group.branch)) return group.branch;
+    if (group.branch && Array.isArray(group.branch.divisions)) return group.branch.divisions;
+    return null;
+  }
+
+  function _emptyPopulationBundle() {
+    return { mouths:0, households:0, ding:0, byAge:{}, byGender:{} };
+  }
+
+  function _addBucketDelta(target, before, after) {
+    Object.keys(before || {}).forEach(function(key) {
+      var delta = Math.max(0, (Number(before[key]) || 0) - (Number(after && after[key]) || 0));
+      target[key] = (Number(target[key]) || 0) + delta;
+    });
+  }
+
+  function _removePopulationForTransfer(leaves, requested) {
+    var bundle = _emptyPopulationBundle();
+    var total = _leafPopulationTotals(leaves).mouths;
+    var remaining = Math.min(Math.max(0, Math.round(Number(requested) || 0)), total);
+    var remainingPool = total;
+    (leaves || []).forEach(function(leaf, index) {
+      var detail = leaf && leaf.populationDetail;
+      if (!detail || remaining <= 0) return;
+      var mouthsBefore = Math.max(0, Math.round(Number(detail.mouths) || 0));
+      if (!mouthsBefore) return;
+      var householdsBefore = Math.max(0, Math.round(Number(detail.households) || 0));
+      var dingBefore = Math.max(0, Math.round(Number(detail.ding) || 0));
+      var bucketsBefore = _ensureLeafDemographicBuckets(leaf, detail);
+      var ageBefore = Object.assign({}, bucketsBefore.byAge);
+      var genderBefore = Object.assign({}, bucketsBefore.byGender);
+      var flow = index === leaves.length - 1
+        ? Math.min(mouthsBefore, remaining)
+        : Math.min(mouthsBefore, Math.round(remaining * mouthsBefore / Math.max(1, remainingPool)));
+      var householdFlow = Math.min(householdsBefore, Math.round(householdsBefore * flow / Math.max(1, mouthsBefore)));
+      var dingFlow = Math.min(dingBefore, Math.round(dingBefore * flow / Math.max(1, mouthsBefore)));
+      detail.mouths = mouthsBefore - flow;
+      detail.households = householdsBefore - householdFlow;
+      detail.ding = dingBefore - dingFlow;
+      var resized = _resizeLeafDemographicBuckets(leaf, detail, detail.mouths);
+      _syncLeafPopulationMirrors(leaf, detail);
+      if (leaf.yearlyNetMigration !== undefined) leaf.yearlyNetMigration = (Number(leaf.yearlyNetMigration) || 0) - flow;
+      bundle.mouths += flow;
+      bundle.households += householdFlow;
+      bundle.ding += dingFlow;
+      _addBucketDelta(bundle.byAge, ageBefore, resized.byAge);
+      _addBucketDelta(bundle.byGender, genderBefore, resized.byGender);
+      remaining -= flow;
+      remainingPool -= mouthsBefore;
+    });
+    bundle.byAge = _scaleBucketsToTotal(bundle.byAge, bundle.mouths, AGE_BUCKET_TEMPLATE);
+    bundle.byGender = _scaleBucketsToTotal(bundle.byGender, bundle.mouths, GENDER_BUCKET_TEMPLATE);
+    return bundle;
+  }
+
+  function _takeExactBucketShare(state, total) {
+    total = Math.max(0, Math.min(Math.round(Number(total) || 0), state.total));
+    var keys = Object.keys(state.values);
+    var out = {};
+    if (!keys.length || !state.total || !total) {
+      keys.forEach(function(key) { out[key] = 0; });
+      return out;
+    }
+    var ranked = [];
+    var assigned = 0;
+    keys.forEach(function(key) {
+      var available = Math.max(0, Math.round(Number(state.values[key]) || 0));
+      var quota = available * total / state.total;
+      var value = Math.min(available, Math.floor(quota));
+      out[key] = value;
+      assigned += value;
+      ranked.push({ key:key, fraction:quota - value, available:available });
+    });
+    ranked.sort(function(a, b) { return b.fraction - a.fraction || String(a.key).localeCompare(String(b.key)); });
+    var remaining = total - assigned;
+    for (var i = 0; remaining > 0 && ranked.length; i = (i + 1) % ranked.length) {
+      var row = ranked[i];
+      if (out[row.key] >= row.available) continue;
+      out[row.key]++;
+      remaining--;
+    }
+    keys.forEach(function(key) { state.values[key] = Math.max(0, Number(state.values[key]) - out[key]); });
+    state.total -= total;
+    return out;
+  }
+
+  function _bundleShare(bundle, index, count, assigned, bucketState) {
+    var last = index === count - 1;
+    var share = {};
+    ['mouths', 'households', 'ding'].forEach(function(field) {
+      share[field] = last
+        ? Math.max(0, Number(bundle[field]) - Number(assigned[field]))
+        : Math.round(Number(bundle[field]) / count);
+      assigned[field] += share[field];
+    });
+    share.byAge = _takeExactBucketShare(bucketState.byAge, share.mouths);
+    share.byGender = _takeExactBucketShare(bucketState.byGender, share.mouths);
+    return share;
+  }
+
+  function materializeQiaozhiResettlement(options) {
+    options = options || {};
+    var G = global.GM;
+    var groups = _factionLeafGroups(G);
+    var target = _resolvePopulationTarget(G, options, groups);
+    if (!target.ok || !target.group) return { ok:false, reason:target.reason || 'player-faction-not-found' };
+    var group = target.group;
+    var container = _populationDivisionContainer(group);
+    if (!container) return { ok:false, reason:'division-container-unavailable' };
+    var eventId = String(options.eventId || '').trim();
+    var targetNames = (Array.isArray(options.targetNames) ? options.targetNames : [])
+      .map(function(value) { return String(value || '').trim(); }).filter(Boolean);
+    if (!eventId || !targetNames.length) return { ok:false, reason:'qiaozhi-spec-invalid' };
+    var existing = group.leaves.filter(function(leaf) {
+      return leaf && (leaf.parentHistoric === eventId || targetNames.indexOf(String(leaf.name || '')) >= 0);
+    });
+    if (existing.length === targetNames.length) {
+      return { ok:true, alreadyMaterialized:true, scale:_leafPopulationTotals(existing).mouths, factionId:group.factionId };
+    }
+    if (existing.length) return { ok:false, reason:'qiaozhi-target-conflict' };
+    var sourceCandidates = Array.isArray(options.sourceCandidates) ? options.sourceCandidates : [];
+    var sourceLeaves = group.leaves.filter(function(leaf) {
+      return leaf && leaf.populationDetail && Number(leaf.populationDetail.mouths) > 0 &&
+        (!sourceCandidates.length || _leafMatchesPopulationCandidates(leaf, sourceCandidates));
+    });
+    if (!sourceLeaves.length) return { ok:false, reason:'source-region-not-found' };
+    var sourceTotal = _leafPopulationTotals(sourceLeaves).mouths;
+    var requested = Math.min(Math.max(0, Math.round(Number(options.mouths) || 0)), Math.round(sourceTotal * 0.3));
+    if (!requested) return { ok:false, reason:'source-population-empty' };
+    var existingIds = Object.create(null);
+    groups.forEach(function(populationGroup) {
+      populationGroup.leaves.forEach(function(leaf) {
+        if (leaf && leaf.id != null) existingIds[String(leaf.id)] = true;
+      });
+    });
+    var plannedIds = targetNames.map(function(name) {
+      var stableId = 'tm_qiaozhi_' + _tmPopulationHash(String(group.factionId || group.key) + '|' + eventId + '|' + name);
+      if (existingIds[stableId]) throw new Error('侨置行政区稳定 ID 冲突: ' + stableId);
+      existingIds[stableId] = true;
+      return stableId;
+    });
+    var bundle = _removePopulationForTransfer(sourceLeaves, requested);
+    if (!bundle.mouths) return { ok:false, reason:'source-population-empty' };
+    var assigned = { mouths:0, households:0, ding:0, byAge:{}, byGender:{} };
+    var bucketState = {
+      byAge:{ values:Object.assign({}, bundle.byAge), total:bundle.mouths },
+      byGender:{ values:Object.assign({}, bundle.byGender), total:bundle.mouths }
+    };
+    var created = targetNames.map(function(name, index) {
+      var share = _bundleShare(bundle, index, targetNames.length, assigned, bucketState);
+      var stableId = plannedIds[index];
+      var detail = {
+        households:share.households,
+        mouths:share.mouths,
+        ding:share.ding,
+        byAge:share.byAge,
+        byGender:share.byGender
+      };
+      return {
+        id:stableId,
+        name:name,
+        level:'qiaozhi',
+        regionType:'qiaozhi',
+        isQiaozhi:true,
+        parentHistoric:eventId,
+        factionId:group.factionId,
+        populationDetail:detail,
+        population:{ households:detail.households, mouths:detail.mouths, ding:detail.ding },
+        byAge:detail.byAge,
+        byGender:detail.byGender,
+        byLegalStatus:{ qiaozhi:{ households:detail.households, mouths:detail.mouths, ding:detail.ding } },
+        yearlyNetMigration:detail.mouths
+      };
+    });
+    created.forEach(function(division) { container.push(division); }); // arch-ok: 户籍权威写口创建侨置叶级行政区
+    groups = _factionLeafGroups(G);
+    _refreshWorldPopulationSummary(G, groups);
+    syncDemographicViews();
+    return {
+      ok:true,
+      scale:bundle.mouths,
+      households:bundle.households,
+      ding:bundle.ding,
+      factionId:group.factionId,
+      regionIds:created.map(function(division) { return division.id; })
+    };
+  }
+
+  function _tmPopulationHash(text) {
+    var hash = 2166136261;
+    text = String(text || '');
+    for (var i = 0; i < text.length; i++) {
+      hash ^= text.charCodeAt(i);
+      hash = typeof Math.imul === 'function' ? Math.imul(hash, 16777619) : hash * 16777619;
+    }
+    return ('00000000' + (hash >>> 0).toString(16)).slice(-8);
   }
 
   function _executeMigrationEvent(e, suppliedGroups) {
@@ -1646,6 +2108,8 @@
     init: init,
     tick: tick,
     applyPopulationLoss: applyPopulationLoss,
+    materializeQiaozhiResettlement: materializeQiaozhiResettlement,
+    syncDemographicViews: syncDemographicViews,
     startLargeCorvee: startLargeCorvee,
     getAIContext: getAIContext,
     CATEGORY_TEMPLATES: CATEGORY_TEMPLATES,

--- a/web/tm-huji-runtime-bridge.js
+++ b/web/tm-huji-runtime-bridge.js
@@ -49,6 +49,27 @@
     return Math.round(number(v, 0) * 100) / 100;
   }
 
+  function addNumericBuckets(target, source) {
+    Object.keys(source || {}).forEach(function(key) {
+      var value = Number(source[key]);
+      if (!isFinite(value)) return;
+      target[key] = (Number(target[key]) || 0) + Math.max(0, Math.round(value));
+    });
+    return target;
+  }
+
+  function addPopulationBreakdown(target, source) {
+    Object.keys(source || {}).forEach(function(key) {
+      var row = source[key];
+      if (!row || typeof row !== 'object' || Array.isArray(row)) return;
+      if (!target[key]) target[key] = { households:0, mouths:0, ding:0 };
+      target[key].households += round(row.households);
+      target[key].mouths += round(row.mouths);
+      target[key].ding += round(row.ding);
+    });
+    return target;
+  }
+
   function clamp(n, min, max) {
     n = number(n, min);
     return Math.max(min, Math.min(max, n));
@@ -231,7 +252,10 @@
       mouths: mouths,
       ding: ding,
       hiddenCount: hidden,
-      fugitives: fugitives
+      fugitives: fugitives,
+      byAge: clone(raw.byAge || region.byAge || {}),
+      byGender: clone(raw.byGender || region.byGender || {}),
+      byLegalStatus: clone(raw.byLegalStatus || region.byLegalStatus || {})
     };
   }
 
@@ -239,6 +263,9 @@
     var initial = (config && config.initial) || {};
     var byRegion = {};
     var totals = { households: 0, mouths: 0, ding: 0, hiddenCount: 0, fugitives: 0 };
+    var byAge = {};
+    var byGender = {};
+    var byLegalStatus = {};
     leaves.forEach(function(region, idx) {
       var d = detailFromRegion(region);
       var id = String(region.id || region.name || ('region-' + idx));
@@ -247,11 +274,17 @@
       totals.ding += d.ding;
       totals.hiddenCount += d.hiddenCount;
       totals.fugitives += d.fugitives;
+      addNumericBuckets(byAge, d.byAge);
+      addNumericBuckets(byGender, d.byGender);
+      addPopulationBreakdown(byLegalStatus, d.byLegalStatus);
       region.populationDetail = Object.assign({}, region.populationDetail || {}, d);
       byRegion[id] = Object.assign({}, d, {
         id: id,
         name: region.name || id,
         regionType: region.regionType || region.type || region.kind || '',
+        byAge: clone(d.byAge),
+        byGender: clone(d.byGender),
+        byLegalStatus: clone(d.byLegalStatus),
         bySettlement: clone(region.bySettlement || (region.populationDetail && region.populationDetail.bySettlement) || {}),
         byEthnicity: clone(region.byEthnicity || (region.populationDetail && region.populationDetail.byEthnicity) || {}),
         byFaith: clone(region.byFaith || region.byReligion || (region.populationDetail && region.populationDetail.byFaith) || {}),
@@ -278,6 +311,9 @@
       fugitives: fugitives,
       regionalHidden: totals.hiddenCount,
       regionalFugitives: totals.fugitives,
+      byAge: byAge,
+      byGender: byGender,
+      byLegalStatus: byLegalStatus,
       byRegion: byRegion
     };
   }
@@ -354,10 +390,18 @@
     var national = aggregate.national;
     var hiddenHouseholds = estimateHiddenHouseholds(aggregate.hiddenCount, national);
     var fugitiveHouseholds = estimateHiddenHouseholds(aggregate.fugitives, national);
-    var visibleHouseholds = Math.max(0, national.households - hiddenHouseholds - fugitiveHouseholds);
-    var visibleMouths = Math.max(0, national.mouths - aggregate.hiddenCount - aggregate.fugitives);
-    var visibleDing = Math.max(0, national.ding - round((aggregate.hiddenCount + aggregate.fugitives) * 0.30));
-    return Object.assign({}, root.population && root.population.byLegalStatus || {}, {
+    var extras = clone(aggregate.byLegalStatus || {});
+    ['huangji', 'baiji', 'taohu', 'yinhu'].forEach(function(key) { delete extras[key]; });
+    var classified = { households:0, mouths:0, ding:0 };
+    Object.keys(extras).forEach(function(key) {
+      classified.households += round(extras[key] && extras[key].households);
+      classified.mouths += round(extras[key] && extras[key].mouths);
+      classified.ding += round(extras[key] && extras[key].ding);
+    });
+    var visibleHouseholds = Math.max(0, national.households - hiddenHouseholds - fugitiveHouseholds - classified.households);
+    var visibleMouths = Math.max(0, national.mouths - aggregate.hiddenCount - aggregate.fugitives - classified.mouths);
+    var visibleDing = Math.max(0, national.ding - round((aggregate.hiddenCount + aggregate.fugitives) * 0.30) - classified.ding);
+    return Object.assign({}, extras, {
       huangji: {
         households: round(visibleHouseholds * 0.94),
         mouths: round(visibleMouths * 0.94),
@@ -400,6 +444,19 @@
     root.population.hiddenCount = aggregate.hiddenCount;
     root.population.fugitives = aggregate.fugitives;
     root.population.byRegion = aggregate.byRegion;
+    root.population.byAge = clone(aggregate.byAge || {});
+    root.population.ageLayers = clone(aggregate.byAge || {});
+    root.population.byGender = clone(aggregate.byGender || {});
+    root.population.gender = {
+      male:round(aggregate.byGender && aggregate.byGender.male),
+      female:round(aggregate.byGender && aggregate.byGender.female),
+      total:round(aggregate.byGender && aggregate.byGender.male) + round(aggregate.byGender && aggregate.byGender.female),
+      ratio:round(aggregate.byGender && aggregate.byGender.male) / Math.max(1, round(aggregate.byGender && aggregate.byGender.female))
+    };
+    root.population.agePyramidFine = Object.assign({}, clone(aggregate.byAge || {}), {
+      _newlyAdult:number(root.population.agePyramidFine && root.population.agePyramidFine._newlyAdult, 0),
+      _leavingDing:number(root.population.agePyramidFine && root.population.agePyramidFine._leavingDing, 0)
+    });
     root.population.byCategory = materializeCategories(root, getPopulationConfig(root, options), aggregate);
     root.population.byLegalStatus = materializeLegalStatus(root, aggregate);
     root.hukou.registeredHouseholds = national.households;

--- a/web/tm-save-lifecycle.js
+++ b/web/tm-save-lifecycle.js
@@ -1197,6 +1197,24 @@ function _tmCollectAdminDivisionEntries(targetGM) {
 
 function _tmAssignMissingStableIds(targetGM, kind, entries) {
   entries = Array.isArray(entries) ? entries : [];
+  var unresolvedFingerprints = Object.create(null);
+  entries.forEach(function(entry, index) {
+    var item = entry && entry.item;
+    if (!item || !_tmStableIdMissing(item.id)) return;
+    var parts = _tmStableIdentityParts(kind, item);
+    if (!parts.length) return;
+    var parentIdentity = '';
+    if (kind === 'division' && entry.identityPath) {
+      var identitySegments = String(entry.identityPath).split('/');
+      identitySegments.pop();
+      parentIdentity = identitySegments.join('/');
+    }
+    var fingerprint = parts.join('|') + (parentIdentity ? '|parent:' + parentIdentity : '');
+    if (_tmHasOwn(unresolvedFingerprints, fingerprint)) {
+      throw new Error('旧存档 ' + kind + ' 身份歧义：' + String(unresolvedFingerprints[fingerprint]) + ' 与 ' + String(entry.path || index) + ' 缺少可区分的稳定来源字段');
+    }
+    unresolvedFingerprints[fingerprint] = entry.path || index;
+  });
   var used = Object.create(null);
   entries.forEach(function(entry) {
     var item = entry && entry.item;
@@ -1333,9 +1351,9 @@ function _tmMigrateCoreStableIds(targetGM) {
   _tmBackfillStableForeignKeys(targetGM);
   if (result.total > 0) {
     if (!targetGM._stableIdMigration || typeof targetGM._stableIdMigration !== 'object') {
-      targetGM._stableIdMigration = { version: 2, totalAssigned: 0, byType: {} }; // arch-ok: schema 迁移收据
+      targetGM._stableIdMigration = { version: 3, totalAssigned: 0, byType: {} }; // arch-ok: schema 迁移收据
     }
-    targetGM._stableIdMigration.version = 2;
+    targetGM._stableIdMigration.version = 3;
     targetGM._stableIdMigration.totalAssigned = Number(targetGM._stableIdMigration.totalAssigned || 0) + result.total;
     Object.keys(result.byType).forEach(function(kind) {
       targetGM._stableIdMigration.byType[kind] = Number(targetGM._stableIdMigration.byType[kind] || 0) + result.byType[kind];


### PR DESCRIPTION
## Summary

- fail closed when mortality targets name an unresolved faction, scope war mortality to actual participants, and preserve explicit player identity after territorial extinction
- route qiaozhi resettlement, regional plague, and war casualties through authoritative faction/region leaf population ledgers
- make age, gender, and ding views derive from leaf population state and keep qiaozhi legal status synchronized
- key faction population summaries by stable faction IDs and reject ambiguous legacy identity collisions
- add focused regressions for faction routing, demographic conservation, qiaozhi persistence, and migration identity ambiguity

## Verification

- 
ode web/scripts/ci-smokes.js — 852 total, 850 passed, 2 existing missing-asset allowlist exemptions
- 
ode web/scripts/lint-arch-all.js — 8/8
- 
ode web/scripts/verify-official-scenario-parity.js — 27 assertions
- 
ode scripts/verify-release-contract.js — 166 assertions
- hot builder gates — 27 assertions
- 
ode scripts/sync-hot-baseline.js --check --version 1.3.4.11 — PASS
- 
pm audit --omit=dev --audit-level=high — 0 high-severity production vulnerabilities
- git diff --check — PASS

No package, release, version bump, or deployment was performed.