### PR TITLE
fix: close sixteenth-round audit population ledger gaps

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-22T10:42:45.570Z",
+  "generatedAt": "2026-08-22T11:35:20.537Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -2161,7 +2161,7 @@
     },
     {
       "path": "index.html",
-      "sha256": "5c6ed76061f183e5118a79be4d5388bbbcd07bfe18e0679ae98b111559e83dc1",
+      "sha256": "1a2fb3b7e9b80cebdfa26408ced21a4e2ce28b9e546e0bbe19438e0393e4c0a4",
       "size": 68643
     },
     {
@@ -4316,8 +4316,8 @@
     },
     {
       "path": "tm-huji-engine.js",
-      "sha256": "e17eb23ac184acd30c92fd1538ce7ed8c63308f5b0471e678d7e7c56167e205f",
-      "size": 118014
+      "sha256": "000d8801f493d0caaa386c670b8ae91baaccf106f40a72758990b29e34fd1a80",
+      "size": 128544
     },
     {
       "path": "tm-huji-governance-loop.js",
@@ -4326,8 +4326,8 @@
     },
     {
       "path": "tm-huji-runtime-bridge.js",
-      "sha256": "ffb72f11a9b4e4d9e1206e1695e91e83928bd47922674270c92801bdb77bf8d1",
-      "size": 63314
+      "sha256": "cba4532ad4619ab66b4145fff3d2a27e49f5c2fb1435ec3be2fd75471ce387ad",
+      "size": 66667
     },
     {
       "path": "tm-indices.js",
@@ -4341,8 +4341,8 @@
     },
     {
       "path": "tm-integration-bridge.js",
-      "sha256": "87644b609081ccd51e40a5493170fd8d335887a50b9df8f66582ac71abef5dd4",
-      "size": 38894
+      "sha256": "cbd9d0d257fe19960215944d205aa6ba22ab2bb7f583b9cdfd31faaee1b68312",
+      "size": 40572
     },
     {
       "path": "tm-invariants.js",

--- a/web/index.html
+++ b/web/index.html
@@ -875,10 +875,10 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-economy-engine-currency.js?v=20260821-auditfix13"></script><!-- 立项拆分：§A CurrencyUnit+§B CurrencyEngine 两整IIFE·紧挨 economy-engine 之前保序·勿动位置 -->
 <script src="tm-economy-engine.js?v=20260821-auditfix13"></script>
 <script src="tm-central-local-engine.js?v=20260709"></script>
-<script src="tm-huji-engine.js?v=20260822-auditfix15"></script>
+<script src="tm-huji-engine.js?v=20260822-auditfix16"></script>
 <script src="tm-edict-parser.js?v=20260709"></script>
 <script src="tm-huji-deep-fill.js?v=20260822-auditfix14"></script>
-<script src="tm-huji-runtime-bridge.js?v=20260822-auditfix15"></script>
+<script src="tm-huji-runtime-bridge.js?v=20260822-auditfix16"></script>
 <script src="tm-huji-governance-loop.js?v=20260602-huji-governance-loop"></script>
 <script src="tm-edict-complete.js?v=2026050701"></script>
 <script src="tm-env-recovery-fill.js?v=20260709"></script>
@@ -912,7 +912,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-ethnic-religion.js?v=2026050701"></script>
 <script src="tm-edict-thresholds.js?v=2026042714"></script>
 <script src="tm-fiscal-ui.js?v=2026042714"></script>
-<script src="tm-integration-bridge.js?v=20260822-auditfix15"></script>
+<script src="tm-integration-bridge.js?v=20260822-auditfix16"></script>
 <script src="tm-fiscal-engine.js?v=20260811-auditfix1"></script>
 <script src="tm-perf.js?v=2026042714"></script>
 <script src="tm-invariants.js?v=2026042714"></script>

--- a/web/scripts/smoke-huji-runtime-bridge.js
+++ b/web/scripts/smoke-huji-runtime-bridge.js
@@ -165,6 +165,10 @@ assert(sandbox.GM.population.byCategory.tusi_custom, 'scenario-specific tusi cat
 assert(/灶户|盐场/.test(sandbox.GM.population.byCategory.daohu.name + sandbox.GM.population.byCategory.daohu.description), 'custom category should preserve description');
 assert(sandbox.GM.population.byRegion.capital && sandbox.GM.population.byRegion.capital.mouths === 26000, 'capital region should be indexed from adminHierarchy');
 assert(sandbox.GM.population.byRegion.tusi.regionType === 'tusi', 'region type should be preserved');
+assert(sandbox.GM.population.byRegion.capital === sandbox.GM.adminHierarchy.player.divisions[0].populationDetail,
+  'byRegion rows should be the authoritative leaf populationDetail objects');
+assert(sandbox.GM.population.byLeafRegion === sandbox.GM.population.byRegion,
+  'byLeafRegion and legacy byRegion should expose the same leaf-granularity table');
 
 assert(sandbox.GM.corvee && sandbox.GM.corvee.ledger, 'corvee ledger should be exposed');
 assert(sandbox.GM.corvee.ledger.summary.totalDemandDays > 0, 'corvee ledger should calculate demand days');
@@ -212,6 +216,33 @@ assert(/playerHujiOperations/.test(prompt), 'prompt should include player operat
 
 const snap = Bridge.snapshot(sandbox.GM, { limit: 5 });
 assert(snap.hukou && snap.corvee && snap.military && snap.operations.length >= 2, 'snapshot should expose all bridge sections');
+
+let exactSmallBreakdowns = true;
+for (let total = 0; total <= 100; total++) {
+  sandbox.GM.adminHierarchy.player.divisions.forEach((region, index) => {
+    region.populationDetail.mouths = index === 0 ? total : 0;
+    region.populationDetail.households = index === 0 ? total : 0;
+    region.populationDetail.ding = index === 0 ? total : 0;
+    region.populationDetail.hiddenCount = 0;
+    region.populationDetail.hidden = 0;
+    region.populationDetail.fugitives = 0;
+    region.populationDetail.byAge = {};
+    region.populationDetail.byGender = {};
+    region.populationDetail.byLegalStatus = {};
+  });
+  sandbox.GM.population.hiddenCount = 0;
+  sandbox.GM.population.fugitives = 0;
+  sandbox.GM.population._leafPopulationAuxAuthoritative = true;
+  Bridge.maintain(sandbox.GM, { scenario, turn: 90 + total, source:'smoke-exact-small', applyHardEffects:false });
+  ['households', 'mouths', 'ding'].forEach(field => {
+    const categorySum = Object.values(sandbox.GM.population.byCategory || {})
+      .reduce((sum, row) => sum + Number(row && row[field] || 0), 0);
+    const legalSum = Object.values(sandbox.GM.population.byLegalStatus || {})
+      .reduce((sum, row) => sum + Number(row && row[field] || 0), 0);
+    exactSmallBreakdowns = exactSmallBreakdowns && categorySum === total && legalSum === total;
+  });
+}
+assert(exactSmallBreakdowns, 'category and legal-status allocations should conserve mouths households and ding for totals 0 through 100');
 
 const src = name => fs.readFileSync(path.join(ROOT, name), 'utf8');
 const index = src('index.html');

--- a/web/scripts/smoke-population-faction-ledger.js
+++ b/web/scripts/smoke-population-faction-ledger.js
@@ -9,6 +9,7 @@ const ROOT = path.resolve(__dirname, '..');
 const hujiSource = fs.readFileSync(path.join(ROOT, 'tm-huji-engine.js'), 'utf8');
 const deepSource = fs.readFileSync(path.join(ROOT, 'tm-huji-deep-fill.js'), 'utf8');
 const runtimeBridgeSource = fs.readFileSync(path.join(ROOT, 'tm-huji-runtime-bridge.js'), 'utf8');
+const integrationBridgeSource = fs.readFileSync(path.join(ROOT, 'tm-integration-bridge.js'), 'utf8');
 const economySource = fs.readFileSync(path.join(ROOT, 'tm-economy-engine.js'), 'utf8');
 const historicalSource = fs.readFileSync(path.join(ROOT, 'tm-historical-presets.js'), 'utf8');
 const regionEnrichSource = fs.readFileSync(path.join(ROOT, 'tm-region-enrich.js'), 'utf8');
@@ -104,6 +105,7 @@ function makeRuntime(options = {}) {
   vm.runInContext(hujiSource, context, { filename: 'tm-huji-engine.js' });
   vm.runInContext(deepSource, context, { filename: 'tm-huji-deep-fill.js' });
   vm.runInContext(runtimeBridgeSource, context, { filename: 'tm-huji-runtime-bridge.js' });
+  vm.runInContext(integrationBridgeSource, context, { filename: 'tm-integration-bridge.js' });
   vm.runInContext(historicalSource, context, { filename: 'tm-historical-presets.js' });
   context.HujiEngine.init(context.P);
   context.GM.population.corvee.enabled = false;
@@ -554,6 +556,102 @@ console.log('[smoke-population-faction-ledger]');
   });
   ok(triggerResults.every(result => result.premature === 0 && result.triggered === result.cycleTurns),
     'registration cycles use canonical elapsed months for every daysPerTurn scale');
+}
+
+{
+  const { context, playerLeaves } = makeRuntime();
+  context.GM.turn = 12;
+  context.GM.population.meta.registrationCycle = 1;
+  context.GM.population.meta.lastRegistrationTurn = 0;
+  playerLeaves[0].populationDetail.hiddenCount = 300000;
+  playerLeaves[1].populationDetail.hiddenCount = 200000;
+  context.GM.population.hiddenCount = 500000;
+  context.HujiEngine.tick({ turn:12, monthRatio:1, strict:true });
+  const leafHiddenAfter = playerLeaves.reduce((sum, leaf) => sum + Number(leaf.populationDetail.hiddenCount || 0), 0);
+  const leafHuangji = playerLeaves.reduce((sum, leaf) => sum + Number(leaf.populationDetail.byLegalStatus.huangji.households || 0), 0);
+  context.TM.HujiRuntimeBridge.maintain(context.GM, { scenario:context.P, turn:12, applyHardEffects:false });
+  ok(leafHiddenAfter === 350000
+    && context.GM.population.hiddenCount === 350000
+    && context.GM.hukou.estimatedHidden === 350000,
+  'census registration removes discovered mouths from authoritative leaves and RuntimeBridge cannot restore them');
+  ok(leafHuangji === 30000
+    && context.GM.population.meta.registrationLedger.slice(-1)[0].mouths === 150000
+    && context.GM.population.meta.registrationLedger.slice(-1)[0].households === 30000,
+  '150,000 discovered hidden mouths become about 30,000 registered households, never 150,000 households');
+}
+
+{
+  const { context, playerLeaves } = makeRuntime();
+  context.GM.turn = 12;
+  context.GM.population.meta.registrationCycle = 1;
+  context.GM.population.meta.lastRegistrationTurn = 0;
+  playerLeaves[0].populationDetail.hiddenCount = 300000;
+  playerLeaves[1].populationDetail.hiddenCount = 200000;
+  context.GM.population.hiddenCount = 500000;
+  const hiddenBefore = playerLeaves.map(leaf => leaf.populationDetail.hiddenCount);
+  const legalBefore = playerLeaves.map(leaf => clone(leaf.populationDetail.byLegalStatus || {}));
+  context.FiscalEngine.spendFromGuoku = () => { throw new Error('injected census payment failure'); };
+  let failure = null;
+  try { context.HujiEngine.tick({ turn:12, monthRatio:1, strict:true }); }
+  catch (error) { failure = error; }
+  ok(failure && /census payment failure/.test(failure.message)
+    && context.GM.population.meta.lastRegistrationTurn === 0
+    && JSON.stringify(playerLeaves.map(leaf => leaf.populationDetail.hiddenCount)) === JSON.stringify(hiddenBefore)
+    && JSON.stringify(playerLeaves.map(leaf => leaf.populationDetail.byLegalStatus || {})) === JSON.stringify(legalBefore),
+  'failed census payment propagates before registration metadata or leaf ledgers change');
+}
+
+{
+  const { context } = makeRuntime();
+  const countyA = makeLeaf('county-a', '甲县', 600000, true);
+  const countyB = makeLeaf('county-b', '乙县', 400000, false);
+  countyA.populationDetail.hiddenCount = 10000;
+  countyB.populationDetail.hiddenCount = 5000;
+  context.GM.adminHierarchy.player.divisions = [{
+    id:'province-a', name:'甲省', children:[{
+      id:'prefecture-a', name:'甲府', children:[countyA, countyB]
+    }]
+  }];
+  context.GM.population.hiddenCount = 15000;
+  context.TM.HujiRuntimeBridge.maintain(context.GM, { scenario:context.P, turn:1, applyHardEffects:false });
+  context.IntegrationBridge.tick({ strict:true });
+  context.GM.population.byRegion['county-a'].baojiaUnits = 100000;
+  const hiddenBefore = countyA.populationDetail.hiddenCount;
+  context.GM.population.dynamics.birthRateBase = 0;
+  context.GM.population.dynamics.deathRateBase = 0;
+  context.HujiEngine.tick({ turn:1, monthRatio:12, strict:true });
+  const reduced = countyA.populationDetail.hiddenCount;
+  context.TM.HujiRuntimeBridge.maintain(context.GM, { scenario:context.P, turn:1, applyHardEffects:false });
+  context.IntegrationBridge.tick({ strict:true });
+  context.TM.HujiRuntimeBridge.maintain(context.GM, { scenario:context.P, turn:1, applyHardEffects:false });
+  const keys = Object.keys(context.GM.population.byRegion).sort();
+  ok(reduced < hiddenBefore
+    && countyA.populationDetail.hiddenCount === reduced
+    && context.GM.population.byRegion['county-a'] === countyA.populationDetail,
+  'multi-level baojia changes remain on the authoritative leaf after both runtime bridges');
+  ok(JSON.stringify(keys) === JSON.stringify(['county-a', 'county-b'])
+    && !context.GM.population.byRegion['province-a']
+    && context.GM.population.byProvince['province-a'],
+  'population.byRegion keeps stable leaf IDs while province proxies use population.byProvince');
+}
+
+{
+  const { context, playerLeaves } = makeRuntime();
+  const source = playerLeaves[0];
+  source.populationDetail.mouths = 10;
+  source.populationDetail.households = 5;
+  source.populationDetail.ding = 5;
+  source.populationDetail.byAge = { age_21_30:10 };
+  source.populationDetail.byGender = { male:5, female:5 };
+  const result = context.HujiEngine.materializeQiaozhiResettlement({
+    eventId:'tiny-four-way-qiaozhi', mouths:3, sourceCandidates:['京城'],
+    targetNames:['侨甲', '侨乙', '侨丙', '侨丁']
+  });
+  const created = context.GM.adminHierarchy.player.divisions.filter(leaf => leaf.parentHistoric === 'tiny-four-way-qiaozhi');
+  ok(result.ok && result.households === 2 && result.ding === 2
+    && created.reduce((sum, leaf) => sum + leaf.populationDetail.households, 0) === 2
+    && created.reduce((sum, leaf) => sum + leaf.populationDetail.ding, 0) === 2,
+  'four-way qiaozhi distributes two households and two ding exactly without rounding inflation');
 }
 
 {

--- a/web/tm-huji-engine.js
+++ b/web/tm-huji-engine.js
@@ -296,6 +296,56 @@
     return total;
   }
 
+  // 将一个非负整数按权重精确分配；任何时候分项之和都严格等于 total。
+  // limits 可选，用于“从现有存量中扣除”这类不能超过各项库存的场景。
+  function _allocateExactIntegers(total, weights, limits) {
+    total = Math.max(0, Math.round(Number(total) || 0));
+    weights = Array.isArray(weights) ? weights.map(function(value) {
+      return Math.max(0, Number(value) || 0);
+    }) : [];
+    limits = Array.isArray(limits) ? limits.map(function(value) {
+      return Math.max(0, Math.round(Number(value) || 0));
+    }) : null;
+    var out = weights.map(function() { return 0; });
+    if (!weights.length || !total) return out;
+    if (limits) {
+      var capacity = limits.reduce(function(sum, value) { return sum + value; }, 0);
+      total = Math.min(total, capacity);
+    }
+    var weightTotal = weights.reduce(function(sum, value, index) {
+      if (limits && limits[index] <= 0) return sum;
+      return sum + value;
+    }, 0);
+    if (!(weightTotal > 0)) {
+      weights = weights.map(function(_, index) { return !limits || limits[index] > 0 ? 1 : 0; });
+      weightTotal = weights.reduce(function(sum, value) { return sum + value; }, 0);
+    }
+    var ranked = [];
+    var assigned = 0;
+    weights.forEach(function(weight, index) {
+      var quota = weightTotal > 0 ? total * weight / weightTotal : 0;
+      var value = Math.floor(quota);
+      if (limits) value = Math.min(value, limits[index]);
+      out[index] = value;
+      assigned += value;
+      ranked.push({ index:index, fraction:quota - Math.floor(quota) });
+    });
+    ranked.sort(function(a, b) { return b.fraction - a.fraction || a.index - b.index; });
+    var remaining = total - assigned;
+    while (remaining > 0) {
+      var progressed = false;
+      for (var i = 0; i < ranked.length && remaining > 0; i++) {
+        var index = ranked[i].index;
+        if (limits && out[index] >= limits[index]) continue;
+        out[index]++;
+        remaining--;
+        progressed = true;
+      }
+      if (!progressed) break;
+    }
+    return out;
+  }
+
   function _maxShare(obj) {
     var total = _sumObj(obj);
     var max = 0;
@@ -805,7 +855,15 @@
       leaf.population.mouths = detail.mouths;
       leaf.population.households = detail.households;
       leaf.population.ding = detail.ding;
+      leaf.population.hiddenCount = Math.max(0, Math.round(Number(detail.hiddenCount != null ? detail.hiddenCount : detail.hidden) || 0));
+      leaf.population.fugitives = Math.max(0, Math.round(Number(detail.fugitives) || 0));
     }
+    detail.hiddenCount = Math.max(0, Math.round(Number(detail.hiddenCount != null ? detail.hiddenCount : detail.hidden) || 0));
+    detail.hidden = detail.hiddenCount;
+    detail.fugitives = Math.max(0, Math.round(Number(detail.fugitives) || 0));
+    leaf.hiddenCount = detail.hiddenCount;
+    leaf.hidden = detail.hiddenCount;
+    leaf.fugitives = detail.fugitives;
     if (leaf.isQiaozhi || leaf.regionType === 'qiaozhi') {
       leaf.byLegalStatus = leaf.byLegalStatus && typeof leaf.byLegalStatus === 'object' ? leaf.byLegalStatus : {};
       leaf.byLegalStatus.qiaozhi = {
@@ -1037,6 +1095,9 @@
       legacyRow.mouths = detail.mouths;
       legacyRow.households = detail.households;
       legacyRow.ding = detail.ding;
+      legacyRow.hiddenCount = Math.max(0, Math.round(Number(detail.hiddenCount != null ? detail.hiddenCount : detail.hidden) || 0));
+      legacyRow.hidden = legacyRow.hiddenCount;
+      legacyRow.fugitives = Math.max(0, Math.round(Number(detail.fugitives) || 0));
     }
   }
 
@@ -1957,14 +2018,10 @@
     return out;
   }
 
-  function _bundleShare(bundle, index, count, assigned, bucketState) {
-    var last = index === count - 1;
+  function _bundleShare(bundle, index, scalarShares, bucketState) {
     var share = {};
     ['mouths', 'households', 'ding'].forEach(function(field) {
-      share[field] = last
-        ? Math.max(0, Number(bundle[field]) - Number(assigned[field]))
-        : Math.round(Number(bundle[field]) / count);
-      assigned[field] += share[field];
+      share[field] = scalarShares[field][index] || 0;
     });
     share.byAge = _takeExactBucketShare(bucketState.byAge, share.mouths);
     share.byGender = _takeExactBucketShare(bucketState.byGender, share.mouths);
@@ -2020,13 +2077,17 @@
     plannedIds.forEach(function(stableId) { existingIds[stableId] = true; });
     var bundle = _removePopulationForTransfer(sourceLeaves, requested);
     if (!bundle.mouths) return { ok:false, reason:'source-population-empty' };
-    var assigned = { mouths:0, households:0, ding:0, byAge:{}, byGender:{} };
+    var scalarShares = {
+      mouths:_allocateExactIntegers(bundle.mouths, targetNames.map(function() { return 1; })),
+      households:_allocateExactIntegers(bundle.households, targetNames.map(function() { return 1; })),
+      ding:_allocateExactIntegers(bundle.ding, targetNames.map(function() { return 1; }))
+    };
     var bucketState = {
       byAge:{ values:Object.assign({}, bundle.byAge), total:bundle.mouths },
       byGender:{ values:Object.assign({}, bundle.byGender), total:bundle.mouths }
     };
     var created = targetNames.map(function(name, index) {
-      var share = _bundleShare(bundle, index, targetNames.length, assigned, bucketState);
+      var share = _bundleShare(bundle, index, scalarShares, bucketState);
       var stableId = plannedIds[index];
       var detail = {
         households:share.households,
@@ -2115,6 +2176,124 @@
   //  造册登记
   // ═══════════════════════════════════════════════════════════════════
 
+  function _leafHiddenMouths(leaf) {
+    var detail = leaf && leaf.populationDetail;
+    if (!detail) return 0;
+    return Math.max(0, Math.round(Number(detail.hiddenCount != null ? detail.hiddenCount : detail.hidden) || 0));
+  }
+
+  function _setLeafHiddenMouths(leaf, value) {
+    if (!leaf || !leaf.populationDetail) return;
+    var hidden = Math.max(0, Math.round(Number(value) || 0));
+    leaf.populationDetail.hiddenCount = hidden;
+    leaf.populationDetail.hidden = hidden;
+    _syncLeafPopulationMirrors(leaf, leaf.populationDetail);
+  }
+
+  function _registrationHiddenTarget(P, group) {
+    var leafTotal = (group && group.leaves || []).reduce(function(sum, leaf) {
+      return sum + _leafHiddenMouths(leaf);
+    }, 0);
+    if (P && P._leafPopulationAuxAuthoritative === true) return leafTotal;
+    return Math.max(leafTotal, Math.max(0, Math.round(Number(P && P.hiddenCount) || 0)));
+  }
+
+  function _materializeHiddenPopulation(P, group, target) {
+    var leaves = (group && group.leaves || []).filter(function(leaf) {
+      return leaf && leaf.populationDetail;
+    });
+    var current = leaves.reduce(function(sum, leaf) { return sum + _leafHiddenMouths(leaf); }, 0);
+    target = Math.max(current, Math.max(0, Math.round(Number(target) || 0)));
+    if (target > current && leaves.length) {
+      var additions = _allocateExactIntegers(target - current, leaves.map(function(leaf) {
+        return Math.max(0, Math.round(Number(leaf.populationDetail.mouths) || 0));
+      }));
+      leaves.forEach(function(leaf, index) {
+        _setLeafHiddenMouths(leaf, _leafHiddenMouths(leaf) + additions[index]);
+      });
+    }
+    P._leafPopulationAuxAuthoritative = true; // arch-ok: 户籍权威写口确认叶级隐口账本已物化
+    P.hiddenCount = leaves.reduce(function(sum, leaf) { return sum + _leafHiddenMouths(leaf); }, 0); // arch-ok: 叶级隐口聚合全国视图
+    return P.hiddenCount;
+  }
+
+  function registerHiddenPopulation(options) {
+    options = options || {};
+    var G = global.GM;
+    var P = G && G.population;
+    if (!P) return { ok:false, reason:'population-unavailable', mouths:0, households:0, ding:0 };
+    var groups = _factionLeafGroups(G);
+    var target = _resolvePopulationTarget(G, options, groups);
+    if (!target.ok || !target.group || !target.group.leaves.length) {
+      return { ok:false, reason:target.reason || 'player-faction-not-found', mouths:0, households:0, ding:0 };
+    }
+    var group = target.group;
+    var available = _materializeHiddenPopulation(P, group, options.availableHidden);
+    var requested = Math.min(available, Math.max(0, Math.round(Number(options.mouths) || 0)));
+    var leaves = group.leaves.filter(function(leaf) { return _leafHiddenMouths(leaf) > 0; });
+    var hiddenBefore = leaves.map(_leafHiddenMouths);
+    var discoveries = _allocateExactIntegers(requested, hiddenBefore, hiddenBefore);
+    var registered = { mouths:0, households:0, ding:0 };
+    leaves.forEach(function(leaf, index) {
+      var discoveredMouths = discoveries[index] || 0;
+      if (!discoveredMouths) return;
+      var detail = leaf.populationDetail;
+      var localMouths = Math.max(0, Math.round(Number(detail.mouths) || 0));
+      var localHouseholds = Math.max(0, Math.round(Number(detail.households) || 0));
+      var localDing = Math.max(0, Math.round(Number(detail.ding) || 0));
+      var mouthsPerHousehold = localMouths / Math.max(1, localHouseholds);
+      if (!(mouthsPerHousehold > 0) || !isFinite(mouthsPerHousehold)) mouthsPerHousehold = 5;
+      var dingRatio = localDing / Math.max(1, localMouths);
+      var discoveredHouseholds = Math.min(localHouseholds, Math.round(discoveredMouths / mouthsPerHousehold));
+      var discoveredDing = Math.min(localDing, Math.round(discoveredMouths * dingRatio));
+      var legal = detail.byLegalStatus && typeof detail.byLegalStatus === 'object' ? detail.byLegalStatus : {};
+      var yinhu = legal.yinhu && typeof legal.yinhu === 'object' ? legal.yinhu : {
+        mouths:hiddenBefore[index],
+        households:Math.round(hiddenBefore[index] / mouthsPerHousehold),
+        ding:Math.round(hiddenBefore[index] * dingRatio)
+      };
+      var huangji = legal.huangji && typeof legal.huangji === 'object' ? legal.huangji : { mouths:0, households:0, ding:0 };
+      yinhu.mouths = Math.max(0, Math.round(Number(yinhu.mouths) || 0) - discoveredMouths);
+      yinhu.households = Math.max(0, Math.round(Number(yinhu.households) || 0) - discoveredHouseholds);
+      yinhu.ding = Math.max(0, Math.round(Number(yinhu.ding) || 0) - discoveredDing);
+      huangji.mouths = Math.max(0, Math.round(Number(huangji.mouths) || 0)) + discoveredMouths;
+      huangji.households = Math.max(0, Math.round(Number(huangji.households) || 0)) + discoveredHouseholds;
+      huangji.ding = Math.max(0, Math.round(Number(huangji.ding) || 0)) + discoveredDing;
+      legal.yinhu = yinhu;
+      legal.huangji = huangji;
+      detail.byLegalStatus = legal;
+      leaf.byLegalStatus = legal;
+      _setLeafHiddenMouths(leaf, hiddenBefore[index] - discoveredMouths);
+      if (!Array.isArray(leaf.populationRegistrationLedger)) leaf.populationRegistrationLedger = [];
+      leaf.populationRegistrationLedger.push({
+        turn:Number(G.turn) || 0,
+        cause:String(options.cause || 'census-registration'),
+        mouths:discoveredMouths,
+        households:discoveredHouseholds,
+        ding:discoveredDing
+      });
+      if (leaf.populationRegistrationLedger.length > 40) {
+        leaf.populationRegistrationLedger.splice(0, leaf.populationRegistrationLedger.length - 40);
+      }
+      registered.mouths += discoveredMouths;
+      registered.households += discoveredHouseholds;
+      registered.ding += discoveredDing;
+    });
+    P.hiddenCount = group.leaves.reduce(function(sum, leaf) { return sum + _leafHiddenMouths(leaf); }, 0); // arch-ok: 造册后由叶级隐口聚合全国视图
+    if (!P.meta || typeof P.meta !== 'object') P.meta = _defaultMeta();
+    if (!Array.isArray(P.meta.registrationLedger)) P.meta.registrationLedger = [];
+    P.meta.registrationLedger.push({
+      turn:Number(G.turn) || 0,
+      factionId:group.factionId,
+      cause:String(options.cause || 'census-registration'),
+      mouths:registered.mouths,
+      households:registered.households,
+      ding:registered.ding
+    });
+    if (P.meta.registrationLedger.length > 80) P.meta.registrationLedger.splice(0, P.meta.registrationLedger.length - 80);
+    return Object.assign({ ok:true, factionId:group.factionId, hiddenRemaining:P.hiddenCount }, registered);
+  }
+
   function _tickRegistration(ctx) {
     var P = global.GM.population;
     if (!P || !P.meta) return;
@@ -2122,12 +2301,30 @@
     var cycleMonths = Math.max(0, Number(P.meta.registrationCycle) || 0) * 12;
     var cycleTurns = (typeof global.turnsForMonths === 'function') ? global.turnsForMonths(cycleMonths) : cycleMonths;
     if (turnsSince < Math.max(1, Number(cycleTurns) || 1)) return;
-    // 触发造册
+    // 触发造册。hiddenCount 的单位是“口”，不能直接写进黄籍“户”。
     var cost = Math.round(P.national.households * 0.05);
     if (global.GM.guoku && global.GM.guoku.money !== undefined && global.GM.guoku.money >= cost) {
       // 造册经费走 FiscalEngine 真账(2026-07-04 收口)
-      if (global.FiscalEngine && global.FiscalEngine.spendFromGuoku) global.FiscalEngine.spendFromGuoku({ money: cost }, '户籍造册');
-      P.meta.lastRegistrationTurn = ctx.turn || 0;
+      if (!global.FiscalEngine || typeof global.FiscalEngine.spendFromGuoku !== 'function') {
+        throw new Error('户籍造册失败：财政写口不可用');
+      }
+      var groups = _factionLeafGroups(global.GM);
+      var playerGroup = groups.find(function(group) { return group.isPlayer; });
+      if (!playerGroup || !playerGroup.leaves.length) return;
+      var availableHidden = _registrationHiddenTarget(P, playerGroup);
+      var discoveredMouths = Math.round(availableHidden * 0.3);
+      var payment = cost > 0 ? global.FiscalEngine.spendFromGuoku({ money: cost }, '户籍造册') : { ok:true };
+      var deficit = payment && payment.deducted && payment.deducted.money && Number(payment.deducted.money.deficit) || 0;
+      if (payment === false || (payment && payment.ok === false) || deficit > 0) {
+        throw new Error('户籍造册失败：财政扣款未完成');
+      }
+      var registered = registerHiddenPopulation({
+        factionId:playerGroup.factionId,
+        mouths:discoveredMouths,
+        availableHidden:availableHidden,
+        cause:'census-registration'
+      });
+      if (!registered.ok) throw new Error('户籍造册失败：' + registered.reason);
       // 更新准确度——腐败降低
       var corrObj = global.GM.corruption;
       var corrRaw = corrObj && typeof corrObj === 'object'
@@ -2135,11 +2332,8 @@
         : corrObj;
       var corrupt = typeof corrRaw === 'number' && isFinite(corrRaw) ? corrRaw : 30;
       P.meta.registrationAccuracy = Math.max(0.5, 1.0 - corrupt / 100 * 0.5);
-      // 发现隐户（部分）
-      var discovered = Math.round(P.hiddenCount * 0.3);
-      P.hiddenCount = Math.max(0, P.hiddenCount - discovered);
-      if (P.byLegalStatus.huangji) P.byLegalStatus.huangji.households += discovered;
-      if (global.addEB) global.addEB('户口', '大造黄册，发现隐户 ' + discovered + ' 户（准确度 ' + (P.meta.registrationAccuracy*100).toFixed(0) + '%）');
+      P.meta.lastRegistrationTurn = ctx.turn || 0;
+      if (global.addEB) global.addEB('户口', '大造黄册，核出隐口 ' + registered.mouths + ' 口、约 ' + registered.households + ' 户（准确度 ' + (P.meta.registrationAccuracy*100).toFixed(0) + '%）');
     }
   }
 
@@ -2221,6 +2415,7 @@
     tick: tick,
     applyPopulationLoss: applyPopulationLoss,
     transferPopulation: transferPopulation,
+    registerHiddenPopulation: registerHiddenPopulation,
     materializeQiaozhiResettlement: materializeQiaozhiResettlement,
     syncDemographicViews: syncDemographicViews,
     startLargeCorvee: startLargeCorvee,

--- a/web/tm-huji-runtime-bridge.js
+++ b/web/tm-huji-runtime-bridge.js
@@ -45,6 +45,36 @@
     return Math.max(0, Math.round(number(v, 0)));
   }
 
+  // 最大余数法：所有人口分类统一从这里取得精确整数分配，避免小总量下
+  // 多个 Math.round() 使分项合计超过总数。
+  function allocateExact(total, weights) {
+    total = round(total);
+    weights = weights && typeof weights === 'object' ? weights : {};
+    var keys = Object.keys(weights);
+    var out = {};
+    keys.forEach(function(key) { out[key] = 0; });
+    if (!keys.length || !total) return out;
+    var weightTotal = keys.reduce(function(sum, key) {
+      return sum + Math.max(0, number(weights[key], 0));
+    }, 0);
+    if (!(weightTotal > 0)) {
+      keys.forEach(function(key) { weights[key] = 1; });
+      weightTotal = keys.length;
+    }
+    var ranked = [];
+    var assigned = 0;
+    keys.forEach(function(key, index) {
+      var quota = total * Math.max(0, number(weights[key], 0)) / weightTotal;
+      var value = Math.floor(quota);
+      out[key] = value;
+      assigned += value;
+      ranked.push({ key:key, index:index, fraction:quota - value });
+    });
+    ranked.sort(function(a, b) { return b.fraction - a.fraction || a.index - b.index; });
+    for (var i = 0; i < total - assigned; i++) out[ranked[i % ranked.length].key]++;
+    return out;
+  }
+
   function round2(v) {
     return Math.round(number(v, 0) * 100) / 100;
   }
@@ -325,8 +355,7 @@
       addNumericBuckets(byAge, d.byAge);
       addNumericBuckets(byGender, d.byGender);
       addPopulationBreakdown(byLegalStatus, d.byLegalStatus);
-      region.populationDetail = Object.assign({}, region.populationDetail || {}, d);
-      byRegion[id] = Object.assign({}, d, {
+      var canonical = Object.assign({}, region.populationDetail || {}, d, {
         id: id,
         name: region.name || id,
         regionType: region.regionType || region.type || region.kind || '',
@@ -339,10 +368,26 @@
         minxin: number(region.minxinLocal || region.minxin || (region.minxinDetail && region.minxinDetail.trueIndex), 0),
         corruption: number(region.corruptionLocal || region.corruption || (region.corruptionDetail && region.corruptionDetail.true), 0),
         taxLevel: region.taxLevel || '',
+        baojiaUnits: round(region.baojiaUnits || (region.populationDetail && region.populationDetail.baojiaUnits) || 0),
+        lijiaUnits: round(region.lijiaUnits || (region.populationDetail && region.populationDetail.lijiaUnits) || 0),
         fiscalDetail: clone(region.fiscalDetail || {}),
         corveeDetail: clone(region.corveeDetail || {}),
         militaryDetail: clone(region.militaryDetail || {})
       });
+      region.populationDetail = canonical;
+      region.byAge = canonical.byAge;
+      region.byGender = canonical.byGender;
+      region.byLegalStatus = canonical.byLegalStatus;
+      if (region.population && typeof region.population === 'object' && region.population !== canonical) {
+        region.population.mouths = canonical.mouths;
+        region.population.households = canonical.households;
+        region.population.ding = canonical.ding;
+        region.population.hiddenCount = canonical.hiddenCount;
+        region.population.fugitives = canonical.fugitives;
+      }
+      // byRegion 是叶级权威表；值与 division.populationDetail 保持同一引用，
+      // 任何保甲、逃户或人口治理修改都会真正落到行政区账本。
+      byRegion[id] = canonical;
     });
 
     var hasRegionalTotals = leaves.length > 0 || totals.households || totals.mouths || totals.ding;
@@ -353,8 +398,33 @@
     var scenarioHidden = round(initial.hiddenPopulation || initial.hiddenCount || initial.unregisteredPopulation || 0);
     var existingHidden = round(root.population && (root.population.hiddenCount || root.population.hiddenPopulation || root.population.unregisteredPopulation) || 0);
     var emptyAuthoritativePlayer = options.authoritativePlayerPopulation === true && leaves.length === 0;
-    var hiddenCount = emptyAuthoritativePlayer ? 0 : Math.max(totals.hiddenCount, scenarioHidden, existingHidden);
-    var fugitives = emptyAuthoritativePlayer ? 0 : Math.max(totals.fugitives, round(root.population && root.population.fugitives || 0), round(root.hukou && (root.hukou.refugees || root.hukou.fugitives) || 0));
+    var existingFugitives = Math.max(round(root.population && root.population.fugitives || 0), round(root.hukou && (root.hukou.refugees || root.hukou.fugitives) || 0));
+    if (options.authoritativePlayerPopulation === true && leaves.length && root.population._leafPopulationAuxAuthoritative !== true) {
+      var targetHidden = Math.max(totals.hiddenCount, scenarioHidden, existingHidden);
+      var targetFugitives = Math.max(totals.fugitives, existingFugitives);
+      var weights = {};
+      leaves.forEach(function(region, index) {
+        var id = String(region.id || region.name || ('region-' + index));
+        weights[id] = Math.max(0, number(byRegion[id] && byRegion[id].mouths, 0));
+      });
+      var hiddenAdditions = allocateExact(targetHidden - totals.hiddenCount, weights);
+      var fugitiveAdditions = allocateExact(targetFugitives - totals.fugitives, weights);
+      leaves.forEach(function(region, index) {
+        var id = String(region.id || region.name || ('region-' + index));
+        var row = byRegion[id];
+        row.hiddenCount = round(row.hiddenCount) + round(hiddenAdditions[id]);
+        row.hidden = row.hiddenCount;
+        row.fugitives = round(row.fugitives) + round(fugitiveAdditions[id]);
+        region.hiddenCount = row.hiddenCount;
+        region.hidden = row.hiddenCount;
+        region.fugitives = row.fugitives;
+      });
+      totals.hiddenCount = targetHidden;
+      totals.fugitives = targetFugitives;
+      root.population._leafPopulationAuxAuthoritative = true;
+    }
+    var hiddenCount = emptyAuthoritativePlayer ? 0 : (options.authoritativePlayerPopulation === true ? totals.hiddenCount : Math.max(totals.hiddenCount, scenarioHidden, existingHidden));
+    var fugitives = emptyAuthoritativePlayer ? 0 : (options.authoritativePlayerPopulation === true ? totals.fugitives : Math.max(totals.fugitives, existingFugitives));
     return {
       national: { households: households, mouths: mouths, ding: ding },
       hiddenCount: hiddenCount,
@@ -392,7 +462,7 @@
   function materializeCategories(root, config, aggregate) {
     var existing = root.population && root.population.byCategory || {};
     var descs = (config && config.categoryDescriptions) || {};
-    var enabled = unique((config && config.categoryEnabled) || Object.keys(existing));
+    var enabled = unique(((config && config.categoryEnabled) || Object.keys(existing)).concat(Object.keys(existing)));
     if (!enabled.length) enabled = ['bianhu', 'junhu', 'jianghu', 'sengdao', 'yuehu'];
     var rawShares = {};
     var totalShare = 0;
@@ -405,28 +475,21 @@
       totalShare = 0.98;
     }
     var out = {};
-    var assigned = { households: 0, mouths: 0, ding: 0 };
-    enabled.forEach(function(cat, idx) {
+    var allocations = {
+      households:allocateExact(aggregate.national.households, rawShares),
+      mouths:allocateExact(aggregate.national.mouths, rawShares),
+      ding:allocateExact(aggregate.national.ding, rawShares)
+    };
+    enabled.forEach(function(cat) {
       var desc = descs[cat] || (existing[cat] && (existing[cat].description || existing[cat].name)) || cat;
       var tmpl = templateForCategory(cat, desc);
-      var share = totalShare > 0 ? rawShares[cat] / totalShare : (1 / enabled.length);
-      var isLast = idx === enabled.length - 1;
-      var households = isLast ? Math.max(0, aggregate.national.households - assigned.households) : round(aggregate.national.households * share);
-      var mouths = isLast ? Math.max(0, aggregate.national.mouths - assigned.mouths) : round(aggregate.national.mouths * share);
-      var ding = isLast ? Math.max(0, aggregate.national.ding - assigned.ding) : round(aggregate.national.ding * share);
-      assigned.households += households;
-      assigned.mouths += mouths;
-      assigned.ding += ding;
-      out[cat] = Object.assign({}, tmpl, {
+      out[cat] = Object.assign({}, existing[cat] || {}, tmpl, {
         id: cat,
-        households: households,
-        mouths: mouths,
-        ding: ding,
+        households: allocations.households[cat] || 0,
+        mouths: allocations.mouths[cat] || 0,
+        ding: allocations.ding[cat] || 0,
         source: 'scenario-runtime-bridge'
       });
-    });
-    Object.keys(existing).forEach(function(cat) {
-      if (!out[cat]) out[cat] = clone(existing[cat]);
     });
     return out;
   }
@@ -442,37 +505,38 @@
     var fugitiveHouseholds = estimateHiddenHouseholds(aggregate.fugitives, national);
     var extras = clone(aggregate.byLegalStatus || {});
     ['huangji', 'baiji', 'taohu', 'yinhu'].forEach(function(key) { delete extras[key]; });
-    var classified = { households:0, mouths:0, ding:0 };
-    Object.keys(extras).forEach(function(key) {
-      classified.households += round(extras[key] && extras[key].households);
-      classified.mouths += round(extras[key] && extras[key].mouths);
-      classified.ding += round(extras[key] && extras[key].ding);
+    function legalWeights(field, total, hiddenValue, fugitiveValue) {
+      var weights = {};
+      var classified = 0;
+      Object.keys(extras).forEach(function(key) {
+        var value = round(extras[key] && extras[key][field]);
+        weights[key] = value;
+        classified += value;
+      });
+      hiddenValue = round(hiddenValue);
+      fugitiveValue = round(fugitiveValue);
+      var visible = Math.max(0, round(total) - hiddenValue - fugitiveValue - classified);
+      weights.huangji = visible * 0.94;
+      weights.baiji = visible * 0.06;
+      weights.taoohu = fugitiveValue;
+      weights.yinhu = hiddenValue;
+      return allocateExact(total, weights);
+    }
+    var allocations = {
+      households:legalWeights('households', national.households, hiddenHouseholds, fugitiveHouseholds),
+      mouths:legalWeights('mouths', national.mouths, aggregate.hiddenCount, aggregate.fugitives),
+      ding:legalWeights('ding', national.ding, round(aggregate.hiddenCount * 0.30), round(aggregate.fugitives * 0.30))
+    };
+    var out = {};
+    var keys = unique(Object.keys(extras).concat(['huangji', 'baiji', 'taoohu', 'yinhu']));
+    keys.forEach(function(key) {
+      out[key] = Object.assign({}, extras[key] || {}, {
+        households:allocations.households[key] || 0,
+        mouths:allocations.mouths[key] || 0,
+        ding:allocations.ding[key] || 0
+      });
     });
-    var visibleHouseholds = Math.max(0, national.households - hiddenHouseholds - fugitiveHouseholds - classified.households);
-    var visibleMouths = Math.max(0, national.mouths - aggregate.hiddenCount - aggregate.fugitives - classified.mouths);
-    var visibleDing = Math.max(0, national.ding - round((aggregate.hiddenCount + aggregate.fugitives) * 0.30) - classified.ding);
-    return Object.assign({}, extras, {
-      huangji: {
-        households: round(visibleHouseholds * 0.94),
-        mouths: round(visibleMouths * 0.94),
-        ding: round(visibleDing * 0.94)
-      },
-      baiji: {
-        households: round(visibleHouseholds * 0.06),
-        mouths: round(visibleMouths * 0.06),
-        ding: round(visibleDing * 0.06)
-      },
-      taoohu: {
-        households: fugitiveHouseholds,
-        mouths: round(aggregate.fugitives),
-        ding: round(aggregate.fugitives * 0.30)
-      },
-      yinhu: {
-        households: hiddenHouseholds,
-        mouths: round(aggregate.hiddenCount),
-        ding: round(aggregate.hiddenCount * 0.30)
-      }
-    });
+    return out;
   }
 
   function syncHukou(root, aggregate, options) {
@@ -493,6 +557,7 @@
     });
     root.population.hiddenCount = aggregate.hiddenCount;
     root.population.fugitives = aggregate.fugitives;
+    root.population.byLeafRegion = aggregate.byRegion;
     root.population.byRegion = aggregate.byRegion;
     root.population.byAge = clone(aggregate.byAge || {});
     root.population.ageLayers = clone(aggregate.byAge || {});

--- a/web/tm-integration-bridge.js
+++ b/web/tm-integration-bridge.js
@@ -341,8 +341,9 @@
         dd: Math.floor(nationalMouths / divCount * 0.25),
         mx: avgMx
       });
-      // 尝试从旧 GM.population.byRegion[div.id 或 div.name] 迁移
-      var legacyPop = G.population && G.population.byRegion && (G.population.byRegion[div.id] || G.population.byRegion[div.name]);
+      // 顶级人口代理已从叶级 byRegion 拆到 byProvince；旧档仍兼容读取 byRegion。
+      var provincePopulation = G.population && (G.population.byProvince || G.population.byRegion);
+      var legacyPop = provincePopulation && (provincePopulation[div.id] || provincePopulation[div.name]);
       if (legacyPop && legacyPop.mouths && !div._migrated) {
         div.population.mouths = legacyPop.mouths;
         div.population.households = legacyPop.households || Math.floor(legacyPop.mouths / 5);
@@ -394,15 +395,18 @@
   }
 
   function _updateLegacyProxies(G) {
-    // 为旧代码兼容，把 byRegion 对象重建为当前 division 的代理。
+    // population.byRegion 永久保持叶级粒度并与 populationDetail 同一引用；
+    // 顶级省/路代理独立放在 byProvince，不能再让一个字段在两种形状间切换。
     // 必须每次构造新表并原子替换；在旧对象上增量写会让已删除、合并或改 ID
     // 的区划继续作为“幽灵地区”参与后续户籍与财政结算。
     var topLevel = getTopLevelDivisions(G.adminHierarchy, 'player');
+    var leaves = getLeafDivisions(G.adminHierarchy, 'player');
     if (!G.population) G.population = {};
     if (!G.minxin) G.minxin = {};
     if (!G.fiscal) G.fiscal = {};
     if (!G.environment) G.environment = {};
-    var nextPopulation = {};
+    var nextLeafPopulation = {};
+    var nextProvincePopulation = {};
     var nextMinxin = {};
     var nextFiscal = {};
     var nextEnvironment = {};
@@ -410,8 +414,7 @@
 
     topLevel.forEach(function(div) {
       var id = String(div.id);
-      // byRegion.<id> 指向 division
-      nextPopulation[id] = div.population;
+      nextProvincePopulation[id] = div.population;
       // minxin byRegion 必须包含 .index（热力图读此字段）
       if (div.minxinDetails) {
         if (div.minxinDetails.index === undefined) {
@@ -427,7 +430,30 @@
       nextRegionMap[id] = div;
     });
 
-    G.population.byRegion = nextPopulation;
+    leaves.forEach(function(div, index) {
+      var id = String(div.id || div.name || ('region-' + index));
+      var detail = div.populationDetail && typeof div.populationDetail === 'object'
+        ? div.populationDetail
+        : (div.population && typeof div.population === 'object' ? div.population : {});
+      if (!detail || typeof detail !== 'object') detail = {};
+      if (!isFinite(Number(detail.mouths))) {
+        detail.mouths = typeof div.population === 'number' ? Number(div.population) || 0 : Number(div.mouths) || 0;
+      }
+      if (!isFinite(Number(detail.households))) detail.households = Math.round((Number(detail.mouths) || 0) / 5);
+      if (!isFinite(Number(detail.ding))) detail.ding = Math.round((Number(detail.mouths) || 0) * 0.25);
+      detail.id = id;
+      detail.name = div.name || id;
+      detail.regionType = div.regionType || div.type || div.kind || detail.regionType || '';
+      detail.hiddenCount = Math.max(0, Math.round(Number(detail.hiddenCount != null ? detail.hiddenCount : detail.hidden) || 0));
+      detail.hidden = detail.hiddenCount;
+      detail.fugitives = Math.max(0, Math.round(Number(detail.fugitives) || 0));
+      div.populationDetail = detail;
+      nextLeafPopulation[id] = detail;
+    });
+
+    G.population.byLeafRegion = nextLeafPopulation;
+    G.population.byRegion = nextLeafPopulation;
+    G.population.byProvince = nextProvincePopulation;
     G.minxin.byRegion = nextMinxin;
     G.fiscal.regions = nextFiscal;
     G.environment.byRegion = nextEnvironment;
@@ -703,7 +729,7 @@
   }
 
   // ═══════════════════════════════════════════════════════════════════
-  //  反向：AI 改 byRegion → 同步到 division
+  //  反向：AI 改区域代理 → 同步到 division
   // ═══════════════════════════════════════════════════════════════════
 
   function syncDivisionFromByRegion(rid) {
@@ -712,8 +738,8 @@
     var topLevel = getTopLevelDivisions(G.adminHierarchy, 'player');
     var div = topLevel.find(function(d) { return d.id === rid || d.name === rid; });
     if (!div) return;
-    if (G.population && G.population.byRegion && G.population.byRegion[rid] && div.population !== G.population.byRegion[rid]) {
-      // 已经是同一引用（代理），无需复制
+    if (G.population && G.population.byProvince && G.population.byProvince[rid] && div.population !== G.population.byProvince[rid]) {
+      div.population = G.population.byProvince[rid];
     }
     if (G.minxin && G.minxin.byRegion && G.minxin.byRegion[rid]) {
       div.minxinDetails = G.minxin.byRegion[rid];


### PR DESCRIPTION
## Summary
- materialize census discoveries in authoritative leaf population ledgers and convert hidden mouths to households with local ratios
- keep `population.byRegion` permanently leaf-scoped while exposing top-level compatibility rows through `population.byProvince`
- use exact integer allocation for qiaozhi scalar fields, population categories, and legal statuses
- add failure-injection, multi-level hierarchy, and 0-100 population conservation coverage

## Verification
- `node web/scripts/ci-smokes.js` — PASS, 852 selected / 850 direct pass / 2 missing-asset allowlist exemptions
- `node web/scripts/lint-arch-all.js` — PASS 8/8
- `node web/scripts/verify-official-scenario-parity.js` — PASS 27 assertions
- `node scripts/verify-release-contract.js` — PASS 166 assertions
- `node scripts/sync-hot-baseline.js --check --version 1.3.4.11 --asset-root C:\Users\37814\Desktop\tianming --temp-root E:\MovedFromC\Desktop_tianming_.claude_worktrees` — PASS 1082 files
- `npm audit --omit=dev --audit-level=high --registry=https://registry.npmjs.org` — 0 vulnerabilities

No package, version, or release action was performed.