### PR TITLE
fix: close fifteenth-round audit population conservation gaps

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-22T08:29:33.572Z",
+  "generatedAt": "2026-08-22T10:42:45.570Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -2161,8 +2161,8 @@
     },
     {
       "path": "index.html",
-      "sha256": "e8ac0c577eceb55d2c6fcd60132e90c6339e42299878cfdf117964dc89a698c0",
-      "size": 68641
+      "sha256": "5c6ed76061f183e5118a79be4d5388bbbcd07bfe18e0679ae98b111559e83dc1",
+      "size": 68643
     },
     {
       "path": "INDEX.md",
@@ -4316,8 +4316,8 @@
     },
     {
       "path": "tm-huji-engine.js",
-      "sha256": "02dda09004299fab809094e8b3c1ceacd80093cca5c21633d3cd3649a2d34ffa",
-      "size": 111835
+      "sha256": "e17eb23ac184acd30c92fd1538ce7ed8c63308f5b0471e678d7e7c56167e205f",
+      "size": 118014
     },
     {
       "path": "tm-huji-governance-loop.js",
@@ -4326,8 +4326,8 @@
     },
     {
       "path": "tm-huji-runtime-bridge.js",
-      "sha256": "4868c879c2e322eb1ea6286df4eecba33ecd4e97bea32f8eb21c2b0cf19b482e",
-      "size": 60911
+      "sha256": "ffb72f11a9b4e4d9e1206e1695e91e83928bd47922674270c92801bdb77bf8d1",
+      "size": 63314
     },
     {
       "path": "tm-indices.js",
@@ -4341,8 +4341,8 @@
     },
     {
       "path": "tm-integration-bridge.js",
-      "sha256": "85e41226ada9de260046c773ef0b7d699b148999aa270de999a875e03aa26e42",
-      "size": 39165
+      "sha256": "87644b609081ccd51e40a5493170fd8d335887a50b9df8f66582ac71abef5dd4",
+      "size": 38894
     },
     {
       "path": "tm-invariants.js",
@@ -4951,8 +4951,8 @@
     },
     {
       "path": "tm-patches-start.js",
-      "sha256": "6d0cabb7da55cae742e73ea92f45fef1d63d2136ae8e94069692f0a4fe8c65d1",
-      "size": 114594
+      "sha256": "c1df9437314f74a89364c1aea680851d94b2a82ade151f50b67e036e16db543a",
+      "size": 114927
     },
     {
       "path": "tm-patches.js",

--- a/web/index.html
+++ b/web/index.html
@@ -720,8 +720,8 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-endturn-progress.js?v=20260620-agentbeats"></script>
 <script src="tm-endturn-loading.js?v=20260620-agentbeats"></script>
 <script src="tm-theme-font.js?v=20260520-theme-font-scopes"></script>
-<script src="tm-patches.js?v=20260811-auditfix1"></script>
-<script src="tm-patches-start.js?v=20260811-auditfix1"></script><!-- 立项拆分：剧本启动链(_tmStart*/开场仪典/startGame/doActualStart)·紧挨 patches 之后保序·勿动位置 -->
+<script src="tm-patches.js?v=20260822-auditfix15"></script>
+<script src="tm-patches-start.js?v=20260822-auditfix15"></script><!-- 立项拆分：剧本启动链(_tmStart*/开场仪典/startGame/doActualStart)·紧挨 patches 之后保序·勿动位置 -->
 <!-- R17-R22: 从 tm-patches.js 抽离的子模块（加载在 patches 之后覆盖原版） -->
 <script src="tm-military-ui.js?v=2026042714"></script>
 <script src="tm-world-view.js?v=2026042714"></script>
@@ -875,10 +875,10 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-economy-engine-currency.js?v=20260821-auditfix13"></script><!-- 立项拆分：§A CurrencyUnit+§B CurrencyEngine 两整IIFE·紧挨 economy-engine 之前保序·勿动位置 -->
 <script src="tm-economy-engine.js?v=20260821-auditfix13"></script>
 <script src="tm-central-local-engine.js?v=20260709"></script>
-<script src="tm-huji-engine.js?v=20260822-auditfix14"></script>
+<script src="tm-huji-engine.js?v=20260822-auditfix15"></script>
 <script src="tm-edict-parser.js?v=20260709"></script>
 <script src="tm-huji-deep-fill.js?v=20260822-auditfix14"></script>
-<script src="tm-huji-runtime-bridge.js?v=20260822-auditfix14"></script>
+<script src="tm-huji-runtime-bridge.js?v=20260822-auditfix15"></script>
 <script src="tm-huji-governance-loop.js?v=20260602-huji-governance-loop"></script>
 <script src="tm-edict-complete.js?v=2026050701"></script>
 <script src="tm-env-recovery-fill.js?v=20260709"></script>
@@ -912,7 +912,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-ethnic-religion.js?v=2026050701"></script>
 <script src="tm-edict-thresholds.js?v=2026042714"></script>
 <script src="tm-fiscal-ui.js?v=2026042714"></script>
-<script src="tm-integration-bridge.js?v=20260821-auditfix12"></script>
+<script src="tm-integration-bridge.js?v=20260822-auditfix15"></script>
 <script src="tm-fiscal-engine.js?v=20260811-auditfix1"></script>
 <script src="tm-perf.js?v=2026042714"></script>
 <script src="tm-invariants.js?v=2026042714"></script>

--- a/web/scripts/smoke-population-faction-ledger.js
+++ b/web/scripts/smoke-population-faction-ledger.js
@@ -36,6 +36,20 @@ function totals(leaves) {
     return out;
   }, { mouths: 0, households: 0, ding: 0 });
 }
+function sumBuckets(buckets) {
+  return Object.values(buckets || {}).reduce((sum, value) => sum + Number(value || 0), 0);
+}
+function demographicTotals(leaves) {
+  return leaves.reduce((out, leaf) => {
+    const detail = leaf.populationDetail || {};
+    out.mouths += Number(detail.mouths || 0);
+    out.households += Number(detail.households || 0);
+    out.ding += Number(detail.ding || 0);
+    Object.keys(detail.byAge || {}).forEach(key => { out.byAge[key] = (out.byAge[key] || 0) + Number(detail.byAge[key] || 0); });
+    Object.keys(detail.byGender || {}).forEach(key => { out.byGender[key] = (out.byGender[key] || 0) + Number(detail.byGender[key] || 0); });
+    return out;
+  }, { mouths:0, households:0,ding:0, byAge:{}, byGender:{} });
+}
 
 function makeRuntime(options = {}) {
   const math = Object.create(Math);
@@ -202,12 +216,36 @@ console.log('[smoke-population-faction-ledger]');
 {
   const { context, npcLeaves } = makeRuntime();
   context.GM.adminHierarchy.player.divisions = [];
-  context.GM.population.national = { mouths:0, households:0, ding:0 };
+  context.GM.population.national = { mouths:10000000, households:2000000, ding:3000000 };
+  context.GM.population.byAge = { age_21_30:10000000 };
+  context.GM.population.byGender = { male:5200000, female:4800000 };
+  context.GM.regions = [makeLeaf('stale-player-region', '旧玩家地区', 10000000, true)];
   context.HujiEngine.tick({ turn: 1, monthRatio: 1, strict: true });
+  context.TM.HujiRuntimeBridge.maintain(context.GM, { scenario:context.P, turn:1 });
   ok(context.GM.population.national.mouths === 0
+    && context.GM.population.national.households === 0
+    && context.GM.population.national.ding === 0
+    && sumBuckets(context.GM.population.byAge) === 0
+    && sumBuckets(context.GM.population.byGender) === 0
+    && context.GM.hukou.registeredMouths === 0
     && context.GM.worldPopulationSummary.byFaction['fac-npc'].isPlayer === false
     && context.GM.worldPopulationSummary.byFaction['fac-npc'].national.mouths === totals(npcLeaves).mouths,
-  'territorial extinction never reclassifies the sole remaining NPC faction as player');
+  'territorial extinction clears stale player population and never revives scenario or root-region fallbacks');
+}
+
+{
+  const { context, npcLeaves } = makeRuntime();
+  delete context.GM.adminHierarchy.player;
+  context.GM.population.national = { mouths:10000000, households:2000000, ding:3000000 };
+  context.GM.regions = [makeLeaf('stale-player-region', '旧玩家地区', 10000000, true)];
+  context.HujiEngine.tick({ turn:1, monthRatio:1, strict:true });
+  context.TM.HujiRuntimeBridge.maintain(context.GM, { scenario:context.P, turn:1 });
+  ok(context.GM.population.national.mouths === 0
+    && context.GM.population.national.households === 0
+    && context.GM.population.national.ding === 0
+    && context.GM.worldPopulationSummary.byFaction['fac-npc'].isPlayer === false
+    && context.GM.worldPopulationSummary.byFaction['fac-npc'].national.mouths === totals(npcLeaves).mouths,
+  'deleting the player branch never turns the sole NPC branch into the player');
 }
 
 {
@@ -304,6 +342,138 @@ console.log('[smoke-population-faction-ledger]');
   const qiaozhiAfterGrowth = totals(qiaozhi).mouths;
   ok(materialized && context.GM.population.byLegalStatus.qiaozhi.mouths === qiaozhiAfterGrowth,
   'qiaozhi creates authoritative leaves, transfers population, and survives RuntimeBridge');
+}
+
+{
+  const { context, playerLeaves } = makeRuntime();
+  const capital = playerLeaves[0];
+  const source = playerLeaves[1];
+  capital.populationDetail.households = 60000;
+  capital.populationDetail.ding = 120000;
+  capital.populationDetail.byAge = { age_71_plus:capital.populationDetail.mouths };
+  capital.populationDetail.byGender = { male:120000, female:480000 };
+  source.populationDetail.households = 160000;
+  source.populationDetail.ding = 240000;
+  source.populationDetail.byAge = { age_21_30:source.populationDetail.mouths };
+  source.populationDetail.byGender = { male:320000, female:80000 };
+  context.HujiEngine.syncDemographicViews();
+  const before = demographicTotals(playerLeaves);
+  const sourceBefore = clone(source.populationDetail);
+  const capitalBefore = clone(capital.populationDetail);
+  const moved = context.HujiEngine.transferPopulation({
+    factionId:'fac-player', sourceRegionIds:['player-south'], targetRegionId:'player-capital', mouths:10000, cause:'smoke-capital-transfer'
+  });
+  const after = demographicTotals(playerLeaves);
+  ok(moved.ok
+    && JSON.stringify(after) === JSON.stringify(before)
+    && sourceBefore.mouths - source.populationDetail.mouths === moved.mouths
+    && sourceBefore.households - source.populationDetail.households === moved.households
+    && sourceBefore.ding - source.populationDetail.ding === moved.ding
+    && capital.populationDetail.mouths - capitalBefore.mouths === moved.mouths
+    && capital.populationDetail.households - capitalBefore.households === moved.households
+    && capital.populationDetail.ding - capitalBefore.ding === moved.ding,
+  'ordinary migration transfers one exact mouths-households-ding-age-gender bundle');
+}
+
+{
+  const { context, playerLeaves } = makeRuntime({ year:1101 });
+  playerLeaves[0].name = '中原京城';
+  playerLeaves[1].name = '江南路';
+  context.GM._capital = '中原京城';
+  context.GM.facs[0].capital = '中原京城';
+  context.GM.population.dynamics.birthRateBase = 0;
+  context.GM.population.dynamics.deathRateBase = 0;
+  playerLeaves[0].populationDetail.byAge = { age_71_plus:playerLeaves[0].populationDetail.mouths };
+  playerLeaves[0].populationDetail.byGender = { male:100000, female:500000 };
+  playerLeaves[1].populationDetail.byAge = { age_21_30:playerLeaves[1].populationDetail.mouths };
+  playerLeaves[1].populationDetail.byGender = { male:300000, female:100000 };
+  context.HujiEngine.syncDemographicViews();
+  const before = demographicTotals(playerLeaves);
+  context.HujiEngine.tick({ turn:1, monthRatio:1e-9, strict:true });
+  const after = demographicTotals(playerLeaves);
+  ok(JSON.stringify(after) === JSON.stringify(before)
+    && context.GM.population.migrationEvents.some(row => row.id === 'jingkang_nandu'),
+  'historical migration conserves every demographic field, not only mouths');
+}
+
+{
+  const { context } = makeRuntime({ year:1101 });
+  context.GM.adminHierarchy = {};
+  context.GM._capital = '不存在的首都';
+  context.GM.population.byRegion = {
+    中原: { mouths:100000, households:20000, ding:40000, byAge:{ age_21_30:100000 }, byGender:{ male:80000, female:20000 } },
+    江南: { mouths:100000, households:10000, ding:20000, byAge:{ age_71_plus:100000 }, byGender:{ male:20000, female:80000 } }
+  };
+  context.GM.population.national = { mouths:200000, households:30000, ding:60000 };
+  context.GM.population.dynamics.birthRateBase = 0;
+  context.GM.population.dynamics.deathRateBase = 0;
+  const before = clone(context.GM.population.byRegion);
+  const beforeTotals = {
+    mouths:before.中原.mouths + before.江南.mouths,
+    households:before.中原.households + before.江南.households,
+    ding:before.中原.ding + before.江南.ding,
+    age21:before.中原.byAge.age_21_30,
+    age71:before.江南.byAge.age_71_plus,
+    male:before.中原.byGender.male + before.江南.byGender.male,
+    female:before.中原.byGender.female + before.江南.byGender.female
+  };
+  context.HujiEngine.tick({ turn:1, monthRatio:1e-9, strict:true });
+  const rows = context.GM.population.byRegion;
+  ok(rows.中原.mouths + rows.江南.mouths === beforeTotals.mouths
+    && rows.中原.households + rows.江南.households === beforeTotals.households
+    && rows.中原.ding + rows.江南.ding === beforeTotals.ding
+    && (rows.中原.byAge.age_21_30 || 0) + (rows.江南.byAge.age_21_30 || 0) === beforeTotals.age21
+    && (rows.中原.byAge.age_71_plus || 0) + (rows.江南.byAge.age_71_plus || 0) === beforeTotals.age71
+    && rows.中原.byGender.male + rows.江南.byGender.male === beforeTotals.male
+    && rows.中原.byGender.female + rows.江南.byGender.female === beforeTotals.female,
+  'legacy byRegion migration transfers households ding age and gender with mouths');
+}
+
+{
+  const { context, playerLeaves } = makeRuntime();
+  let exact = true;
+  for (let mouths = 0; mouths <= 100; mouths++) {
+    playerLeaves[0].populationDetail.mouths = mouths;
+    playerLeaves[0].populationDetail.households = Math.round(mouths / 5);
+    playerLeaves[0].populationDetail.ding = Math.round(mouths * 0.3);
+    playerLeaves[0].populationDetail.byAge = {};
+    playerLeaves[0].populationDetail.byGender = {};
+    playerLeaves[0].byAge = {};
+    playerLeaves[0].byGender = {};
+    playerLeaves[1].populationDetail.mouths = 0;
+    playerLeaves[1].populationDetail.households = 0;
+    playerLeaves[1].populationDetail.ding = 0;
+    playerLeaves[1].populationDetail.byAge = {};
+    playerLeaves[1].populationDetail.byGender = {};
+    playerLeaves[1].byAge = {};
+    playerLeaves[1].byGender = {};
+    context.HujiEngine.syncDemographicViews();
+    exact = exact
+      && sumBuckets(playerLeaves[0].populationDetail.byAge) === mouths
+      && sumBuckets(playerLeaves[0].populationDetail.byGender) === mouths;
+  }
+  ok(exact, 'largest-remainder allocation keeps age and gender buckets exact for populations 0 through 100');
+}
+
+{
+  const { context } = makeRuntime();
+  const branch = context.GM.adminHierarchy.player.divisions;
+  ['侨京西', '侨京东', '侨河北'].forEach((name, index) => branch.push(makeLeaf('ordinary-same-name-' + index, name, 1000, false)));
+  const first = context.HujiEngine.materializeQiaozhiResettlement({
+    eventId:'jingkang_qiao', mouths:100000, sourceCandidates:['京城'], targetNames:['侨京西', '侨京东', '侨河北']
+  });
+  const eventOwned = branch.filter(leaf => leaf.parentHistoric === 'jingkang_qiao');
+  const second = context.HujiEngine.materializeQiaozhiResettlement({
+    eventId:'jingkang_qiao', mouths:100000, sourceCandidates:['京城'], targetNames:['侨京西', '侨京东', '侨河北']
+  });
+  branch.splice(branch.indexOf(eventOwned[0]), 1);
+  const partial = context.HujiEngine.materializeQiaozhiResettlement({
+    eventId:'jingkang_qiao', mouths:100000, sourceCandidates:['京城'], targetNames:['侨京西', '侨京东', '侨河北']
+  });
+  ok(first.ok && !first.alreadyMaterialized && eventOwned.length === 3
+    && second.ok && second.alreadyMaterialized
+    && partial.ok === false && partial.reason === 'qiaozhi-target-conflict',
+  'qiaozhi idempotence uses complete event-owned stable IDs, never unrelated display names');
 }
 
 {

--- a/web/tm-huji-engine.js
+++ b/web/tm-huji-engine.js
@@ -310,17 +310,37 @@
   function _scaleBucketsToTotal(obj, total, template) {
     obj = obj || {};
     total = Math.max(0, Math.round(total || 0));
-    var keys = Object.keys(template || obj || {});
+    var keys = Object.keys(template || {});
+    Object.keys(obj || {}).forEach(function(key) {
+      if (keys.indexOf(key) < 0) keys.push(key);
+    });
     if (!keys.length) return {};
     var current = _sumObj(obj);
+    var weights = {};
+    var weightTotal = 0;
+    keys.forEach(function(key) {
+      var weight = current > 0 ? Math.max(0, Number(obj[key]) || 0) : Math.max(0, Number(template && template[key]) || 0);
+      weights[key] = weight;
+      weightTotal += weight;
+    });
+    if (!(weightTotal > 0)) {
+      keys.forEach(function(key) { weights[key] = key === keys[0] ? 1 : 0; });
+      weightTotal = 1;
+    }
     var out = {};
     var assigned = 0;
-    keys.forEach(function(k, idx) {
-      var base = current > 0 ? Number(obj[k] || 0) / current : Number(template[k] || 0);
-      var val = idx === keys.length - 1 ? Math.max(0, total - assigned) : Math.round(total * base);
-      out[k] = val;
-      assigned += val;
+    var ranked = [];
+    keys.forEach(function(key, index) {
+      var quota = total * weights[key] / weightTotal;
+      var value = Math.floor(quota);
+      out[key] = value;
+      assigned += value;
+      ranked.push({ key:key, fraction:quota - value, index:index });
     });
+    ranked.sort(function(a, b) { return b.fraction - a.fraction || a.index - b.index; });
+    for (var remaining = total - assigned, i = 0; remaining > 0; remaining--, i++) {
+      out[ranked[i % ranked.length].key]++;
+    }
     return out;
   }
 
@@ -577,33 +597,55 @@
     return String(value == null ? '' : value).replace(/[\s·（）()\-—_]/g, '').toLowerCase();
   }
 
+  function _playerPopulationAliases(G) {
+    var aliases = [];
+    function add(value) {
+      var normalized = _normPopulationName(value);
+      if (normalized && aliases.indexOf(normalized) < 0) aliases.push(normalized);
+    }
+    add(global.P && global.P.playerInfo && global.P.playerInfo.factionId);
+    add(global.P && global.P.playerInfo && global.P.playerInfo.factionName);
+    add(global.P && global.P.playerFactionId);
+    add(global.P && global.P.playerFaction);
+    add(G && G.playerFactionId);
+    add(G && G.playerFaction);
+    (G && Array.isArray(G.facs) ? G.facs : []).forEach(function(faction) {
+      if (faction && faction.isPlayer) {
+        add(faction.id); add(faction.name); add(faction.key); add(faction.factionName);
+      }
+    });
+    return aliases;
+  }
+
+  function _hasExplicitPlayerIdentity(G, hierarchy) {
+    if (!hierarchy || typeof hierarchy !== 'object') return false;
+    if (Array.isArray(hierarchy.divisions)) return true;
+    var branchKeys = Object.keys(hierarchy).filter(function(key) {
+      var branch = hierarchy[key];
+      return Array.isArray(branch) || (branch && Array.isArray(branch.divisions));
+    });
+    if (!branchKeys.length) return false;
+    if (Object.prototype.hasOwnProperty.call(hierarchy, 'player')) return true;
+    return _playerPopulationAliases(G).length > 0;
+  }
+
   function _playerAdminKey(G, hierarchy) {
+    if (hierarchy && Object.prototype.hasOwnProperty.call(hierarchy, 'player')) return 'player';
     try {
       if (typeof global._tmResolvePlayerAdminKey === 'function') {
-        var resolved = global._tmResolvePlayerAdminKey(hierarchy, global.P || null);
+        var resolved = global._tmResolvePlayerAdminKey(hierarchy, global.P || null, { allowSoleBranchFallback:false });
         if (resolved && resolved !== 'divisions') return resolved;
       }
     } catch (_) {}
-    if (hierarchy && hierarchy.player) return 'player';
     var keys = Object.keys(hierarchy || {}).filter(function(key) {
       var branch = hierarchy[key];
       return Array.isArray(branch) || (branch && Array.isArray(branch.divisions));
     });
-    if (keys.length === 1) return keys[0];
-    var playerNames = [];
-    function add(value) {
-      var normalized = _normPopulationName(value);
-      if (normalized && playerNames.indexOf(normalized) < 0) playerNames.push(normalized);
-    }
-    add(global.P && global.P.playerInfo && global.P.playerInfo.factionName);
-    add(global.P && global.P.playerFaction);
-    add(G && G.playerFaction);
-    (G && Array.isArray(G.facs) ? G.facs : []).forEach(function(faction) {
-      if (faction && faction.isPlayer) { add(faction.id); add(faction.name); add(faction.key); }
-    });
+    var playerNames = _playerPopulationAliases(G);
     for (var i = 0; i < keys.length; i++) {
       var branch = hierarchy[keys[i]] || {};
-      var aliases = [keys[i], branch.factionId, branch.factionName, branch.name, branch.key];
+      if (branch && branch.isPlayer) return keys[i];
+      var aliases = [keys[i], branch.factionId, branch.factionName, branch.name, branch.key, branch.id];
       if (aliases.some(function(alias) { return playerNames.indexOf(_normPopulationName(alias)) >= 0; })) return keys[i];
     }
     return null;
@@ -635,7 +677,7 @@
       if (!Array.isArray(roots)) return;
       var leaves = [];
       _walkAdminLeaves(roots, leaves, []);
-      if (!leaves.length) return;
+      if (!leaves.length && key !== playerKey) return;
       var faction = _factionForAdminBranch(G, key, branch || {});
       groups.push({
         key: key,
@@ -903,8 +945,18 @@
     var groups = _factionLeafGroups(G);
     var playerGroup = groups.find(function(group) { return group.isPlayer; });
     if (!playerGroup) {
+      if (_hasExplicitPlayerIdentity(G, G && G.adminHierarchy)) {
+        _zeroPlayerPopulationViews(P);
+        _refreshWorldPopulationSummary(G, groups);
+        return { ok:true, national:{ mouths:0, households:0, ding:0 }, byAge:{}, byGender:{}, territorialExtinction:true };
+      }
       _ensureDeepDemographics(P);
       return { ok:true, legacy:true };
+    }
+    if (!playerGroup.leaves.length) {
+      _zeroPlayerPopulationViews(P);
+      _refreshWorldPopulationSummary(G, groups);
+      return { ok:true, national:{ mouths:0, households:0, ding:0 }, byAge:{}, byGender:{}, territorialExtinction:true };
     }
     var totals = _leafPopulationTotals(playerGroup.leaves);
     var demographic = _leafDemographicTotals(playerGroup.leaves);
@@ -925,6 +977,21 @@
       ratio:(Number(demographic.byGender.male) || 0) / Math.max(1, Number(demographic.byGender.female) || 0)
     }; // arch-ok: 叶级人口结构派生兼容性别视图
     return { ok:true, national:totals, byAge:demographic.byAge, byGender:demographic.byGender };
+  }
+
+  function _zeroPlayerPopulationViews(P) {
+    if (!P.national || typeof P.national !== 'object') P.national = {};
+    P.national.mouths = 0; // arch-ok: 领土灭失时清零玩家全国人口真值
+    P.national.households = 0; // arch-ok: 领土灭失时清零玩家全国户数真值
+    P.national.ding = 0; // arch-ok: 领土灭失时清零玩家全国丁口真值
+    P.byRegion = {}; // arch-ok: 领土灭失时清除旧地区人口代理
+    P.byAge = {}; // arch-ok: 领土灭失时清零玩家年龄视图
+    P.ageLayers = {}; // arch-ok: 领土灭失时清零兼容年龄视图
+    P.agePyramidFine = { _newlyAdult:0, _leavingDing:0 }; // arch-ok: 领土灭失时清零精细年龄视图
+    P.byGender = {}; // arch-ok: 领土灭失时清零玩家性别视图
+    P.gender = { male:0, female:0, total:0, ratio:0 }; // arch-ok: 领土灭失时清零兼容性别视图
+    if (!P.deepFieldEffects || typeof P.deepFieldEffects !== 'object') P.deepFieldEffects = {};
+    P.deepFieldEffects.serviceAgeDing = 0;
   }
 
   function _recordPopulationDynamics(d, ctx, G, births, deaths, mr) {
@@ -1609,10 +1676,7 @@
         var pullRate = 0.0001 * mr; // 月千分之一流入京畿
         var flow = Math.round(r.mouths * pullRate);
         if (flow > 0 && r.mouths > 10000) {
-          r.mouths -= flow;
-          P.byRegion[capital].mouths += flow;
-          r.yearlyNetMigration -= flow;
-          P.byRegion[capital].yearlyNetMigration = (P.byRegion[capital].yearlyNetMigration || 0) + flow;
+          _transferLegacyPopulationRows(r, P.byRegion[capital], flow, rid, capital);
         }
       });
       }
@@ -1689,11 +1753,7 @@
     groups.forEach(function(group) {
       var capLeaf = _findCapitalLeaf(group);
       if (!capLeaf || !capLeaf.populationDetail) return;
-      var totals = _leafPopulationTotals(group.leaves);
-      var dingRatio = totals.ding / Math.max(1, totals.mouths);
-      var mphh = totals.mouths / Math.max(1, totals.households);
       var pullRate = 0.0001 * mr;
-      var totalFlow = 0;
       group.leaves.forEach(function(leaf) {
         if (leaf === capLeaf) return;
         var detail = leaf && leaf.populationDetail;
@@ -1702,31 +1762,9 @@
         if (mouths <= 10000) return;
         var flow = Math.round(mouths * pullRate);
         if (flow > 0) {
-          var localDingRatio = Number(detail.ding) > 0 ? Number(detail.ding) / mouths : dingRatio;
-          var localMphh = Number(detail.households) > 0 ? mouths / Number(detail.households) : mphh;
-          detail.mouths = mouths - flow;
-          detail.households = Math.round(detail.mouths / Math.max(1, localMphh));
-          detail.ding = Math.round(detail.mouths * localDingRatio);
-          _resizeLeafDemographicBuckets(leaf, detail, detail.mouths);
-          _syncLeafPopulationMirrors(leaf, detail);
-          if (group.isPlayer) _syncPlayerLegacyRow(P, leaf, detail);
-          leaf.yearlyNetMigration = (Number(leaf.yearlyNetMigration) || 0) - flow;
-          totalFlow += flow;
+          _transferPopulationBetweenLeaves(group, [leaf], capLeaf, flow, 'capital-pull');
         }
       });
-      if (totalFlow > 0) {
-        var capitalDetail = capLeaf.populationDetail;
-        var capitalMouths = Number(capitalDetail.mouths) || 0;
-        var capitalDingRatio = Number(capitalDetail.ding) > 0 ? Number(capitalDetail.ding) / Math.max(1, capitalMouths) : dingRatio;
-        var capitalMphh = Number(capitalDetail.households) > 0 ? capitalMouths / Number(capitalDetail.households) : mphh;
-        capitalDetail.mouths = capitalMouths + totalFlow;
-        capitalDetail.households = Math.round(capitalDetail.mouths / Math.max(1, capitalMphh));
-        capitalDetail.ding = Math.round(capitalDetail.mouths * capitalDingRatio);
-        _resizeLeafDemographicBuckets(capLeaf, capitalDetail, capitalDetail.mouths);
-        _syncLeafPopulationMirrors(capLeaf, capitalDetail);
-        if (group.isPlayer) _syncPlayerLegacyRow(P, capLeaf, capitalDetail);
-        capLeaf.yearlyNetMigration = (Number(capLeaf.yearlyNetMigration) || 0) + totalFlow;
-      }
     });
     var playerGroup = groups.find(function(group) { return group.isPlayer; });
     if (playerGroup) {
@@ -1791,7 +1829,7 @@
       detail.ding = dingBefore - dingFlow;
       var resized = _resizeLeafDemographicBuckets(leaf, detail, detail.mouths);
       _syncLeafPopulationMirrors(leaf, detail);
-      if (leaf.yearlyNetMigration !== undefined) leaf.yearlyNetMigration = (Number(leaf.yearlyNetMigration) || 0) - flow;
+      leaf.yearlyNetMigration = (Number(leaf.yearlyNetMigration) || 0) - flow;
       bundle.mouths += flow;
       bundle.households += householdFlow;
       bundle.ding += dingFlow;
@@ -1803,6 +1841,89 @@
     bundle.byAge = _scaleBucketsToTotal(bundle.byAge, bundle.mouths, AGE_BUCKET_TEMPLATE);
     bundle.byGender = _scaleBucketsToTotal(bundle.byGender, bundle.mouths, GENDER_BUCKET_TEMPLATE);
     return bundle;
+  }
+
+  function _addPopulationBundleToLeaf(leaf, bundle) {
+    var detail = leaf && leaf.populationDetail;
+    if (!detail || !bundle) return { ok:false, reason:'target-region-invalid' };
+    var buckets = _ensureLeafDemographicBuckets(leaf, detail);
+    var bundleAge = _scaleBucketsToTotal(bundle.byAge || {}, bundle.mouths, AGE_BUCKET_TEMPLATE);
+    var bundleGender = _scaleBucketsToTotal(bundle.byGender || {}, bundle.mouths, GENDER_BUCKET_TEMPLATE);
+    detail.mouths = Math.max(0, Math.round(Number(detail.mouths) || 0)) + Math.max(0, Math.round(Number(bundle.mouths) || 0));
+    detail.households = Math.max(0, Math.round(Number(detail.households) || 0)) + Math.max(0, Math.round(Number(bundle.households) || 0));
+    detail.ding = Math.max(0, Math.round(Number(detail.ding) || 0)) + Math.max(0, Math.round(Number(bundle.ding) || 0));
+    detail.byAge = Object.assign({}, buckets.byAge);
+    detail.byGender = Object.assign({}, buckets.byGender);
+    Object.keys(bundleAge).forEach(function(key) { detail.byAge[key] = (Number(detail.byAge[key]) || 0) + bundleAge[key]; });
+    Object.keys(bundleGender).forEach(function(key) { detail.byGender[key] = (Number(detail.byGender[key]) || 0) + bundleGender[key]; });
+    leaf.byAge = detail.byAge;
+    leaf.byGender = detail.byGender;
+    _syncLeafPopulationMirrors(leaf, detail);
+    return { ok:true, detail:detail };
+  }
+
+  function _transferPopulationBetweenLeaves(group, sourceLeaves, targetLeaf, requested, cause) {
+    sourceLeaves = (sourceLeaves || []).filter(function(leaf) {
+      return leaf && leaf !== targetLeaf && leaf.populationDetail && Number(leaf.populationDetail.mouths) > 0;
+    });
+    if (!targetLeaf || !targetLeaf.populationDetail) return { ok:false, reason:'target-region-not-found' };
+    if (!sourceLeaves.length) return { ok:false, reason:'source-region-not-found' };
+    var bundle = _removePopulationForTransfer(sourceLeaves, requested);
+    if (!bundle.mouths) return { ok:false, reason:'source-population-empty' };
+    var added = _addPopulationBundleToLeaf(targetLeaf, bundle);
+    if (!added.ok) return added;
+    sourceLeaves.forEach(function(leaf) {
+      if (group && group.isPlayer) _syncPlayerLegacyRow(global.GM.population, leaf, leaf.populationDetail);
+    });
+    if (group && group.isPlayer) _syncPlayerLegacyRow(global.GM.population, targetLeaf, targetLeaf.populationDetail);
+    targetLeaf.yearlyNetMigration = (Number(targetLeaf.yearlyNetMigration) || 0) + bundle.mouths;
+    return {
+      ok:true,
+      cause:String(cause || 'migration'),
+      factionId:group && group.factionId,
+      targetRegionId:String(targetLeaf.id || targetLeaf.name || ''),
+      mouths:bundle.mouths,
+      households:bundle.households,
+      ding:bundle.ding,
+      byAge:bundle.byAge,
+      byGender:bundle.byGender
+    };
+  }
+
+  function _transferLegacyPopulationRows(source, target, requested, sourceId, targetId) {
+    if (!source || !target) return { ok:false, reason:'region-match-failed' };
+    var sourceLeaf = { id:String(sourceId || 'legacy-source'), populationDetail:source, byAge:source.byAge, byGender:source.byGender };
+    var targetLeaf = { id:String(targetId || 'legacy-target'), populationDetail:target, byAge:target.byAge, byGender:target.byGender };
+    var result = _transferPopulationBetweenLeaves(null, [sourceLeaf], targetLeaf, requested, 'legacy-migration');
+    source.byAge = sourceLeaf.populationDetail.byAge;
+    source.byGender = sourceLeaf.populationDetail.byGender;
+    target.byAge = targetLeaf.populationDetail.byAge;
+    target.byGender = targetLeaf.populationDetail.byGender;
+    source.yearlyNetMigration = (Number(source.yearlyNetMigration) || 0) - (result.ok ? result.mouths : 0);
+    target.yearlyNetMigration = (Number(target.yearlyNetMigration) || 0) + (result.ok ? result.mouths : 0);
+    return result;
+  }
+
+  function transferPopulation(options) {
+    options = options || {};
+    var G = global.GM;
+    var groups = _factionLeafGroups(G);
+    var factionTarget = _resolvePopulationTarget(G, options, groups);
+    if (!factionTarget.ok || !factionTarget.group) return { ok:false, reason:factionTarget.reason || 'player-faction-not-found' };
+    var group = factionTarget.group;
+    var targetWanted = _normPopulationName(options.targetRegionId || options.targetRegionName);
+    var targetLeaf = group.leaves.find(function(leaf) { return _leafPopulationAliases(leaf).indexOf(targetWanted) >= 0; }) || null;
+    if (!targetLeaf) return { ok:false, reason:'target-region-not-found' };
+    var sourceWanted = (Array.isArray(options.sourceRegionIds) ? options.sourceRegionIds : [options.sourceRegionId])
+      .concat(Array.isArray(options.sourceRegionNames) ? options.sourceRegionNames : [options.sourceRegionName])
+      .map(_normPopulationName).filter(Boolean);
+    var sources = group.leaves.filter(function(leaf) {
+      if (leaf === targetLeaf || !leaf || !leaf.populationDetail) return false;
+      if (!sourceWanted.length) return true;
+      return _leafPopulationAliases(leaf).some(function(alias) { return sourceWanted.indexOf(alias) >= 0; });
+    });
+    if (sourceWanted.length && sources.length !== sourceWanted.length) return { ok:false, reason:'source-region-not-found' };
+    return _transferPopulationBetweenLeaves(group, sources, targetLeaf, options.mouths, options.cause);
   }
 
   function _takeExactBucketShare(state, total) {
@@ -1863,13 +1984,21 @@
     var targetNames = (Array.isArray(options.targetNames) ? options.targetNames : [])
       .map(function(value) { return String(value || '').trim(); }).filter(Boolean);
     if (!eventId || !targetNames.length) return { ok:false, reason:'qiaozhi-spec-invalid' };
-    var existing = group.leaves.filter(function(leaf) {
-      return leaf && (leaf.parentHistoric === eventId || targetNames.indexOf(String(leaf.name || '')) >= 0);
+    var plannedIds = targetNames.map(function(name) {
+      return 'tm_qiaozhi_' + _tmPopulationHash(String(group.factionId || group.key) + '|' + eventId + '|' + name);
     });
-    if (existing.length === targetNames.length) {
-      return { ok:true, alreadyMaterialized:true, scale:_leafPopulationTotals(existing).mouths, factionId:group.factionId };
+    if (plannedIds.some(function(id, index) { return plannedIds.indexOf(id) !== index; })) {
+      return { ok:false, reason:'qiaozhi-spec-duplicate-target' };
     }
-    if (existing.length) return { ok:false, reason:'qiaozhi-target-conflict' };
+    var existing = group.leaves.filter(function(leaf) { return leaf && leaf.parentHistoric === eventId; });
+    if (existing.length) {
+      var actualIds = existing.map(function(leaf) { return String(leaf.id || ''); });
+      var complete = actualIds.length === plannedIds.length && plannedIds.every(function(id) {
+        return actualIds.filter(function(actualId) { return actualId === id; }).length === 1;
+      });
+      if (complete) return { ok:true, alreadyMaterialized:true, scale:_leafPopulationTotals(existing).mouths, factionId:group.factionId };
+      return { ok:false, reason:'qiaozhi-target-conflict' };
+    }
     var sourceCandidates = Array.isArray(options.sourceCandidates) ? options.sourceCandidates : [];
     var sourceLeaves = group.leaves.filter(function(leaf) {
       return leaf && leaf.populationDetail && Number(leaf.populationDetail.mouths) > 0 &&
@@ -1885,12 +2014,10 @@
         if (leaf && leaf.id != null) existingIds[String(leaf.id)] = true;
       });
     });
-    var plannedIds = targetNames.map(function(name) {
-      var stableId = 'tm_qiaozhi_' + _tmPopulationHash(String(group.factionId || group.key) + '|' + eventId + '|' + name);
-      if (existingIds[stableId]) throw new Error('侨置行政区稳定 ID 冲突: ' + stableId);
-      existingIds[stableId] = true;
-      return stableId;
-    });
+    if (plannedIds.some(function(stableId) { return existingIds[stableId]; })) {
+      return { ok:false, reason:'qiaozhi-target-conflict' };
+    }
+    plannedIds.forEach(function(stableId) { existingIds[stableId] = true; });
     var bundle = _removePopulationForTransfer(sourceLeaves, requested);
     if (!bundle.mouths) return { ok:false, reason:'source-population-empty' };
     var assigned = { mouths:0, households:0, ding:0, byAge:{}, byGender:{} };
@@ -1960,28 +2087,12 @@
       to = playerGroup.leaves.find(function(leaf) { return _normPopulationName(leaf && (leaf.name || leaf.id)).indexOf(_normPopulationName(e.toRegion)) >= 0; });
     }
     if (from && to && from.populationDetail && to.populationDetail) {
-      var fromDetail = from.populationDetail;
-      var toDetail = to.populationDetail;
-      var fromMouths = Math.max(0, Number(fromDetail.mouths) || 0);
-      var toMouths = Math.max(0, Number(toDetail.mouths) || 0);
+      var fromMouths = Math.max(0, Number(from.populationDetail.mouths) || 0);
       var scale = Math.max(0, Math.round(Math.min(e.scale, fromMouths * 0.3)));
       if (!scale) return { ok:false, reason:'source-population-empty' };
-      var fromMphh = fromMouths / Math.max(1, Number(fromDetail.households) || 0);
-      var fromDingRatio = Number(fromDetail.ding) / Math.max(1, fromMouths);
-      var toMphh = toMouths / Math.max(1, Number(toDetail.households) || 0);
-      var toDingRatio = Number(toDetail.ding) / Math.max(1, toMouths);
-      fromDetail.mouths = fromMouths - scale;
-      fromDetail.households = Math.round(fromDetail.mouths / Math.max(1, fromMphh));
-      fromDetail.ding = Math.round(fromDetail.mouths * fromDingRatio);
-      toDetail.mouths = toMouths + scale;
-      toDetail.households = Math.round(toDetail.mouths / Math.max(1, toMphh));
-      toDetail.ding = Math.round(toDetail.mouths * toDingRatio);
-      _syncLeafPopulationMirrors(from, fromDetail);
-      _syncLeafPopulationMirrors(to, toDetail);
-      _syncPlayerLegacyRow(P, from, fromDetail);
-      _syncPlayerLegacyRow(P, to, toDetail);
-      from.yearlyNetMigration = (Number(from.yearlyNetMigration) || 0) - scale;
-      to.yearlyNetMigration = (Number(to.yearlyNetMigration) || 0) + scale;
+      var moved = _transferPopulationBetweenLeaves(playerGroup, [from], to, scale, e.id);
+      if (!moved.ok) return moved;
+      scale = moved.mouths;
     } else {
       if (!P.byRegion) return { ok:false, reason:'regions-unavailable' };
       var fromKey = Object.keys(P.byRegion).find(function(k) { return _normPopulationName(k).indexOf(_normPopulationName(e.fromRegion)) >= 0; });
@@ -1991,8 +2102,9 @@
       to = P.byRegion[toKey];
       var scale = Math.max(0, Math.round(Math.min(e.scale, (Number(from.mouths) || 0) * 0.3)));
       if (!scale) return { ok:false, reason:'source-population-empty' };
-      from.mouths -= scale;
-      to.mouths += scale;
+      var legacyMoved = _transferLegacyPopulationRows(from, to, scale, fromKey, toKey);
+      if (!legacyMoved.ok) return legacyMoved;
+      scale = legacyMoved.mouths;
     }
     P.migrationEvents.push({ id: e.id, name: e.name, turn: global.GM.turn, scale: scale });
     if (global.addEB) global.addEB('迁徙', e.name + '：' + e.fromRegion + ' → ' + e.toRegion + ' 约 ' + Math.round(scale/10000) + ' 万口');
@@ -2108,6 +2220,7 @@
     init: init,
     tick: tick,
     applyPopulationLoss: applyPopulationLoss,
+    transferPopulation: transferPopulation,
     materializeQiaozhiResettlement: materializeQiaozhiResettlement,
     syncDemographicViews: syncDemographicViews,
     startLargeCorvee: startLargeCorvee,

--- a/web/tm-huji-runtime-bridge.js
+++ b/web/tm-huji-runtime-bridge.js
@@ -180,6 +180,68 @@
     return (scenario && scenario.populationConfig) || (root && root.populationConfig) || {};
   }
 
+  function normalizedIdentity(value) {
+    return String(value == null ? '' : value).replace(/[\s·（）()\-—_]/g, '').toLowerCase();
+  }
+
+  function playerIdentityAliases(root) {
+    var aliases = [];
+    function add(value) {
+      var normalized = normalizedIdentity(value);
+      if (normalized && aliases.indexOf(normalized) < 0) aliases.push(normalized);
+    }
+    add(global.P && global.P.playerInfo && global.P.playerInfo.factionId);
+    add(global.P && global.P.playerInfo && global.P.playerInfo.factionName);
+    add(global.P && global.P.playerFactionId);
+    add(global.P && global.P.playerFaction);
+    add(root && root.playerFactionId);
+    add(root && root.playerFaction);
+    (root && Array.isArray(root.facs) ? root.facs : []).forEach(function(faction) {
+      if (faction && faction.isPlayer) {
+        add(faction.id); add(faction.name); add(faction.key); add(faction.factionName);
+      }
+    });
+    return aliases;
+  }
+
+  function strictPlayerAdminKey(root, hierarchy) {
+    if (!hierarchy || typeof hierarchy !== 'object') return null;
+    if (Object.prototype.hasOwnProperty.call(hierarchy, 'player')) return 'player';
+    if (Array.isArray(hierarchy.divisions)) return 'divisions';
+    try {
+      if (typeof global._tmResolvePlayerAdminKey === 'function') {
+        var resolved = global._tmResolvePlayerAdminKey(hierarchy, global.P || null, { allowSoleBranchFallback:false });
+        if (resolved) return resolved;
+      }
+    } catch (_) {}
+    var wanted = playerIdentityAliases(root);
+    var keys = Object.keys(hierarchy).filter(function(key) {
+      var branch = hierarchy[key];
+      return Array.isArray(branch) || (branch && Array.isArray(branch.divisions));
+    });
+    for (var i = 0; i < keys.length; i++) {
+      var branch = hierarchy[keys[i]] || {};
+      if (branch && branch.isPlayer) return keys[i];
+      var values = [keys[i], branch.id, branch.key, branch.factionId, branch.factionName, branch.name]
+        .map(normalizedIdentity).filter(Boolean);
+      if (values.some(function(value) { return wanted.indexOf(value) >= 0; })) return keys[i];
+    }
+    return null;
+  }
+
+  function hasAuthoritativePlayerPopulation(root) {
+    var hierarchy = root && root.adminHierarchy;
+    if (!hierarchy || typeof hierarchy !== 'object') return false;
+    if (Array.isArray(hierarchy.divisions)) return true;
+    var branchKeys = Object.keys(hierarchy).filter(function(key) {
+      var branch = hierarchy[key];
+      return Array.isArray(branch) || (branch && Array.isArray(branch.divisions));
+    });
+    if (!branchKeys.length) return false;
+    if (strictPlayerAdminKey(root, hierarchy)) return true;
+    return playerIdentityAliases(root).length > 0;
+  }
+
   function walkAdminNode(node, out) {
     if (!node) return;
     if (Array.isArray(node)) {
@@ -198,33 +260,18 @@
   function getLeafRegions(root) {
     root = pickRoot(root);
     var leaves = [];
+    var authoritativePlayerPopulation = hasAuthoritativePlayerPopulation(root);
     if (root.adminHierarchy) {
-      if (global.IntegrationBridge && typeof global.IntegrationBridge.getLeafDivisions === 'function') {
-        try { leaves = global.IntegrationBridge.getLeafDivisions(root.adminHierarchy) || []; } catch (_) { leaves = []; }
+      var hierarchy = root.adminHierarchy || {};
+      var playerKey = strictPlayerAdminKey(root, hierarchy);
+      if (playerKey === 'divisions') {
+        walkAdminNode(hierarchy.divisions, leaves);
+      } else if (playerKey && global.IntegrationBridge && typeof global.IntegrationBridge.getLeafDivisions === 'function') {
+        try { leaves = global.IntegrationBridge.getLeafDivisions(hierarchy, playerKey) || []; } catch (_) { leaves = []; }
       }
-      if (!leaves.length) {
-        var hierarchy = root.adminHierarchy || {};
-        var playerKey = null;
-        if (typeof global._tmResolvePlayerAdminKey === 'function') {
-          try { playerKey = global._tmResolvePlayerAdminKey(hierarchy) || null; } catch (_) {}
-        }
-        if (!playerKey && Object.prototype.hasOwnProperty.call(hierarchy, 'player')) playerKey = 'player';
-        if (!playerKey && Array.isArray(hierarchy.divisions)) {
-          walkAdminNode(hierarchy.divisions, leaves);
-        } else if (!playerKey) {
-          var candidateKeys = Object.keys(hierarchy).filter(function(k) {
-            var branch = hierarchy[k];
-            return Array.isArray(branch) || (branch && Array.isArray(branch.divisions));
-          });
-          if (candidateKeys.length === 1) playerKey = candidateKeys[0];
-        }
-        // Compatibility aggregation must never silently turn a multi-faction
-        // world into the player's national ledger. If ownership is ambiguous,
-        // leave the fallback empty instead of summing every faction together.
-        if (playerKey) walkAdminNode(hierarchy[playerKey], leaves);
-      }
+      if (!leaves.length && playerKey && playerKey !== 'divisions') walkAdminNode(hierarchy[playerKey], leaves);
     }
-    if (!leaves.length && Array.isArray(root.regions)) leaves = root.regions.slice();
+    if (!leaves.length && !authoritativePlayerPopulation && Array.isArray(root.regions)) leaves = root.regions.slice();
     var seen = {};
     return leaves.filter(function(row, idx) {
       if (!row || typeof row !== 'object') return false;
@@ -259,7 +306,8 @@
     };
   }
 
-  function aggregatePopulation(root, config, leaves) {
+  function aggregatePopulation(root, config, leaves, options) {
+    options = options || {};
     var initial = (config && config.initial) || {};
     var byRegion = {};
     var totals = { households: 0, mouths: 0, ding: 0, hiddenCount: 0, fugitives: 0 };
@@ -297,14 +345,16 @@
       });
     });
 
-    var hasRegionalTotals = totals.households || totals.mouths || totals.ding;
-    var households = hasRegionalTotals ? totals.households : round(initial.nationalHouseholds || (root.population && root.population.national && root.population.national.households) || 0);
-    var mouths = hasRegionalTotals ? totals.mouths : round(initial.nationalMouths || (root.population && root.population.national && root.population.national.mouths) || households * DEFAULT_MOUTHS_PER_HOUSEHOLD);
-    var ding = hasRegionalTotals ? totals.ding : round(initial.nationalDing || (root.population && root.population.national && root.population.national.ding) || mouths * 0.30);
+    var hasRegionalTotals = leaves.length > 0 || totals.households || totals.mouths || totals.ding;
+    var useRegionalTruth = options.authoritativePlayerPopulation === true || !!hasRegionalTotals;
+    var households = useRegionalTruth ? totals.households : round(initial.nationalHouseholds || (root.population && root.population.national && root.population.national.households) || 0);
+    var mouths = useRegionalTruth ? totals.mouths : round(initial.nationalMouths || (root.population && root.population.national && root.population.national.mouths) || households * DEFAULT_MOUTHS_PER_HOUSEHOLD);
+    var ding = useRegionalTruth ? totals.ding : round(initial.nationalDing || (root.population && root.population.national && root.population.national.ding) || mouths * 0.30);
     var scenarioHidden = round(initial.hiddenPopulation || initial.hiddenCount || initial.unregisteredPopulation || 0);
     var existingHidden = round(root.population && (root.population.hiddenCount || root.population.hiddenPopulation || root.population.unregisteredPopulation) || 0);
-    var hiddenCount = Math.max(totals.hiddenCount, scenarioHidden, existingHidden);
-    var fugitives = Math.max(totals.fugitives, round(root.population && root.population.fugitives || 0), round(root.hukou && (root.hukou.refugees || root.hukou.fugitives) || 0));
+    var emptyAuthoritativePlayer = options.authoritativePlayerPopulation === true && leaves.length === 0;
+    var hiddenCount = emptyAuthoritativePlayer ? 0 : Math.max(totals.hiddenCount, scenarioHidden, existingHidden);
+    var fugitives = emptyAuthoritativePlayer ? 0 : Math.max(totals.fugitives, round(root.population && root.population.fugitives || 0), round(root.hukou && (root.hukou.refugees || root.hukou.fugitives) || 0));
     return {
       national: { households: households, mouths: mouths, ding: ding },
       hiddenCount: hiddenCount,
@@ -1190,7 +1240,9 @@
     var store = ensureStore(root);
     var config = getPopulationConfig(root, options);
     var leaves = getLeafRegions(root);
-    var aggregate = aggregatePopulation(root, config, leaves);
+    var aggregate = aggregatePopulation(root, config, leaves, {
+      authoritativePlayerPopulation:hasAuthoritativePlayerPopulation(root)
+    });
     var hukouLedger = syncHukou(root, aggregate, options);
     var corveeLedger = buildCorveeLedger(root, config, aggregate, options);
     var militaryServicePool = buildMilitaryPool(root, config, aggregate, options);

--- a/web/tm-integration-bridge.js
+++ b/web/tm-integration-bridge.js
@@ -58,15 +58,8 @@
     var fac = adminHierarchy[requested] || null;
     if (fac && !Array.isArray(fac) && !Array.isArray(fac.divisions)) fac = null;
     if (!fac && requested === 'player' && typeof _tmResolvePlayerAdminKey === 'function') {
-      var resolved = _tmResolvePlayerAdminKey(adminHierarchy);
+      var resolved = _tmResolvePlayerAdminKey(adminHierarchy, null, { allowSoleBranchFallback:false });
       if (resolved) fac = adminHierarchy[resolved];
-    }
-    if (!fac && requested === 'player') {
-      var keys = Object.keys(adminHierarchy).filter(function(key) {
-        var tree = adminHierarchy[key];
-        return Array.isArray(tree) || (tree && Array.isArray(tree.divisions));
-      });
-      if (keys.length === 1) fac = adminHierarchy[keys[0]];
     }
     if (Array.isArray(fac)) return fac;
     if (!fac || !Array.isArray(fac.divisions)) return [];

--- a/web/tm-patches-start.js
+++ b/web/tm-patches-start.js
@@ -70,9 +70,10 @@ function _tmStartFirstFiniteNumber() {
   return null;
 }
 
-// 玩家行政树解析：显式 player 优先，其次按玩家势力名/玩家角色/势力标记匹配；
-// 只有唯一树时才可兜底。多树而无法确认时返回 null，禁止静默把敌方第一项当玩家。
-function _tmResolvePlayerAdminKey(adminHierarchy, sc) {
+// 玩家行政树解析：运行期只接受显式 player 或稳定玩家身份匹配。
+// “唯一树即玩家”仅允许由一次性旧档/开局迁移显式开启，禁止日常聚合把唯一 NPC 认成玩家。
+function _tmResolvePlayerAdminKey(adminHierarchy, sc, options) {
+  options = options || {};
   if (!adminHierarchy || typeof adminHierarchy !== 'object' || Array.isArray(adminHierarchy)) return null;
   if (adminHierarchy.player && (Array.isArray(adminHierarchy.player) || Array.isArray(adminHierarchy.player.divisions))) return 'player';
   if (Array.isArray(adminHierarchy.divisions)) return 'divisions';
@@ -88,14 +89,19 @@ function _tmResolvePlayerAdminKey(adminHierarchy, sc) {
   }
   try {
     if (typeof P !== 'undefined' && P) {
+      add(P.playerInfo && P.playerInfo.factionId);
       add(P.playerInfo && P.playerInfo.factionName);
+      add(P.playerFactionId);
       add(P.playerFaction);
     }
   } catch (_) {}
+  add(sc && sc.playerInfo && sc.playerInfo.factionId);
   add(sc && sc.playerInfo && sc.playerInfo.factionName);
+  add(sc && sc.playerFactionId);
   add(sc && sc.playerFaction);
   try {
     var G = (typeof GM !== 'undefined' && GM) ? GM : null;
+    add(G && G.playerFactionId);
     add(G && G.playerFaction);
     (G && Array.isArray(G.facs) ? G.facs : []).forEach(function(f) {
       if (f && f.isPlayer) { add(f.name); add(f.id); add(f.key); }
@@ -109,11 +115,11 @@ function _tmResolvePlayerAdminKey(adminHierarchy, sc) {
     var want = norm(candidates[i]);
     for (var j = 0; j < keys.length; j++) {
       var key = keys[j], tree = adminHierarchy[key] || {};
-      var aliases = [key, tree && tree.name, tree && tree.faction, tree && tree.factionName, tree && tree.id, tree && tree.key, tree && tree.owner];
+      var aliases = [key, tree && tree.name, tree && tree.faction, tree && tree.factionId, tree && tree.factionName, tree && tree.id, tree && tree.key, tree && tree.owner];
       if (aliases.some(function(v) { return norm(v) === want; })) return key;
     }
   }
-  return keys.length === 1 ? keys[0] : null;
+  return options.allowSoleBranchFallback === true && keys.length === 1 ? keys[0] : null;
 }
 
 function _tmStartLoadVars(sid, sc) {
@@ -168,7 +174,7 @@ function _tmStartPinMinxinFromVars(sc) {
     pin = Math.max(0, Math.min(100, pin));
     function _pinLeaves(ah) {
       if (!ah || typeof ah !== 'object') return 0;
-      var key = _tmResolvePlayerAdminKey(ah, sc);
+      var key = _tmResolvePlayerAdminKey(ah, sc, { allowSoleBranchFallback:true });
       var fac = Array.isArray(ah.divisions) ? ah : (key ? ah[key] : null);
       if (!fac) return 0;
       var leaves = [];


### PR DESCRIPTION
## Summary
- zero the player population ledger when the authoritative player branch has no territory, without reclassifying a sole NPC branch
- route capital pull and historical migration through one exact demographic bundle transfer for mouths, households, ding, age, and gender
- make age and gender bucket scaling exact with largest-remainder allocation
- validate qiaozhi idempotence through complete event-owned stable IDs
- add focused regression coverage and refresh runtime cache stamps plus the canonical hot baseline

## Verification
- node web/scripts/ci-smokes.js: 852 total, 850 direct pass, 2 existing missing-asset allowlist exemptions
- node web/scripts/lint-arch-all.js: 8/8
- node web/scripts/verify-official-scenario-parity.js: 27 assertions
- node scripts/verify-release-contract.js: 166 assertions
- node web/scripts/verify-hot-builder-gates.js: 27 assertions
- npm audit --omit=dev --audit-level=high --registry=https://registry.npmjs.org: 0 vulnerabilities
- full asset hot baseline check: 1082 files, version 1.3.4.11