### PR TITLE
fix: close seventeenth-round audit environment ledger gaps

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-22T11:35:20.537Z",
+  "generatedAt": "2026-08-22T13:00:13.952Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -2161,7 +2161,7 @@
     },
     {
       "path": "index.html",
-      "sha256": "1a2fb3b7e9b80cebdfa26408ced21a4e2ce28b9e546e0bbe19438e0393e4c0a4",
+      "sha256": "789cffb0d89a075f0f0d9cbb0957284edc3f6d06f0088f04a82dba9fff2d671f",
       "size": 68643
     },
     {
@@ -3821,8 +3821,8 @@
     },
     {
       "path": "tm-economy-engine.js",
-      "sha256": "7619e6a9c583cd6fb8188fe8cb56e079b316789f2e5edf86da97486ae98e569f",
-      "size": 106183
+      "sha256": "15665d9ff9198ffc984e77009dd3871da3fc3ab2ea34ba1b55d07ae47040f7f3",
+      "size": 118819
     },
     {
       "path": "tm-economy.js",
@@ -4016,8 +4016,8 @@
     },
     {
       "path": "tm-endturn-systems.js",
-      "sha256": "7b9dd289b65b694c94e1bf8cefac0764ded466dc582d6d3d9b5c9d4dafe2a715",
-      "size": 39504
+      "sha256": "d66e884b438f72ac5fa7b1145c42daa464daf10e2144cb19a9195e6129d53865",
+      "size": 39518
     },
     {
       "path": "tm-endturn-timing-ledger.js",
@@ -4326,8 +4326,8 @@
     },
     {
       "path": "tm-huji-runtime-bridge.js",
-      "sha256": "cba4532ad4619ab66b4145fff3d2a27e49f5c2fb1435ec3be2fd75471ce387ad",
-      "size": 66667
+      "sha256": "1c2f67cc510b3b7c7877f59e6a30f4a949703ea8b497bc40d1bc9498459955fd",
+      "size": 69040
     },
     {
       "path": "tm-indices.js",
@@ -4341,8 +4341,8 @@
     },
     {
       "path": "tm-integration-bridge.js",
-      "sha256": "cbd9d0d257fe19960215944d205aa6ba22ab2bb7f583b9cdfd31faaee1b68312",
-      "size": 40572
+      "sha256": "caddb856ca64331d846263a07d3bb47627b168c6af572e22aeabdb5ec683430d",
+      "size": 41054
     },
     {
       "path": "tm-invariants.js",

--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-22T13:00:13.952Z",
+  "generatedAt": "2026-08-22T14:09:14.926Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -2161,8 +2161,8 @@
     },
     {
       "path": "index.html",
-      "sha256": "789cffb0d89a075f0f0d9cbb0957284edc3f6d06f0088f04a82dba9fff2d671f",
-      "size": 68643
+      "sha256": "b76c384e09305ad2f51427cb25adc58fc379057f7f5a6591c251da369357ef29",
+      "size": 68647
     },
     {
       "path": "INDEX.md",
@@ -3821,8 +3821,8 @@
     },
     {
       "path": "tm-economy-engine.js",
-      "sha256": "15665d9ff9198ffc984e77009dd3871da3fc3ab2ea34ba1b55d07ae47040f7f3",
-      "size": 118819
+      "sha256": "98f9bddf5ef736357f63cf1856d18a3812eb9c087716e25f4c680d55945211ce",
+      "size": 121718
     },
     {
       "path": "tm-economy.js",
@@ -4951,8 +4951,8 @@
     },
     {
       "path": "tm-patches-start.js",
-      "sha256": "c1df9437314f74a89364c1aea680851d94b2a82ade151f50b67e036e16db543a",
-      "size": 114927
+      "sha256": "107c06b6c280fab3a7cb097485a24986d89784b8b7469978f876690caa78a441",
+      "size": 115422
     },
     {
       "path": "tm-patches.js",

--- a/web/index.html
+++ b/web/index.html
@@ -654,7 +654,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-world-digest.js?v=20260630"></script><!-- 天下牵动·因果综述·W1a·把割裂的系统反应重组成连贯因果注入推演 -->
 <script src="tm-benji.js?v=20260707"></script><!-- 帝王本纪·终局回顾式修史(鼎革R1g·每12回合一卷串行修纂·flag benjiEnabled) -->
 <script src="tm-world-reactors.js?v=20260630"></script><!-- 世界反应总线·跨系统reactor·W2a军事→势力·flag-gated默认关 -->
-<script src="tm-endturn-systems.js?v=20260822-auditfix14"></script>
+<script src="tm-endturn-systems.js?v=20260822-auditfix17"></script>
 <script src="tm-endturn-ai-helpers.js?v=2026042714"></script>
 <script src="tm-endturn-ai-context.js?v=2026050401"></script>
 <script src="tm-history-events.js?v=20260719-histanchors"></script>
@@ -872,13 +872,13 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-ceming.js?v=2026042817"></script>
 <script src="tm-char-economy-ui.js?v=2026042714"></script>
 <script src="tm-char-full-schema.js?v=2026042714"></script>
-<script src="tm-economy-engine-currency.js?v=20260821-auditfix13"></script><!-- 立项拆分：§A CurrencyUnit+§B CurrencyEngine 两整IIFE·紧挨 economy-engine 之前保序·勿动位置 -->
-<script src="tm-economy-engine.js?v=20260821-auditfix13"></script>
+<script src="tm-economy-engine-currency.js?v=20260822-auditfix17"></script><!-- 立项拆分：§A CurrencyUnit+§B CurrencyEngine 两整IIFE·紧挨 economy-engine 之前保序·勿动位置 -->
+<script src="tm-economy-engine.js?v=20260822-auditfix17"></script>
 <script src="tm-central-local-engine.js?v=20260709"></script>
 <script src="tm-huji-engine.js?v=20260822-auditfix16"></script>
 <script src="tm-edict-parser.js?v=20260709"></script>
 <script src="tm-huji-deep-fill.js?v=20260822-auditfix14"></script>
-<script src="tm-huji-runtime-bridge.js?v=20260822-auditfix16"></script>
+<script src="tm-huji-runtime-bridge.js?v=20260822-auditfix17"></script>
 <script src="tm-huji-governance-loop.js?v=20260602-huji-governance-loop"></script>
 <script src="tm-edict-complete.js?v=2026050701"></script>
 <script src="tm-env-recovery-fill.js?v=20260709"></script>
@@ -912,7 +912,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-ethnic-religion.js?v=2026050701"></script>
 <script src="tm-edict-thresholds.js?v=2026042714"></script>
 <script src="tm-fiscal-ui.js?v=2026042714"></script>
-<script src="tm-integration-bridge.js?v=20260822-auditfix16"></script>
+<script src="tm-integration-bridge.js?v=20260822-auditfix17"></script>
 <script src="tm-fiscal-engine.js?v=20260811-auditfix1"></script>
 <script src="tm-perf.js?v=2026042714"></script>
 <script src="tm-invariants.js?v=2026042714"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -720,8 +720,8 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-endturn-progress.js?v=20260620-agentbeats"></script>
 <script src="tm-endturn-loading.js?v=20260620-agentbeats"></script>
 <script src="tm-theme-font.js?v=20260520-theme-font-scopes"></script>
-<script src="tm-patches.js?v=20260822-auditfix15"></script>
-<script src="tm-patches-start.js?v=20260822-auditfix15"></script><!-- 立项拆分：剧本启动链(_tmStart*/开场仪典/startGame/doActualStart)·紧挨 patches 之后保序·勿动位置 -->
+<script src="tm-patches.js?v=20260822-auditfix17b"></script>
+<script src="tm-patches-start.js?v=20260822-auditfix17b"></script><!-- 立项拆分：剧本启动链(_tmStart*/开场仪典/startGame/doActualStart)·紧挨 patches 之后保序·勿动位置 -->
 <!-- R17-R22: 从 tm-patches.js 抽离的子模块（加载在 patches 之后覆盖原版） -->
 <script src="tm-military-ui.js?v=2026042714"></script>
 <script src="tm-world-view.js?v=2026042714"></script>
@@ -872,8 +872,8 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-ceming.js?v=2026042817"></script>
 <script src="tm-char-economy-ui.js?v=2026042714"></script>
 <script src="tm-char-full-schema.js?v=2026042714"></script>
-<script src="tm-economy-engine-currency.js?v=20260822-auditfix17"></script><!-- 立项拆分：§A CurrencyUnit+§B CurrencyEngine 两整IIFE·紧挨 economy-engine 之前保序·勿动位置 -->
-<script src="tm-economy-engine.js?v=20260822-auditfix17"></script>
+<script src="tm-economy-engine-currency.js?v=20260822-auditfix17b"></script><!-- 立项拆分：§A CurrencyUnit+§B CurrencyEngine 两整IIFE·紧挨 economy-engine 之前保序·勿动位置 -->
+<script src="tm-economy-engine.js?v=20260822-auditfix17b"></script>
 <script src="tm-central-local-engine.js?v=20260709"></script>
 <script src="tm-huji-engine.js?v=20260822-auditfix16"></script>
 <script src="tm-edict-parser.js?v=20260709"></script>

--- a/web/scripts/smoke-economy-env-huangquan.js
+++ b/web/scripts/smoke-economy-env-huangquan.js
@@ -9,6 +9,7 @@ const vm = require('vm');
 
 const ROOT = path.resolve(__dirname, '..');
 const src = (fs.readFileSync(path.join(ROOT, 'tm-economy-engine-currency.js'), 'utf8') + '\n' + fs.readFileSync(path.join(ROOT, 'tm-economy-engine.js'), 'utf8'));
+const hujiSource = fs.readFileSync(path.join(ROOT, 'tm-huji-engine.js'), 'utf8');
 
 let assertions = 0;
 function assert(cond, msg) {
@@ -18,6 +19,23 @@ function assert(cond, msg) {
 
 const math = Object.create(Math);
 math.random = () => 1;
+
+function makeLeaf(id, name, mouths) {
+  return {
+    id,
+    name,
+    populationDetail: {
+      mouths,
+      households: Math.round(mouths / 5),
+      ding: Math.round(mouths * 0.3),
+      byAge: { child: Math.round(mouths * 0.2), adult: mouths - Math.round(mouths * 0.2) },
+      byGender: { male: Math.floor(mouths / 2), female: mouths - Math.floor(mouths / 2) }
+    }
+  };
+}
+
+const countyA = makeLeaf('capital-east', '京东县', 600000);
+const countyB = makeLeaf('capital-west', '京西县', 500000);
 
 const authorityCalls = [];
 const ctx = {
@@ -38,9 +56,19 @@ const ctx = {
     sid: 'smoke',
     turn: 12,
     regions: [{ id: 'capital', unrest: 30, disasterLevel: 0 }],
+    adminHierarchy: {
+      player: {
+        factionId: 'player-faction',
+        divisions: [{ id: 'capital', name: '京畿省', children: [countyA, countyB] }]
+      }
+    },
     population: {
-      byRegion: { capital: { mouths: 1100000, yearlyDeaths: 0 } },
-      national: { mouths: 1100000 }
+      byRegion: {
+        'capital-east': countyA.populationDetail,
+        'capital-west': countyB.populationDetail
+      },
+      national: { mouths: 1100000, households: 220000, ding: 330000 },
+      dynamics: { yearlyLog: [] }
     },
     minxin: { trueIndex: 60 },
     huangquan: { index: 55 },
@@ -85,6 +113,10 @@ const ctx = {
       }
     }
   },
+  P: { id: 'smoke', conf: {}, time: { daysPerTurn: 30 }, playerInfo: { factionName: 'player-faction' } },
+  IntegrationBridge: {
+    getTopLevelDivisions(hierarchy) { return hierarchy.player.divisions; }
+  },
   _adjAuthority(key, delta, reason, meta) {
     authorityCalls.push({ key, delta, reason, meta });
     if (key === 'minxin') ctx.GM.minxin.trueIndex += delta;
@@ -101,13 +133,105 @@ ctx.globalThis = ctx;
 
 vm.createContext(ctx);
 vm.runInContext(src, ctx, { filename: 'tm-economy-engine.js' });
+vm.runInContext(hujiSource, ctx, { filename: 'tm-huji-engine.js' });
 
 const beforeHuangquan = ctx.GM.huangquan.index;
-ctx.EnvCapacityEngine.tick({ monthRatio: 1, turn: ctx.GM.turn });
+const beforePopulation = countyA.populationDetail.mouths + countyB.populationDetail.mouths;
+ctx.EnvCapacityEngine.tick({ monthRatio: 1, turn: ctx.GM.turn, strict: true });
+const afterPopulation = countyA.populationDetail.mouths + countyB.populationDetail.mouths;
 
 assert(ctx.GM.environment.nationalLoad > 1.2, 'fixture should remain overloaded after recompute');
+assert(Math.abs(ctx.GM.environment.byRegion.capital.currentLoad
+  - beforePopulation / ctx.GM.environment.byRegion.capital.carryingMax) < 1e-9,
+'province carrying load should use the real sum of child-leaf population');
+assert(ctx.GM.environment.byRegion.capital.carrying.housingSupport === beforePopulation * 1.1,
+  'province housing support should never fall back to a fictitious fixed population');
+assert(afterPopulation < beforePopulation, 'province overload should debit authoritative child leaves');
+assert(ctx.GM.population.mortalityLedger.some(row => /^environment-overload:/.test(row.cause)),
+'environment overload should be recorded by the Huji mortality ledger');
+[countyA, countyB].forEach(leaf => {
+  const detail = leaf.populationDetail;
+  const ageTotal = Object.values(detail.byAge || {}).reduce((sum, value) => sum + Number(value || 0), 0);
+  const genderTotal = Object.values(detail.byGender || {}).reduce((sum, value) => sum + Number(value || 0), 0);
+  assert(ageTotal === detail.mouths && genderTotal === detail.mouths,
+    'overload mortality should keep each leaf demographic bundle exact');
+});
 assert(authorityCalls.some(call => call.key === 'minxin'), 'overload should still affect minxin');
 assert(!authorityCalls.some(call => call.key === 'huangquan'), 'environment capacity must not adjust huangquan');
 assert(ctx.GM.huangquan.index === beforeHuangquan, 'huangquan index should remain unchanged by environment capacity');
+
+const realLoss = ctx.HujiEngine.applyPopulationLoss;
+let injectedCalls = 0;
+ctx.HujiEngine.applyPopulationLoss = options => {
+  injectedCalls += 1;
+  if (injectedCalls === 2) throw new Error('environment-second-leaf-failure');
+  return { ok: true, mouths: options.mouths };
+};
+let strictFailure = null;
+try {
+  ctx.EnvCapacityEngine.tick({ monthRatio: 1, turn: ctx.GM.turn, strict: true });
+} catch (error) {
+  strictFailure = error;
+}
+ctx.HujiEngine.applyPopulationLoss = realLoss;
+assert(strictFailure && /environment-second-leaf-failure/.test(strictFailure.message) && injectedCalls === 2,
+  'strict environment tick should propagate an internal partial-leaf failure');
+
+function resetLeafPopulation(leaf, mouths) {
+  const detail = leaf.populationDetail;
+  detail.mouths = mouths;
+  detail.households = Math.round(mouths / 5);
+  detail.ding = Math.round(mouths * 0.3);
+  detail.byAge = { child: Math.round(mouths * 0.2), adult: mouths - Math.round(mouths * 0.2) };
+  detail.byGender = { male: Math.floor(mouths / 2), female: mouths - Math.floor(mouths / 2) };
+}
+resetLeafPopulation(countyA, 50000);
+resetLeafPopulation(countyB, 50000);
+ctx.GM.population.national = { mouths: 100000, households: 20000, ding: 30000 };
+ctx.GM.environment.byRegion.capital.ecoScars.riverSilting = 0.6;
+ctx.GM.environment.byRegion.capital._crisis_huaihe_flood = 0;
+let crisisRolls = 0;
+math.random = () => crisisRolls++ === 0 ? 0 : 1;
+const crisisPopulationBefore = countyA.populationDetail.mouths + countyB.populationDetail.mouths;
+const successfulHistoryBefore = ctx.GM.environment.crisisHistory.length;
+ctx.EnvCapacityEngine.tick({ monthRatio: 1, turn: ctx.GM.turn, strict: true });
+assert(countyA.populationDetail.mouths + countyB.populationDetail.mouths === crisisPopulationBefore - 8000
+  && ctx.GM.environment.crisisHistory.length === successfulHistoryBefore + 1
+  && ctx.GM.environment.crisisHistory[ctx.GM.environment.crisisHistory.length - 1].id === 'huaihe_flood',
+'province crisis should debit child leaves before committing one matching history record');
+
+countyA.populationDetail.mouths = 500;
+countyB.populationDetail.mouths = 500;
+ctx.GM.environment.byRegion.capital.ecoScars.riverSilting = 0.6;
+ctx.GM.environment.byRegion.capital._crisis_huaihe_flood = 0;
+const crisisHistoryBefore = ctx.GM.environment.crisisHistory.length;
+crisisRolls = 0;
+math.random = () => crisisRolls++ === 0 ? 0 : 1;
+ctx.HujiEngine.applyPopulationLoss = () => ({ ok: false, reason: 'injected-crisis-ledger-failure', mouths: 0 });
+let crisisFailure = null;
+try {
+  ctx.EnvCapacityEngine.tick({ monthRatio: 1, turn: ctx.GM.turn, strict: true });
+} catch (error) {
+  crisisFailure = error;
+}
+ctx.HujiEngine.applyPopulationLoss = realLoss;
+assert(crisisFailure && /injected-crisis-ledger-failure/.test(crisisFailure.message)
+  && ctx.GM.environment.crisisHistory.length === crisisHistoryBefore
+  && !ctx.GM.environment.byRegion.capital._crisis_huaihe_flood,
+'failed crisis mortality should propagate before crisis history or cooldown markers are committed');
+
+const hierarchy = ctx.GM.adminHierarchy;
+delete ctx.GM.adminHierarchy;
+const scarBeforeUnresolvedMapping = ctx.GM.environment.byRegion.capital.ecoScars.deforestation;
+let mappingFailure = null;
+try {
+  ctx.EnvCapacityEngine.tick({ monthRatio: 1, turn: ctx.GM.turn, strict: true });
+} catch (error) {
+  mappingFailure = error;
+}
+ctx.GM.adminHierarchy = hierarchy;
+assert(mappingFailure && /无法解析人口层级/.test(mappingFailure.message)
+  && ctx.GM.environment.byRegion.capital.ecoScars.deforestation === scarBeforeUnresolvedMapping,
+'strict environment tick should fail before mutation when a province cannot resolve authoritative leaves');
 
 console.log('[smoke-economy-env-huangquan] pass assertions=' + assertions);

--- a/web/scripts/smoke-economy-env-huangquan.js
+++ b/web/scripts/smoke-economy-env-huangquan.js
@@ -131,9 +131,128 @@ ctx.window = ctx;
 ctx.global = ctx;
 ctx.globalThis = ctx;
 
+function runOverloadTierCase(load) {
+  const mouths = Math.round(load * 100000);
+  const leaf = makeLeaf('tier-county', '分级县', mouths);
+  const calls = [];
+  const tierMath = Object.create(Math);
+  tierMath.random = () => 1;
+  const tierCtx = {
+    console,
+    Date,
+    JSON,
+    Math: tierMath,
+    Object,
+    Array,
+    Number,
+    String,
+    Boolean,
+    parseInt,
+    parseFloat,
+    isFinite,
+    TM: { errors: { capture() {}, captureSilent() {} } },
+    GM: {
+      sid: 'overload-tier-' + String(load),
+      turn: 12,
+      regions: [{ id: 'tier-province', unrest: 30, disasterLevel: 0 }],
+      adminHierarchy: {
+        player: {
+          factionId: 'player-faction',
+          divisions: [{ id: 'tier-province', name: '分级省', children: [leaf] }]
+        }
+      },
+      population: {
+        byRegion: { 'tier-county': leaf.populationDetail },
+        national: {
+          mouths,
+          households: leaf.populationDetail.households,
+          ding: leaf.populationDetail.ding
+        },
+        dynamics: { yearlyLog: [] }
+      },
+      minxin: { trueIndex: 60 },
+      environment: {
+        _inited: true,
+        techEra: '汉',
+        nationalLoad: load,
+        nationalCarrying: {},
+        activePolicies: [],
+        crisisHistory: [],
+        byRegion: {
+          'tier-province': {
+            carrying: {},
+            carryingMax: 100000,
+            ecoScars: {
+              deforestation: 0,
+              soilErosion: 0,
+              waterTableDrop: 0,
+              riverSilting: 0,
+              soilFertilityLoss: 0,
+              salinization: 0,
+              desertification: 0,
+              biodiversityLoss: 0,
+              urbanSewageOverload: 0
+            },
+            currentLoad: load,
+            forestArea: 100000,
+            coalReserve: 0,
+            aquiferLevel: 1,
+            riverFlow: 1,
+            arableArea: 100000,
+            soilFertility: 1,
+            techLevel: {}
+          }
+        }
+      }
+    },
+    P: {
+      id: 'overload-tier-' + String(load),
+      conf: {},
+      time: { daysPerTurn: 30 },
+      playerInfo: { factionName: 'player-faction' }
+    },
+    IntegrationBridge: {
+      getTopLevelDivisions(hierarchy) { return hierarchy.player.divisions; }
+    },
+    _adjAuthority(key, delta) {
+      calls.push({ key, delta });
+      return { ok: true };
+    },
+    addEB() {},
+    turnsForMonths(months) { return months; },
+    findScenarioById() { return null; }
+  };
+  tierCtx.window = tierCtx;
+  tierCtx.global = tierCtx;
+  tierCtx.globalThis = tierCtx;
+  vm.createContext(tierCtx);
+  vm.runInContext(src, tierCtx, { filename: 'tm-economy-engine.js' });
+  vm.runInContext(hujiSource, tierCtx, { filename: 'tm-huji-engine.js' });
+  tierCtx.EnvCapacityEngine.tick({ monthRatio: 1, turn: tierCtx.GM.turn, strict: true });
+  const region = tierCtx.GM.regions[0];
+  return {
+    unrest: region.unrest - 30,
+    disaster: region.disasterLevel,
+    minxin: calls.filter(call => call.key === 'minxin' && call.delta < 0)
+      .reduce((sum, call) => sum + call.delta, 0)
+  };
+}
+
 vm.createContext(ctx);
 vm.runInContext(src, ctx, { filename: 'tm-economy-engine.js' });
 vm.runInContext(hujiSource, ctx, { filename: 'tm-huji-engine.js' });
+
+const lightOverload = runOverloadTierCase(1.10);
+const mediumOverload = runOverloadTierCase(1.30);
+const severeOverload = runOverloadTierCase(1.60);
+assert(lightOverload.unrest === 0 && lightOverload.disaster === 0 && lightOverload.minxin === 0,
+  'level-one overload should not fall through to level-three collapse effects');
+assert(mediumOverload.unrest === 3 && mediumOverload.disaster === 0 && mediumOverload.minxin === -0.2,
+  'level-two overload should apply only the famine-tier social effects');
+assert(severeOverload.unrest === 8 && severeOverload.disaster === 0.05 && severeOverload.minxin === -0.5,
+  'level-three overload should apply the strongest collapse effects');
+assert(lightOverload.unrest < mediumOverload.unrest && mediumOverload.unrest < severeOverload.unrest,
+  'overload social penalties should increase monotonically across all three tiers');
 
 const beforeHuangquan = ctx.GM.huangquan.index;
 const beforePopulation = countyA.populationDetail.mouths + countyB.populationDetail.mouths;

--- a/web/scripts/smoke-economy-env-huangquan.js
+++ b/web/scripts/smoke-economy-env-huangquan.js
@@ -238,6 +238,109 @@ function runOverloadTierCase(load) {
   };
 }
 
+function runZeroResourceCase() {
+  const leaf = makeLeaf('barren-county', '荒县', 10000);
+  const zeroMath = Object.create(Math);
+  zeroMath.random = () => 1;
+  const zeroCtx = {
+    console,
+    Date,
+    JSON,
+    Math: zeroMath,
+    Object,
+    Array,
+    Number,
+    String,
+    Boolean,
+    parseInt,
+    parseFloat,
+    isFinite,
+    TM: { errors: { capture() {}, captureSilent() {} } },
+    GM: {
+      sid: 'zero-environment-resources',
+      turn: 12,
+      regions: [{ id: 'barren', unrest: 0, disasterLevel: 0 }],
+      guoku: { money: 1000000, grain: 500000, cloth: 0 },
+      adminHierarchy: {
+        player: {
+          factionId: 'player-faction',
+          divisions: [{ id: 'barren', name: '荒芜省', children: [leaf] }]
+        }
+      },
+      population: {
+        byRegion: { 'barren-county': leaf.populationDetail },
+        national: { mouths: 10000, households: 2000, ding: 3000 },
+        dynamics: { yearlyLog: [] }
+      },
+      minxin: { trueIndex: 60 }
+    },
+    P: {
+      id: 'zero-environment-resources',
+      dynasty: '汉',
+      conf: {},
+      time: { daysPerTurn: 30 },
+      playerInfo: { factionName: 'player-faction' },
+      environmentConfig: {
+        initialCarrying: {
+          byRegion: {
+            barren: {
+              farmlandSupport: 0,
+              waterSupport: 0,
+              fuelSupport: 0,
+              housingSupport: 0,
+              sanitationSupport: 0,
+              forestArea: 0,
+              coalReserve: 0,
+              aquiferLevel: 0,
+              riverFlow: 0,
+              arableArea: 0,
+              soilFertility: 0
+            }
+          }
+        }
+      }
+    },
+    IntegrationBridge: {
+      getTopLevelDivisions(hierarchy) { return hierarchy.player.divisions; }
+    },
+    FiscalEngine: {
+      spendFromGuoku(cost) {
+        const deducted = {};
+        ['money', 'grain', 'cloth'].forEach(kind => {
+          const amount = Number(cost[kind]) || 0;
+          zeroCtx.GM.guoku[kind] -= amount;
+          deducted[kind] = { deducted: amount, deficit: 0 };
+        });
+        return { ok: true, deducted };
+      }
+    },
+    _adjAuthority() { return { ok: true }; },
+    addEB() {},
+    turnsForMonths(months) { return months; },
+    findScenarioById() { return zeroCtx.P; }
+  };
+  zeroCtx.window = zeroCtx;
+  zeroCtx.global = zeroCtx;
+  zeroCtx.globalThis = zeroCtx;
+  vm.createContext(zeroCtx);
+  vm.runInContext(src, zeroCtx, { filename: 'tm-economy-engine.js' });
+  zeroCtx.EnvCapacityEngine.init(zeroCtx.P);
+  const row = zeroCtx.GM.environment.byRegion.barren;
+  ['forestArea', 'coalReserve', 'aquiferLevel', 'riverFlow', 'arableArea', 'soilFertility'].forEach(field => {
+    assert(row[field] === 0, 'explicit zero ' + field + ' should survive environment initialization');
+  });
+  zeroCtx.EnvCapacityEngine.tick({ monthRatio: 1, turn: zeroCtx.GM.turn, strict: true });
+  assert(row.forestArea === 0 && row.aquiferLevel === 0 && row.riverFlow === 0
+    && row.arableArea === 0 && row.soilFertility === 0,
+  'environment recomputation and passive decay must not revive zero natural resources');
+  const technology = zeroCtx.EnvCapacityEngine.enactPolicy('tech_investment', 'barren');
+  assert(technology && technology.ok && row.arableArea === 0 && row.forestArea === 0,
+    'percentage technology boosts must not conjure arable land or forest from zero');
+  const recovery = zeroCtx.EnvCapacityEngine.enactPolicy('disaster_recovery', 'barren');
+  assert(recovery && recovery.ok && row.arableArea === 0 && Math.abs(row.soilFertility - 0.05) < 1e-12,
+    'disaster recovery should add only its explicit fertility boost to a zero-resource region');
+}
+
 vm.createContext(ctx);
 vm.runInContext(src, ctx, { filename: 'tm-economy-engine.js' });
 vm.runInContext(hujiSource, ctx, { filename: 'tm-huji-engine.js' });
@@ -253,6 +356,7 @@ assert(severeOverload.unrest === 8 && severeOverload.disaster === 0.05 && severe
   'level-three overload should apply the strongest collapse effects');
 assert(lightOverload.unrest < mediumOverload.unrest && mediumOverload.unrest < severeOverload.unrest,
   'overload social penalties should increase monotonically across all three tiers');
+runZeroResourceCase();
 
 const beforeHuangquan = ctx.GM.huangquan.index;
 const beforePopulation = countyA.populationDetail.mouths + countyB.populationDetail.mouths;

--- a/web/scripts/smoke-endturn-transaction-failures.js
+++ b/web/scripts/smoke-endturn-transaction-failures.js
@@ -60,6 +60,7 @@ function resetWorld(extra) {
   delete ctx.CorruptionEngine;
   delete ctx.HujiEngine;
   delete ctx.HujiDeepFill;
+  delete ctx.EnvCapacityEngine;
   delete ctx.updateProvinceEconomy;
   delete ctx.IntegrationBridge;
   delete ctx.TMArmory;
@@ -150,6 +151,23 @@ async function main() {
   ok(await expectFailure(ctx._endTurn_updateSystems(1, ''), 'guoku-ledger-failure'), 'treasury failure propagates after an intermediate turn increment');
   ctx._tmRollbackEndTurnTransaction(txn, new Error('guoku-ledger-failure'));
   ok(ctx.GM.treasury === 50 && ctx.GM.turn === 4, 'partial treasury mutation and turn increment roll back atomically');
+
+  resetWorld({ environment: { byRegion: { first: { scar: 0 } }, crisisHistory: [] } });
+  txn = ctx._tmCaptureEndTurnTransaction();
+  let environmentStrict = false;
+  ctx.EnvCapacityEngine = {
+    tick(options) {
+      environmentStrict = options && options.strict === true;
+      ctx.GM.environment.byRegion.first.scar = 0.75;
+      ctx.GM.environment.crisisHistory.push({ id: 'partial-environment-crisis' });
+      throw new Error('environment-ledger-failure');
+    }
+  };
+  ok(await expectFailure(ctx._endTurn_updateSystems(1, ''), 'environment-ledger-failure') && environmentStrict,
+    'strict environment failure propagates out of systems after partial state writes');
+  ctx._tmRollbackEndTurnTransaction(txn, new Error('environment-ledger-failure'));
+  ok(ctx.GM.environment.byRegion.first.scar === 0 && ctx.GM.environment.crisisHistory.length === 0,
+    'partial environment and crisis history writes roll back atomically');
 
   resetWorld({
     environment: { nationalLoad: 0.5 }, vars: { disasterLevel: 0 }, activeWars: [],

--- a/web/scripts/smoke-env-policy-complete-chain.js
+++ b/web/scripts/smoke-env-policy-complete-chain.js
@@ -16,9 +16,45 @@ function load(ctx, rel) {
   vm.runInContext(fs.readFileSync(path.join(ROOT, rel), 'utf8'), ctx, { filename: rel });
 }
 
+function makeLeaf(id, name, mouths) {
+  const child = Math.round(mouths * 0.2);
+  return {
+    id,
+    name,
+    populationDetail: {
+      mouths,
+      households: Math.round(mouths / 5),
+      ding: Math.round(mouths * 0.3),
+      byAge: { child, adult: mouths - child },
+      byGender: { male: Math.floor(mouths / 2), female: mouths - Math.floor(mouths / 2) }
+    }
+  };
+}
+
+function demographicTotal(leaves) {
+  return leaves.reduce((out, leaf) => {
+    const detail = leaf.populationDetail;
+    out.mouths += detail.mouths;
+    out.households += detail.households;
+    out.ding += detail.ding;
+    Object.keys(detail.byAge || {}).forEach(key => { out.byAge[key] = (out.byAge[key] || 0) + detail.byAge[key]; });
+    Object.keys(detail.byGender || {}).forEach(key => { out.byGender[key] = (out.byGender[key] || 0) + detail.byGender[key]; });
+    return out;
+  }, { mouths: 0, households: 0, ding: 0, byAge: {}, byGender: {} });
+}
+
+const mountainLeaves = [
+  makeLeaf('mountain-east', '东山县', 600000),
+  makeLeaf('mountain-west', '西山县', 300000)
+];
+const plainLeaves = [makeLeaf('plain-center', '平原县', 300000)];
+const allLeaves = mountainLeaves.concat(plainLeaves);
+const math = Object.create(Math);
+math.random = () => 1;
+
 const ctx = {
   console,
-  Math, Date, JSON, RegExp, Error,
+  Math: math, Date, JSON, RegExp, Error,
   Array, Object, String, Number, Boolean,
   parseInt, parseFloat, isFinite, isNaN,
   setTimeout() { return 1; },
@@ -39,18 +75,33 @@ ctx.GM = {
   ],
   guoku: { money: 1000000, grain: 500000 },
   minxin: { trueIndex: 58 },
+  adminHierarchy: {
+    player: {
+      factionId: 'player-faction',
+      divisions: [
+        { id: 'mountain', name: '山地府', children: mountainLeaves },
+        { id: 'plain', name: '平原府', children: plainLeaves }
+      ]
+    }
+  },
   population: {
+    _inited: true,
     national: { households: 240000, mouths: 1200000, ding: 360000 },
     byRegion: {
-      mountain: { households: 160000, mouths: 900000, ding: 270000, yearlyNetMigration: 0, yearlyDeaths: 0 },
-      plain: { households: 80000, mouths: 300000, ding: 90000, yearlyNetMigration: 0, yearlyDeaths: 0 }
-    }
+      'mountain-east': mountainLeaves[0].populationDetail,
+      'mountain-west': mountainLeaves[1].populationDetail,
+      'plain-center': plainLeaves[0].populationDetail
+    },
+    dynamics: { yearlyLog: [] }
   }
 };
 ctx.P = {
   id: 'env-policy-chain',
   name: '明末环境政策烟测',
   dynasty: '明',
+  conf: {},
+  time: { daysPerTurn: 30 },
+  playerInfo: { factionName: 'player-faction' },
   environmentConfig: {
     initialCarrying: {
       byRegion: {
@@ -71,8 +122,11 @@ ctx.findScenarioById = () => ctx.P;
 vm.createContext(ctx);
 load(ctx, 'tm-fiscal-engine.js');   // 国库出入已收口走真账(2026-07-04)·沙箱须与运行时同形态
 load(ctx, 'tm-economy-engine-currency.js'); load(ctx, 'tm-economy-engine.js');
+load(ctx, 'tm-huji-engine.js');
+load(ctx, 'tm-integration-bridge.js');
 load(ctx, 'tm-edict-parser.js');
 
+ctx.HujiEngine.init(ctx.P);
 ctx.EnvCapacityEngine.init(ctx.P);
 
 const policyIds = ctx.EnvCapacityEngine.ENV_POLICIES.map(p => p.id);
@@ -82,11 +136,31 @@ const policyIds = ctx.EnvCapacityEngine.ENV_POLICIES.map(p => p.id);
 
 const beforeMoney = ctx.GM.guoku.money;
 const beforeGrain = ctx.GM.guoku.grain;
-const beforeMountainMouths = ctx.GM.population.byRegion.mountain.mouths;
-const beforePlainMouths = ctx.GM.population.byRegion.plain.mouths;
+const beforeMountain = demographicTotal(mountainLeaves);
+const beforePlain = demographicTotal(plainLeaves);
+const beforeWorld = demographicTotal(allLeaves);
 const beforeTech = ctx.GM.environment.byRegion.mountain.techLevel.irrigation;
 const beforeScar = ctx.GM.environment.byRegion.mountain.ecoScars.soilErosion;
 const beforeArable = ctx.GM.environment.byRegion.mountain.arableArea;
+
+const affordableGrain = ctx.GM.guoku.grain;
+ctx.GM.guoku.grain = 10;
+const insufficientSnapshot = JSON.stringify({
+  guoku: ctx.GM.guoku,
+  environment: ctx.GM.environment,
+  population: ctx.GM.population,
+  hierarchy: ctx.GM.adminHierarchy
+});
+const insufficient = ctx.EnvCapacityEngine.enactPolicy('migration_relief', 'mountain');
+assert(insufficient && insufficient.ok === false
+  && JSON.stringify({
+    guoku: ctx.GM.guoku,
+    environment: ctx.GM.environment,
+    population: ctx.GM.population,
+    hierarchy: ctx.GM.adminHierarchy
+  }) === insufficientSnapshot,
+'grain preflight failure should leave treasury environment population and policies unchanged');
+ctx.GM.guoku.grain = affordableGrain;
 
 const edicts = [
   '诏令：山地府迁民出山，移民减压，给粮安置于平原府。',
@@ -105,12 +179,39 @@ const active = ctx.GM.environment.activePolicies || [];
 
 assert(ctx.GM.guoku.money < beforeMoney, 'environment policies should spend money');
 assert(ctx.GM.guoku.grain < beforeGrain, 'migration/recovery should spend grain');
-assert(ctx.GM.population.byRegion.mountain.mouths < beforeMountainMouths, 'migration relief should move people out of overloaded region');
-assert(ctx.GM.population.byRegion.plain.mouths > beforePlainMouths, 'migration relief should settle people in receiving region');
+const afterMountain = demographicTotal(mountainLeaves);
+const afterPlain = demographicTotal(plainLeaves);
+const afterWorld = demographicTotal(allLeaves);
+assert(afterMountain.mouths < beforeMountain.mouths, 'migration relief should move people out of overloaded province leaves');
+assert(afterPlain.mouths > beforePlain.mouths, 'migration relief should settle people in a receiving province leaf');
+assert(JSON.stringify(afterWorld) === JSON.stringify(beforeWorld),
+  'migration relief should conserve mouths households ding age and gender across provinces');
 assert(ctx.GM.environment.byRegion.mountain.techLevel.irrigation > beforeTech, 'tech investment should raise a real tech level');
 assert(ctx.GM.environment.byRegion.mountain.arableArea > beforeArable, 'disaster recovery should restore arable area');
 
-ctx.EnvCapacityEngine.tick({ turn: 73, monthRatio: 12, _monthRatio: 12 });
+const realSpend = ctx.FiscalEngine.spendFromGuoku;
+const partialSnapshot = JSON.stringify({
+  guoku: ctx.GM.guoku,
+  environment: ctx.GM.environment,
+  population: ctx.GM.population,
+  hierarchy: ctx.GM.adminHierarchy
+});
+ctx.FiscalEngine.spendFromGuoku = () => {
+  ctx.GM.guoku.money -= 10;
+  return { ok: true, deducted: { money: { deducted: 10, deficit: 159990 } } };
+};
+const partialPayment = ctx.EnvCapacityEngine.enactPolicy('tech_investment', 'mountain');
+ctx.FiscalEngine.spendFromGuoku = realSpend;
+assert(partialPayment && partialPayment.ok === false
+  && JSON.stringify({
+    guoku: ctx.GM.guoku,
+    environment: ctx.GM.environment,
+    population: ctx.GM.population,
+    hierarchy: ctx.GM.adminHierarchy
+  }) === partialSnapshot,
+'partial fiscal payment should roll treasury and all policy effects back atomically');
+
+ctx.EnvCapacityEngine.tick({ turn: 73, monthRatio: 12, _monthRatio: 12, strict: true });
 assert(ctx.GM.environment.byRegion.mountain.ecoScars.soilErosion < beforeScar, 'active policies should reduce scars through tick');
 assert(ctx.GM._envPolicyActions && ctx.GM._envPolicyActions.length >= 3, 'edict path should audit environment policy actions');
 assert(ctx.GM.environment.policyHistory && ctx.GM.environment.policyHistory.length >= 3, 'environment should keep policy history');

--- a/web/scripts/smoke-env-policy-complete-chain.js
+++ b/web/scripts/smoke-env-policy-complete-chain.js
@@ -43,6 +43,14 @@ function demographicTotal(leaves) {
   }, { mouths: 0, households: 0, ding: 0, byAge: {}, byGender: {} });
 }
 
+function sameDemographicTotals(a, b) {
+  if (a.mouths !== b.mouths || a.households !== b.households || a.ding !== b.ding) return false;
+  return ['byAge', 'byGender'].every(field => {
+    const keys = new Set(Object.keys(a[field] || {}).concat(Object.keys(b[field] || {})));
+    return Array.from(keys).every(key => Number(a[field] && a[field][key] || 0) === Number(b[field] && b[field][key] || 0));
+  });
+}
+
 const mountainLeaves = [
   makeLeaf('mountain-east', '东山县', 600000),
   makeLeaf('mountain-west', '西山县', 300000)
@@ -184,8 +192,15 @@ const afterPlain = demographicTotal(plainLeaves);
 const afterWorld = demographicTotal(allLeaves);
 assert(afterMountain.mouths < beforeMountain.mouths, 'migration relief should move people out of overloaded province leaves');
 assert(afterPlain.mouths > beforePlain.mouths, 'migration relief should settle people in a receiving province leaf');
-assert(JSON.stringify(afterWorld) === JSON.stringify(beforeWorld),
+assert(sameDemographicTotals(afterWorld, beforeWorld),
   'migration relief should conserve mouths households ding age and gender across provinces');
+const plainEnvironment = ctx.GM.environment.byRegion.plain;
+assert(Math.abs(plainEnvironment.currentLoad - afterPlain.mouths / plainEnvironment.carryingMax) < 1e-12,
+  'migration relief should immediately recompute the receiving province load');
+const expectedNationalLoad = Object.values(ctx.GM.environment.byRegion)
+  .reduce((sum, row) => sum + row.currentLoad, 0) / Object.keys(ctx.GM.environment.byRegion).length;
+assert(Math.abs(ctx.GM.environment.nationalLoad - expectedNationalLoad) < 1e-12,
+  'migration relief should recompute national load from fully refreshed source and target rows');
 assert(ctx.GM.environment.byRegion.mountain.techLevel.irrigation > beforeTech, 'tech investment should raise a real tech level');
 assert(ctx.GM.environment.byRegion.mountain.arableArea > beforeArable, 'disaster recovery should restore arable area');
 
@@ -210,6 +225,111 @@ assert(partialPayment && partialPayment.ok === false
     hierarchy: ctx.GM.adminHierarchy
   }) === partialSnapshot,
 'partial fiscal payment should roll treasury and all policy effects back atomically');
+
+function runAllRegionMigrationOrder(order) {
+  const specs = {
+    highA: { name: '高压甲省', mouths: 900000, load: 1.5 },
+    highB: { name: '高压乙省', mouths: 600000, load: 1.3 },
+    refuge: { name: '承接省', mouths: 300000, load: 0.4 }
+  };
+  const leaves = {};
+  Object.keys(specs).forEach(id => {
+    leaves[id] = makeLeaf(id + '-county', specs[id].name + '县', specs[id].mouths);
+  });
+  const orderMath = Object.create(Math);
+  orderMath.random = () => 1;
+  const orderCtx = {
+    console,
+    Math: orderMath, Date, JSON, RegExp, Error,
+    Array, Object, String, Number, Boolean,
+    parseInt, parseFloat, isFinite, isNaN,
+    setTimeout() { return 1; },
+    clearTimeout() {},
+    addEB() {},
+    toast() {}
+  };
+  orderCtx.window = orderCtx;
+  orderCtx.global = orderCtx;
+  orderCtx.globalThis = orderCtx;
+  orderCtx.TM = { errors: { capture() {}, captureSilent() {} } };
+  orderCtx.GM = {
+    sid: 'env-migration-order',
+    turn: 72,
+    regions: order.map(id => ({ id, name: specs[id].name, unrest: 20 })),
+    guoku: { money: 1000000, grain: 500000, cloth: 0 },
+    minxin: { trueIndex: 60 },
+    adminHierarchy: {
+      player: {
+        factionId: 'player-faction',
+        divisions: order.map(id => ({ id, name: specs[id].name, children: [leaves[id]] }))
+      }
+    },
+    population: {
+      national: { mouths: 1800000, households: 360000, ding: 540000 },
+      byRegion: order.reduce((out, id) => {
+        out[id + '-county'] = leaves[id].populationDetail;
+        return out;
+      }, {}),
+      dynamics: { yearlyLog: [] }
+    }
+  };
+  orderCtx.P = {
+    id: 'env-migration-order',
+    name: '迁民顺序烟测',
+    dynasty: '汉',
+    conf: {},
+    time: { daysPerTurn: 30 },
+    playerInfo: { factionName: 'player-faction' }
+  };
+  orderCtx.findScenarioById = () => orderCtx.P;
+  orderCtx.IntegrationBridge = {
+    getTopLevelDivisions(hierarchy) { return hierarchy.player.divisions; }
+  };
+  orderCtx.FiscalEngine = {
+    spendFromGuoku(cost) {
+      const deducted = {};
+      ['money', 'grain', 'cloth'].forEach(kind => {
+        const amount = Number(cost[kind]) || 0;
+        orderCtx.GM.guoku[kind] -= amount;
+        deducted[kind] = { deducted: amount, deficit: 0 };
+      });
+      return { ok: true, deducted };
+    }
+  };
+  vm.createContext(orderCtx);
+  load(orderCtx, 'tm-economy-engine-currency.js');
+  load(orderCtx, 'tm-economy-engine.js');
+  load(orderCtx, 'tm-huji-engine.js');
+  orderCtx.EnvCapacityEngine.init(orderCtx.P);
+  Object.keys(specs).forEach(id => {
+    orderCtx.GM.environment.byRegion[id].currentLoad = specs[id].load;
+  });
+  const before = demographicTotal(Object.values(leaves));
+  const result = orderCtx.EnvCapacityEngine.enactPolicy('migration_relief', 'all');
+  assert(result && result.ok, 'all-region migration relief should execute from a valid immutable plan');
+  const after = demographicTotal(Object.values(leaves));
+  assert(sameDemographicTotals(after, before),
+    'all-region migration should conserve the complete demographic world bundle');
+  assert(leaves.highA.populationDetail.mouths === 810000
+    && leaves.highB.populationDetail.mouths === 540000
+    && leaves.refuge.populationDetail.mouths === 450000,
+  'only pre-policy overloaded sources should move once into the pre-policy receiving province');
+  Object.keys(specs).forEach(id => {
+    const environment = orderCtx.GM.environment.byRegion[id];
+    assert(Math.abs(environment.currentLoad - leaves[id].populationDetail.mouths / environment.carryingMax) < 1e-12,
+      'all-region migration should refresh the final load for ' + id);
+  });
+  const byId = {};
+  Object.keys(specs).sort().forEach(id => {
+    byId[id] = JSON.parse(JSON.stringify(leaves[id].populationDetail));
+  });
+  return byId;
+}
+
+const forwardMigration = runAllRegionMigrationOrder(['highA', 'highB', 'refuge']);
+const reverseMigration = runAllRegionMigrationOrder(['refuge', 'highB', 'highA']);
+assert(JSON.stringify(forwardMigration) === JSON.stringify(reverseMigration),
+  'migration_relief(all) must be independent of environment object insertion order');
 
 ctx.EnvCapacityEngine.tick({ turn: 73, monthRatio: 12, _monthRatio: 12, strict: true });
 assert(ctx.GM.environment.byRegion.mountain.ecoScars.soilErosion < beforeScar, 'active policies should reduce scars through tick');

--- a/web/scripts/smoke-population-faction-ledger.js
+++ b/web/scripts/smoke-population-faction-ledger.js
@@ -633,6 +633,51 @@ console.log('[smoke-population-faction-ledger]');
     && !context.GM.population.byRegion['province-a']
     && context.GM.population.byProvince['province-a'],
   'population.byRegion keeps stable leaf IDs while province proxies use population.byProvince');
+
+  [countyA, countyB].forEach((county, index) => {
+    county.populationDetail.mouths = 0;
+    county.populationDetail.households = 0;
+    county.populationDetail.ding = 0;
+    county.populationDetail.hiddenCount = 0;
+    county.populationDetail.fugitives = 0;
+    county.population = { mouths: 900000 + index, households: 180000, ding: 270000 };
+  });
+  context.GM.population.national = { mouths: 1000000, households: 200000, ding: 300000 };
+  context.TM.HujiRuntimeBridge.maintain(context.GM, { scenario:context.P, turn:2, applyHardEffects:false });
+  context.IntegrationBridge.tick({ strict:true });
+  ok(context.GM.population.national.mouths === 0
+    && context.GM.population.national.households === 0
+    && context.GM.population.national.ding === 0
+    && context.GM.population.byRegion['county-a'].mouths === 0
+    && context.GM.population.byProvince['province-a'].mouths === 0,
+  'authoritative zero leaf population survives both bridges despite stale nonzero legacy mirrors');
+}
+
+{
+  const { context, playerLeaves } = makeRuntime();
+  playerLeaves.forEach((leaf, index) => {
+    leaf.populationDetail.mouths = 0;
+    leaf.populationDetail.households = 0;
+    leaf.populationDetail.ding = 0;
+    leaf.populationDetail.hiddenCount = 0;
+    leaf.populationDetail.fugitives = 0;
+    leaf.mouths = 700000 + index;
+    leaf.hiddenCount = 5000;
+    leaf.fugitives = 3000;
+  });
+  context.GM.population.national = { mouths:1000000, households:200000, ding:300000 };
+  context.GM.population.hiddenCount = 10000;
+  context.GM.population.fugitives = 6000;
+  delete context.GM.population._leafPopulationAuxAuthoritative;
+  context.TM.HujiRuntimeBridge.maintain(context.GM, { scenario:context.P, turn:1, applyHardEffects:false });
+  context.IntegrationBridge.tick({ strict:true });
+  ok(context.GM.population.national.mouths === 0
+    && context.GM.population.hiddenCount === 0
+    && context.GM.population.fugitives === 0
+    && playerLeaves.every(leaf => leaf.populationDetail.mouths === 0
+      && leaf.populationDetail.hiddenCount === 0
+      && leaf.populationDetail.fugitives === 0),
+  'first bridge pass preserves explicit zero mouths hidden population and fugitives over stale legacy values');
 }
 
 {
@@ -696,8 +741,10 @@ console.log('[smoke-population-faction-ledger]');
   'large-corvee mortality survives the complete leaf-to-national bridge');
 }
 
-ok(/HujiEngine\.applyPopulationLoss\(\{ cause:'environment-crisis:/.test(economySource)
-  && !/target\.mouths\s*=\s*Math\.max\(10000/.test(economySource),
+ok(/function _applyEnvironmentPopulationLoss/.test(economySource)
+  && /HujiEngine\.applyPopulationLoss/.test(economySource)
+  && !/pop\.mouths\s*=/.test(economySource)
+  && !/Math\.max\(10000\s*,/.test(economySource),
   'environment crisis mortality is routed through the leaf ledger');
 ok(/HujiEngine\.applyPopulationLoss\(Object\.assign\(target/.test(historicalSource)
   && /faction-target-required/.test(historicalSource)

--- a/web/scripts/smoke-start-game-data-integrity.js
+++ b/web/scripts/smoke-start-game-data-integrity.js
@@ -570,6 +570,107 @@ async function runMemorialInteractionGuardCase() {
   console.log('[smoke-start-game-data-integrity] player-body-edit-blocks-late-initial-memorials PASS');
 }
 
+async function runScenarioSourceIsolationCase() {
+  const sandbox = loadGame();
+  attachTianqiMap(sandbox);
+  vm.runInContext(`(function(){
+    var sc = findScenarioById('${SID}');
+    var fields = ['characters', 'factions', 'parties', 'classes', 'items', 'relations', 'events'];
+    fields.forEach(function(field){
+      if (!Array.isArray(sc[field]) || !sc[field].length) throw new Error('scenario isolation fixture missing ' + field);
+      sc[field][0].__scenarioAliasKey = field;
+      sc[field][0].__scenarioAliasNested = { value: 'source-' + field };
+    });
+    sc.rigidHistoryEvents = [{
+      id: 'scenario-alias-rigid',
+      name: '隔离烟测史事',
+      triggerTurn: 999999,
+      __scenarioAliasKey: 'rigidHistoryEvents',
+      __scenarioAliasNested: { value: 'source-rigidHistoryEvents' }
+    }];
+    sc.globalRules = [{
+      id: 'scenario-alias-rule',
+      nested: { value: 'source-globalRules' }
+    }];
+    window.__scenarioAliasFields = fields.concat(['rigidHistoryEvents']);
+    window.__scenarioAliasSource = sc;
+    window.__scenarioAliasSnapshot = JSON.stringify({
+      characters: sc.characters,
+      factions: sc.factions,
+      parties: sc.parties,
+      classes: sc.classes,
+      items: sc.items,
+      relations: sc.relations,
+      events: sc.events,
+      rigidHistoryEvents: sc.rigidHistoryEvents,
+      globalRules: sc.globalRules
+    });
+  })()`, sandbox);
+
+  vm.runInContext(`doActualStart('${SID}')`, sandbox, { timeout: START_VM_TIMEOUT_MS });
+  await delay(30);
+  const firstLoad = vm.runInContext(`(function(){
+    var sc = window.__scenarioAliasSource;
+    var refsDistinct = true;
+    var nestedDistinct = true;
+    window.__scenarioAliasFields.forEach(function(field){
+      var sourceRow = sc[field].filter(function(row){ return row && row.__scenarioAliasKey === field; })[0];
+      var runtimeRow = (P[field] || []).filter(function(row){ return row && row.sid === '${SID}' && row.__scenarioAliasKey === field; })[0];
+      if (!sourceRow || !runtimeRow || sourceRow === runtimeRow) refsDistinct = false;
+      if (!sourceRow || !runtimeRow || sourceRow.__scenarioAliasNested === runtimeRow.__scenarioAliasNested) nestedDistinct = false;
+      if (runtimeRow && runtimeRow.__scenarioAliasNested) runtimeRow.__scenarioAliasNested.value = 'runtime-' + field;
+    });
+    var rulesDistinct = P.globalRules !== sc.globalRules
+      && P.globalRules[0] !== sc.globalRules[0]
+      && P.globalRules[0].nested !== sc.globalRules[0].nested;
+    P.globalRules[0].nested.value = 'runtime-globalRules';
+    return {
+      refsDistinct: refsDistinct,
+      nestedDistinct: nestedDistinct,
+      rulesDistinct: rulesDistinct,
+      sourceUnchanged: JSON.stringify({
+        characters: sc.characters,
+        factions: sc.factions,
+        parties: sc.parties,
+        classes: sc.classes,
+        items: sc.items,
+        relations: sc.relations,
+        events: sc.events,
+        rigidHistoryEvents: sc.rigidHistoryEvents,
+        globalRules: sc.globalRules
+      }) === window.__scenarioAliasSnapshot
+    };
+  })()`, sandbox);
+  assert(firstLoad.refsDistinct && firstLoad.nestedDistinct && firstLoad.rulesDistinct,
+    'scenario rows and globalRules must cross sc-to-P through deep clones');
+  assert(firstLoad.sourceUnchanged,
+    'mutating P after start must not mutate the registered scenario source');
+
+  vm.runInContext(`doActualStart('${SID}')`, sandbox, { timeout: START_VM_TIMEOUT_MS });
+  await delay(30);
+  const secondLoad = vm.runInContext(`(function(){
+    var cleanRows = window.__scenarioAliasFields.every(function(field){
+      var row = (P[field] || []).filter(function(item){ return item && item.sid === '${SID}' && item.__scenarioAliasKey === field; })[0];
+      return row && row.__scenarioAliasNested && row.__scenarioAliasNested.value === 'source-' + field;
+    });
+    return cleanRows
+      && P.globalRules[0].nested.value === 'source-globalRules'
+      && JSON.stringify({
+        characters: window.__scenarioAliasSource.characters,
+        factions: window.__scenarioAliasSource.factions,
+        parties: window.__scenarioAliasSource.parties,
+        classes: window.__scenarioAliasSource.classes,
+        items: window.__scenarioAliasSource.items,
+        relations: window.__scenarioAliasSource.relations,
+        events: window.__scenarioAliasSource.events,
+        rigidHistoryEvents: window.__scenarioAliasSource.rigidHistoryEvents,
+        globalRules: window.__scenarioAliasSource.globalRules
+      }) === window.__scenarioAliasSnapshot;
+  })()`, sandbox);
+  assert(secondLoad, 'restarting the same scenario must hydrate clean rows from an unchanged source');
+  console.log('[smoke-start-game-data-integrity] scenario-source-isolation PASS');
+}
+
 (async function main() {
   await runCase('stale-map-choice-is-ignored', function (sandbox) {
     sandbox._pendingUseMap = false;
@@ -615,6 +716,7 @@ async function runMemorialInteractionGuardCase() {
   await runStrictHistoryFastPathCase();
   await runMemorialCandidateOrderingCase();
   await runMemorialInteractionGuardCase();
+  await runScenarioSourceIsolationCase();
   await runBackgroundPrewarmCase();
   await runDeepReadImmutableConfigCase();
   await runDeepReadStaleCallCase();

--- a/web/tm-economy-engine.js
+++ b/web/tm-economy-engine.js
@@ -243,9 +243,170 @@
     return s;
   }
 
+  function _envFiniteNumber(value, fallback) {
+    if (value === undefined || value === null || (typeof value === 'string' && value.trim() === '')) return fallback;
+    var n = Number(value);
+    return isFinite(n) ? n : fallback;
+  }
+
+  function _envNodeChildren(node) {
+    if (!node || typeof node !== 'object') return [];
+    var fields = ['children', 'divisions', 'subdivisions', 'subs', 'items'];
+    for (var i = 0; i < fields.length; i++) {
+      var children = node[fields[i]];
+      if (Array.isArray(children) && children.length) return children;
+    }
+    return [];
+  }
+
+  function _collectEnvLeaves(node, out) {
+    if (!node || typeof node !== 'object') return;
+    var children = _envNodeChildren(node);
+    if (!children.length) {
+      out.push(node);
+      return;
+    }
+    children.forEach(function(child) { _collectEnvLeaves(child, out); });
+  }
+
+  function _envRegionAliases(node) {
+    return [node && node.id, node && node.name, node && node.mapRegionId, node && node.regionId]
+      .filter(function(value) { return value !== undefined && value !== null && String(value).trim() !== ''; })
+      .map(function(value) { return String(value); });
+  }
+
+  function _envPlayerTopLevel() {
+    var G = global.GM;
+    if (!G || !G.adminHierarchy) return [];
+    if (global.IntegrationBridge && typeof global.IntegrationBridge.getTopLevelDivisions === 'function') {
+      var bridged = global.IntegrationBridge.getTopLevelDivisions(G.adminHierarchy, 'player');
+      if (Array.isArray(bridged) && bridged.length) return bridged;
+    }
+    var hierarchy = G.adminHierarchy;
+    if (Array.isArray(hierarchy.divisions)) return hierarchy.divisions;
+    var branch = hierarchy.player;
+    if (!branch) {
+      var wanted = [G.playerFactionId, G._playerFactionId, G.factionId]
+        .filter(function(value) { return value !== undefined && value !== null; })
+        .map(String);
+      Object.keys(hierarchy).some(function(key) {
+        var candidate = hierarchy[key];
+        if (!candidate || (!Array.isArray(candidate) && !Array.isArray(candidate.divisions))) return false;
+        if (candidate.isPlayer || wanted.indexOf(String(key)) >= 0 || wanted.indexOf(String(candidate.factionId || '')) >= 0) {
+          branch = candidate;
+          return true;
+        }
+        return false;
+      });
+    }
+    if (Array.isArray(branch)) return branch;
+    return branch && Array.isArray(branch.divisions) ? branch.divisions : [];
+  }
+
+  // 环境仍以顶级省/路为单位；人口已是叶级真值。所有跨系统读取先解析
+  // “环境省 → 子叶级地区”，再聚合真实人口，禁止用固定默认人口兜底。
+  function _environmentPopulationScope(rid) {
+    var G = global.GM;
+    var population = G && G.population || {};
+    var byLeaf = population.byLeafRegion || population.byRegion || {};
+    var byProvince = population.byProvince || {};
+    var wanted = String(rid == null ? '' : rid);
+    var top = _envPlayerTopLevel();
+    var owner = top.find(function(node) { return _envRegionAliases(node).indexOf(wanted) >= 0; }) || null;
+    var leaves = [];
+    if (owner) _collectEnvLeaves(owner, leaves);
+    if (!leaves.length && byLeaf[wanted]) {
+      leaves.push({ id:wanted, name:wanted, populationDetail:byLeaf[wanted] });
+    }
+    var rows = [];
+    var seen = {};
+    leaves.forEach(function(leaf, index) {
+      var id = String(leaf.id || leaf.name || leaf.mapRegionId || leaf.regionId || ('env-leaf-' + index));
+      if (seen[id]) return;
+      seen[id] = true;
+      var detail = leaf.populationDetail && typeof leaf.populationDetail === 'object'
+        ? leaf.populationDetail
+        : (byLeaf[id] && typeof byLeaf[id] === 'object' ? byLeaf[id]
+          : (leaf.population && typeof leaf.population === 'object' ? leaf.population : null));
+      if (!detail) return;
+      rows.push({ id:id, leaf:leaf, detail:detail, mouths:Math.max(0, Math.round(_envFiniteNumber(detail.mouths, 0))) });
+    });
+    var mouths = rows.reduce(function(sum, row) { return sum + row.mouths; }, 0);
+    var provinceRow = byProvince[wanted];
+    var directRow = byLeaf[wanted];
+    var fallbackRow = provinceRow && typeof provinceRow === 'object' ? provinceRow
+      : (directRow && typeof directRow === 'object' ? directRow : null);
+    if (!rows.length && fallbackRow) mouths = Math.max(0, Math.round(_envFiniteNumber(fallbackRow.mouths, 0)));
+    return {
+      ok: rows.length > 0 || !!fallbackRow,
+      regionId:wanted,
+      owner:owner,
+      rows:rows,
+      leafIds:rows.map(function(row) { return row.id; }),
+      mouths:mouths,
+      fallbackRow:fallbackRow
+    };
+  }
+
+  function _allocateEnvironmentLoss(total, rows) {
+    total = Math.max(0, Math.round(Number(total) || 0));
+    var weights = rows.map(function(row) { return Math.max(0, Number(row.mouths) || 0); });
+    var weightTotal = weights.reduce(function(sum, value) { return sum + value; }, 0);
+    var out = rows.map(function() { return 0; });
+    if (!total || !rows.length || !weightTotal) return out;
+    total = Math.min(total, weightTotal);
+    var ranked = [];
+    var assigned = 0;
+    rows.forEach(function(row, index) {
+      var quota = total * weights[index] / weightTotal;
+      out[index] = Math.min(weights[index], Math.floor(quota));
+      assigned += out[index];
+      ranked.push({ index:index, fraction:quota - Math.floor(quota) });
+    });
+    ranked.sort(function(a, b) { return b.fraction - a.fraction || a.index - b.index; });
+    for (var remaining = total - assigned, cursor = 0; remaining > 0; cursor = (cursor + 1) % ranked.length) {
+      var idx = ranked[cursor].index;
+      if (out[idx] >= weights[idx]) continue;
+      out[idx]++;
+      remaining--;
+    }
+    return out;
+  }
+
+  function _applyEnvironmentPopulationLoss(rid, mouths, cause) {
+    if (!global.HujiEngine || typeof global.HujiEngine.applyPopulationLoss !== 'function') {
+      return { ok:false, reason:'population-ledger-unavailable', mouths:0 };
+    }
+    var scope = rid ? _environmentPopulationScope(rid) : null;
+    if (rid && (!scope || !scope.ok)) return { ok:false, reason:'environment-population-scope-not-found', mouths:0 };
+    var requested = Math.max(0, Math.round(Number(mouths) || 0));
+    if (!requested) return { ok:true, mouths:0, regionIds:scope ? scope.leafIds.slice() : [] };
+    if (scope && scope.rows.length) {
+      var allocations = _allocateEnvironmentLoss(requested, scope.rows);
+      var applied = 0;
+      for (var i = 0; i < scope.rows.length; i++) {
+        if (!allocations[i]) continue;
+        var result = global.HujiEngine.applyPopulationLoss({
+          cause:String(cause || 'environment'),
+          regionId:scope.rows[i].id,
+          mouths:allocations[i]
+        });
+        if (!result || result.ok === false || Number(result.mouths) !== allocations[i]) {
+          return { ok:false, reason:String(result && result.reason || 'population-loss-incomplete'), mouths:applied };
+        }
+        applied += Number(result.mouths) || 0;
+      }
+      return { ok:applied === Math.min(requested, scope.mouths), mouths:applied, regionIds:scope.leafIds.slice(), reason:applied === Math.min(requested, scope.mouths) ? '' : 'population-loss-incomplete' };
+    }
+    if (rid) return { ok:false, reason:'environment-leaf-population-not-found', mouths:0 };
+    var legacy = global.HujiEngine.applyPopulationLoss({ cause:String(cause || 'environment'), mouths:requested });
+    return legacy || { ok:false, reason:'population-loss-unavailable', mouths:0 };
+  }
+
   function _recomputeRegionCarrying(rid, reg) {
     // 1) 土地支撑
     var G = global.GM;
+    var popCount = _environmentPopulationScope(rid).mouths;
     var techEra = G.environment ? G.environment.techEra : '唐';
     var yieldMult = _getTechEraMult('agriculture', techEra, 'yieldMult') || 1.0;
     var irrigMult = _getTechEraMult('irrigation', techEra, 'capMult') || 1.0;
@@ -264,7 +425,7 @@
                - (reg.ecoScars.deforestation || 0) * 400000;
     reg.carrying.fuelSupport = Math.max(50000, fuel);
     // 4) 住房
-    reg.carrying.housingSupport = (reg.mouths || 1200000) * 1.1; // 简化估算
+    reg.carrying.housingSupport = Math.max(0, popCount * 1.1); // 简化估算·人口口径与省辖叶级合计一致
     // 5) 卫生
     var sani = 1000000 - (reg.ecoScars.urbanSewageOverload || 0) * 500000;
     reg.carrying.sanitationSupport = Math.max(100000, sani);
@@ -278,8 +439,6 @@
     );
 
     // 加载比
-    var pop = global.GM.population && global.GM.population.byRegion && global.GM.population.byRegion[rid];
-    var popCount = pop ? pop.mouths : 1000000;
     reg.currentLoad = popCount / Math.max(1, reg.carryingMax);
   }
 
@@ -319,8 +478,9 @@
     var G = global.GM;
     Object.keys(E.byRegion).forEach(function(rid) {
       var reg = E.byRegion[rid];
-      var pop = G.population && G.population.byRegion && G.population.byRegion[rid];
-      var popCount = pop ? pop.mouths : 500000;
+      var populationScope = _environmentPopulationScope(rid);
+      if (!populationScope.ok) throw new Error('环境地区无法解析人口层级: ' + rid);
+      var popCount = populationScope.mouths;
       var load = reg.currentLoad || 0.5;
       // 过载加速疤痕
       var overloadMult = Math.max(1.0, load);
@@ -385,20 +545,17 @@
       // 级别 2: 1.2-1.5 饥荒
       // 级别 3: >1.5 崩溃
       var level = load < 1.2 ? 1 : load < 1.5 ? 2 : 3;
-      var pop = G.population && G.population.byRegion && G.population.byRegion[rid];
-      if (!pop) return;
-      if (level === 1) {
-        pop.yearlyDeaths = (pop.yearlyDeaths || 0) + pop.mouths * 0.002 * mr / 12;
-        pop.mouths = Math.max(10000, pop.mouths - pop.mouths * 0.002 * mr / 12);
-      } else if (level === 2) {
-        pop.yearlyDeaths = (pop.yearlyDeaths || 0) + pop.mouths * 0.008 * mr / 12;
-        pop.mouths = Math.max(10000, pop.mouths - pop.mouths * 0.008 * mr / 12);
+      var scope = _environmentPopulationScope(rid);
+      if (!scope.ok || scope.mouths <= 0) return;
+      var deathRate = level === 1 ? 0.002 : level === 2 ? 0.008 : 0.02;
+      var deaths = Math.min(scope.mouths, Math.max(0, Math.round(scope.mouths * deathRate * mr / 12)));
+      var mortality = _applyEnvironmentPopulationLoss(rid, deaths, 'environment-overload:' + String(level));
+      if (!mortality || mortality.ok === false) throw new Error('环境过载人口损失落账失败: ' + String(mortality && mortality.reason || 'unknown'));
+      if (level === 2) {
         var region = (G.regions || []).find(function(r) { return r.id === rid; });
         if (region) region.unrest = Math.min(100, (region.unrest || 30) + 3 * mr);
         if (global._adjAuthority) global._adjAuthority('minxin', -0.2 * mr);
       } else {
-        pop.yearlyDeaths = (pop.yearlyDeaths || 0) + pop.mouths * 0.02 * mr / 12;
-        pop.mouths = Math.max(10000, pop.mouths - pop.mouths * 0.02 * mr / 12);
         var region2 = (G.regions || []).find(function(r) { return r.id === rid; });
         if (region2) { region2.unrest = Math.min(100, (region2.unrest || 30) + 8 * mr); region2.disasterLevel = Math.min(1, (region2.disasterLevel || 0) + 0.05 * mr); }
         if (global._adjAuthority) global._adjAuthority('minxin', -0.5 * mr);
@@ -443,20 +600,17 @@
 
   function _triggerCrisis(ev, rid) {
     var E = global.GM.environment;
-    E.crisisHistory.push({ id: ev.id, name: ev.name, turn: global.GM.turn, regionId: rid || 'national', severity: ev.severity });
-    if (E.crisisHistory.length > 60) E.crisisHistory.splice(0, E.crisisHistory.length - 60);
-    // 效果
+    // 先完成所有玩法效果，再写入危机历史。人口落账失败时不得留下
+    // “史书说死了人、叶级账本却没有变化”的半危机记录。
     if (ev.effect) {
       var ef = ev.effect;
       if (ef.deathRate) {
         var P = global.GM.population;
-        if (P) {
-          var target = rid && P.byRegion[rid] ? P.byRegion[rid] : P.national;
-          var deaths = Math.round(target.mouths * ef.deathRate);
-          if (!global.HujiEngine || typeof global.HujiEngine.applyPopulationLoss !== 'function') throw new Error('人口损失账本不可用');
-          var mortality = global.HujiEngine.applyPopulationLoss({ cause:'environment-crisis:' + String(ev.id || 'unknown'), regionId:rid || '', mouths:deaths });
-          if (!mortality || mortality.ok === false) throw new Error('环境危机人口损失落账失败: ' + String(mortality && mortality.reason || 'unknown'));
-        }
+        if (!P) throw new Error('环境危机人口账本不可用');
+        var targetMouths = rid ? _environmentPopulationScope(rid).mouths : _envFiniteNumber(P.national && P.national.mouths, 0);
+        var deaths = Math.round(Math.max(0, targetMouths) * ef.deathRate);
+        var mortality = _applyEnvironmentPopulationLoss(rid || '', deaths, 'environment-crisis:' + String(ev.id || 'unknown'));
+        if (!mortality || mortality.ok === false) throw new Error('环境危机人口损失落账失败: ' + String(mortality && mortality.reason || 'unknown'));
       }
       if (ef.unrest) {
         var G = global.GM;
@@ -473,6 +627,8 @@
         }
       }
     }
+    E.crisisHistory.push({ id: ev.id, name: ev.name, turn: global.GM.turn, regionId: rid || 'national', severity: ev.severity });
+    if (E.crisisHistory.length > 60) E.crisisHistory.splice(0, E.crisisHistory.length - 60);
     if (global.addEB) global.addEB('环境', ev.name + (rid ? '（' + rid + '）' : '') + ' · ' + ev.severity);
   }
 
@@ -484,6 +640,7 @@
     var E = global.GM && global.GM.environment;
     if (!E || !E.byRegion) return [];
     if (regionId && regionId !== 'all' && E.byRegion[regionId]) return [regionId];
+    if (regionId && regionId !== 'all') return [];
     return Object.keys(E.byRegion);
   }
 
@@ -494,7 +651,7 @@
     Object.keys(E.byRegion).forEach(function(rid) {
       if (rid === fromId) return;
       var reg = E.byRegion[rid] || {};
-      if (!best || (reg.currentLoad || 0.5) < (E.byRegion[best].currentLoad || 0.5)) best = rid;
+      if (!best || _envFiniteNumber(reg.currentLoad, 0.5) < _envFiniteNumber(E.byRegion[best].currentLoad, 0.5)) best = rid;
     });
     return best;
   }
@@ -507,6 +664,38 @@
     if (E.policyHistory.length > 120) E.policyHistory.splice(0, E.policyHistory.length - 120);
   }
 
+  function _pickEnvironmentMigrationTarget(scope) {
+    if (!scope || !scope.rows || !scope.rows.length) return null;
+    return scope.rows.slice().sort(function(a, b) {
+      var aLoad = _envFiniteNumber(a.leaf && a.leaf.environment && a.leaf.environment.currentLoad, 0.5);
+      var bLoad = _envFiniteNumber(b.leaf && b.leaf.environment && b.leaf.environment.currentLoad, 0.5);
+      return aLoad - bLoad || a.mouths - b.mouths || String(a.id).localeCompare(String(b.id));
+    })[0];
+  }
+
+  function _applyEnvironmentMigration(rid, share, destinationId) {
+    if (!global.HujiEngine || typeof global.HujiEngine.transferPopulation !== 'function') {
+      return { ok:false, reason:'population-transfer-ledger-unavailable' };
+    }
+    var source = _environmentPopulationScope(rid);
+    var destination = _environmentPopulationScope(destinationId);
+    if (!source.ok || !source.leafIds.length) return { ok:false, reason:'source-population-scope-not-found' };
+    if (!destination.ok || !destination.leafIds.length) return { ok:false, reason:'target-population-scope-not-found' };
+    var target = _pickEnvironmentMigrationTarget(destination);
+    if (!target) return { ok:false, reason:'target-region-not-found' };
+    var amount = Math.max(0, Math.min(source.mouths, Math.round(source.mouths * Math.max(0, Number(share) || 0))));
+    if (!amount) return { ok:true, mouths:0, households:0, ding:0, targetRegionId:target.id };
+    var result = global.HujiEngine.transferPopulation({
+      sourceRegionIds:source.leafIds,
+      targetRegionId:target.id,
+      mouths:amount,
+      cause:'environment-policy:migration-relief'
+    });
+    if (!result || result.ok === false) return result || { ok:false, reason:'population-transfer-failed' };
+    if (Number(result.mouths) !== amount) return { ok:false, reason:'population-transfer-incomplete' };
+    return result;
+  }
+
   function _applyPolicyImmediateEffect(policy, policyId, regionId) {
     var G = global.GM;
     var E = G && G.environment;
@@ -516,26 +705,20 @@
     _envRegionIds(regionId).forEach(function(rid) {
       var reg = E.byRegion[rid];
       if (!reg) return;
+      if (!_environmentPopulationScope(rid).ok) throw new Error('环境政策地区无法解析人口层级: ' + rid);
       var row = { regionId: rid };
 
-      if (effect.migrateShare && G.population && G.population.byRegion && G.population.byRegion[rid]) {
-        var pop = G.population.byRegion[rid];
-        var amount = Math.max(0, Math.round((pop.mouths || 0) * effect.migrateShare));
+      if (effect.migrateShare) {
         var destId = _findEnvReceivingRegion(rid);
-        if (amount > 0 && destId && G.population.byRegion[destId]) {
-          pop.mouths = Math.max(0, (pop.mouths || 0) - amount);
-          pop.households = Math.max(0, Math.round((pop.households || 0) - amount / 5));
-          pop.ding = Math.max(0, Math.round((pop.ding || 0) - amount * 0.3));
-          pop.yearlyNetMigration = (pop.yearlyNetMigration || 0) - amount;
-          var dst = G.population.byRegion[destId];
-          dst.mouths = (dst.mouths || 0) + amount;
-          dst.households = Math.round((dst.households || 0) + amount / 5);
-          dst.ding = Math.round((dst.ding || 0) + amount * 0.3);
-          dst.yearlyNetMigration = (dst.yearlyNetMigration || 0) + amount;
-          row.migrated = amount;
-          row.toRegionId = destId;
-          summary.migrated += amount;
-        }
+        if (!destId) throw new Error('迁民减压缺少接纳地区: ' + rid);
+        var migration = _applyEnvironmentMigration(rid, effect.migrateShare, destId);
+        if (!migration || migration.ok === false) throw new Error('迁民减压人口落账失败: ' + String(migration && migration.reason || 'unknown'));
+        row.migrated = Number(migration.mouths) || 0;
+        row.migratedHouseholds = Number(migration.households) || 0;
+        row.migratedDing = Number(migration.ding) || 0;
+        row.toRegionId = destId;
+        row.toLeafRegionId = migration.targetRegionId || '';
+        summary.migrated += row.migrated;
       }
 
       if (policy.scarReduce) {
@@ -603,31 +786,104 @@
     return summary;
   }
 
+  function _cloneEnvironmentPolicyState(value, seen) {
+    if (typeof global.structuredClone === 'function' && !seen) return global.structuredClone(value);
+    if (value === null || typeof value !== 'object') return value;
+    seen = seen || new WeakMap();
+    if (seen.has(value)) return seen.get(value);
+    var copy = Array.isArray(value) ? [] : {};
+    seen.set(value, copy);
+    Object.keys(value).forEach(function(key) {
+      copy[key] = _cloneEnvironmentPolicyState(value[key], seen);
+    });
+    return copy;
+  }
+
+  function _captureEnvironmentPolicyTransaction(G) {
+    var keys = ['guoku', 'environment', 'population', 'adminHierarchy', 'regions', 'worldPopulationSummary', 'hukou'];
+    var state = {};
+    var present = {};
+    keys.forEach(function(key) {
+      present[key] = Object.prototype.hasOwnProperty.call(G, key);
+      if (present[key]) state[key] = G[key];
+    });
+    return { keys:keys, present:present, state:_cloneEnvironmentPolicyState(state) };
+  }
+
+  function _restoreEnvironmentPolicyTransaction(G, txn) {
+    (txn.keys || []).forEach(function(key) {
+      if (txn.present[key]) G[key] = txn.state[key]; // arch-ok: 环政跨财政/环境/人口失败时恢复局部事务快照
+      else delete G[key]; // arch-ok: 环政局部事务恢复原本不存在的 GM 子树
+    });
+  }
+
+  function _availableGuokuResource(G, kind) {
+    if (!G || !G.guoku) return 0;
+    if (kind === 'money') return Math.max(0, _envFiniteNumber(G.guoku.money, _envFiniteNumber(G.guoku.balance, 0)));
+    return Math.max(0, _envFiniteNumber(G.guoku[kind], 0));
+  }
+
+  function _paymentCoversPolicyCost(payment, cost) {
+    if (!payment || payment.ok === false || !payment.deducted) return false;
+    return ['money', 'grain', 'cloth'].every(function(kind) {
+      var needed = Math.max(0, Number(cost[kind]) || 0);
+      if (!needed) return true;
+      var row = payment.deducted[kind];
+      return !!row && (Number(row.deficit) || 0) <= 0 && (Number(row.deducted) || 0) >= needed;
+    });
+  }
+
   function enactPolicy(policyId, regionId) {
     var policy = ENV_POLICIES.find(function(p) { return p.id === policyId; });
     if (!policy) return { ok: false, reason: 'unknown policy' };
     var E = global.GM.environment;
     if (!E) return { ok: false };
-    if (!Array.isArray(E.activePolicies)) E.activePolicies = [];
-    if (!Array.isArray(E.policyHistory)) E.policyHistory = [];
-    // 扣钱
     var cost = policy.cost || {};
-    if (cost.money && global.GM.guoku && (global.GM.guoku.money || 0) < cost.money) return { ok: false, reason: '帑廪不足' };
-    // 国库支出走 FiscalEngine 真账(2026-07-04 收口)
-    if ((cost.money || cost.grain) && global.FiscalEngine && global.FiscalEngine.spendFromGuoku) {
-      global.FiscalEngine.spendFromGuoku({ money: cost.money || 0, grain: cost.grain || 0 }, '经济政策');
+    var targetRegions = _envRegionIds(regionId || 'all');
+    if (!targetRegions.length) return { ok:false, reason:'环境地区不存在' };
+    var resourceLabels = { money:'帑廪', grain:'粮储', cloth:'布帛' };
+    var resourceKinds = ['money', 'grain', 'cloth'];
+    for (var i = 0; i < resourceKinds.length; i++) {
+      var kind = resourceKinds[i];
+      if ((Number(cost[kind]) || 0) > _availableGuokuResource(global.GM, kind)) {
+        return { ok:false, reason:resourceLabels[kind] + '不足' };
+      }
     }
-    var immediate = _applyPolicyImmediateEffect(policy, policyId, regionId || 'all');
-    // 加入活跃政策（默认持续 24 回合，重点政策可自定）
-    E.activePolicies.push({
-      id: policyId, regionId: regionId || 'all',
-      name: policy.name,
-      startTurn: global.GM.turn || 0, duration: policy.duration || 24,
-      cost: Object.assign({}, cost),
-      immediate: immediate
-    });
-    if (global.addEB) global.addEB('环政', '推行 ' + policy.name + (regionId ? '（' + regionId + '）' : '（全国）'));
-    return { ok: true, policyId: policyId, name: policy.name, regionId: regionId || 'all', immediate: immediate };
+    var hasCost = resourceKinds.some(function(resourceKind) { return (Number(cost[resourceKind]) || 0) > 0; });
+    if (hasCost && (!global.FiscalEngine || typeof global.FiscalEngine.spendFromGuoku !== 'function')) {
+      return { ok:false, reason:'财政账本不可用' };
+    }
+    var txn = null;
+    var outcome;
+    try {
+      txn = _captureEnvironmentPolicyTransaction(global.GM);
+      if (!Array.isArray(E.activePolicies)) E.activePolicies = [];
+      if (!Array.isArray(E.policyHistory)) E.policyHistory = [];
+      if (hasCost) {
+        var payment = global.FiscalEngine.spendFromGuoku({ money:cost.money || 0, grain:cost.grain || 0, cloth:cost.cloth || 0 }, '经济政策');
+        if (!_paymentCoversPolicyCost(payment, cost)) throw new Error('环境政策支付未足额完成');
+      }
+      var immediate = _applyPolicyImmediateEffect(policy, policyId, regionId || 'all');
+      E = global.GM.environment;
+      E.activePolicies.push({
+        id: policyId, regionId: regionId || 'all',
+        name: policy.name,
+        startTurn: global.GM.turn || 0, duration: policy.duration || 24,
+        cost: Object.assign({}, cost),
+        immediate: immediate
+      });
+      outcome = { ok:true, policyId:policyId, name:policy.name, regionId:regionId || 'all', immediate:immediate };
+    } catch (error) {
+      if (txn) _restoreEnvironmentPolicyTransaction(global.GM, txn);
+      if (global.TM && global.TM.errors && typeof global.TM.errors.capture === 'function') global.TM.errors.capture(error, 'env-policy] atomic rollback');
+      return { ok:false, reason:String(error && error.message || error || '环境政策执行失败') };
+    }
+    try {
+      if (global.addEB) global.addEB('环政', '推行 ' + policy.name + (regionId ? '（' + regionId + '）' : '（全国）'));
+    } catch (notificationError) {
+      if (global.TM && global.TM.errors && typeof global.TM.errors.captureSilent === 'function') global.TM.errors.captureSilent(notificationError, 'tm-env-policy-notice');
+    }
+    return outcome;
   }
 
   function _cleanExpiredPolicies(ctx) {
@@ -698,6 +954,17 @@
   //  主 tick
   // ═══════════════════════════════════════════════════════════════════
 
+  function _runEnvironmentStep(label, fn, strict) {
+    try {
+      return fn();
+    } catch (error) {
+      if (global.TM && global.TM.errors && typeof global.TM.errors.capture === 'function') global.TM.errors.capture(error, label);
+      else console.error(label, error);
+      if (strict) throw error;
+      return null;
+    }
+  }
+
   function tick(ctx) {
     ctx = ctx || {};
     if (!global.GM || !global.GM.environment) {
@@ -705,11 +972,13 @@
       init(sc);
     }
     var mr = ctx.monthRatio || 1;
-    try { _tickScarAccumulation(ctx, mr); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'env] scars:') : console.error('[env] scars:', e); }
-    try { _tickOverloadFeedback(ctx, mr); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'env] overload:') : console.error('[env] overload:', e); }
-    try { _tickCrisisEvents(ctx, mr); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'env] crises:') : console.error('[env] crises:', e); }
-    try { _cleanExpiredPolicies(ctx); } catch(e){try{window.TM&&TM.errors&&TM.errors.captureSilent(e,'tm-env-capacity-engine');}catch(_){}}
-    try { _applyMinxinCoupling(mr); } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'env] minxin:') : console.error('[env] minxin:', e); }
+    var strict = ctx.strict === true;
+    _runEnvironmentStep('env] scars:', function() { return _tickScarAccumulation(ctx, mr); }, strict);
+    _runEnvironmentStep('env] overload:', function() { return _tickOverloadFeedback(ctx, mr); }, strict);
+    _runEnvironmentStep('env] crises:', function() { return _tickCrisisEvents(ctx, mr); }, strict);
+    _runEnvironmentStep('env] policies:', function() { return _cleanExpiredPolicies(ctx); }, strict);
+    _runEnvironmentStep('env] minxin:', function() { return _applyMinxinCoupling(mr); }, strict);
+    return { ok:true };
   }
 
   // ═══════════════════════════════════════════════════════════════════

--- a/web/tm-economy-engine.js
+++ b/web/tm-economy-engine.js
@@ -645,19 +645,7 @@
     if (!E || !E.byRegion) return [];
     if (regionId && regionId !== 'all' && E.byRegion[regionId]) return [regionId];
     if (regionId && regionId !== 'all') return [];
-    return Object.keys(E.byRegion);
-  }
-
-  function _findEnvReceivingRegion(fromId) {
-    var E = global.GM && global.GM.environment;
-    if (!E || !E.byRegion) return null;
-    var best = null;
-    Object.keys(E.byRegion).forEach(function(rid) {
-      if (rid === fromId) return;
-      var reg = E.byRegion[rid] || {};
-      if (!best || _envFiniteNumber(reg.currentLoad, 0.5) < _envFiniteNumber(E.byRegion[best].currentLoad, 0.5)) best = rid;
-    });
-    return best;
+    return Object.keys(E.byRegion).sort();
   }
 
   function _pushEnvPolicyHistory(entry) {
@@ -677,27 +665,88 @@
     })[0];
   }
 
-  function _applyEnvironmentMigration(rid, share, destinationId) {
-    if (!global.HujiEngine || typeof global.HujiEngine.transferPopulation !== 'function') {
-      return { ok:false, reason:'population-transfer-ledger-unavailable' };
-    }
-    var source = _environmentPopulationScope(rid);
-    var destination = _environmentPopulationScope(destinationId);
-    if (!source.ok || !source.leafIds.length) return { ok:false, reason:'source-population-scope-not-found' };
-    if (!destination.ok || !destination.leafIds.length) return { ok:false, reason:'target-population-scope-not-found' };
-    var target = _pickEnvironmentMigrationTarget(destination);
-    if (!target) return { ok:false, reason:'target-region-not-found' };
-    var amount = Math.max(0, Math.min(source.mouths, Math.round(source.mouths * Math.max(0, Number(share) || 0))));
-    if (!amount) return { ok:true, mouths:0, households:0, ding:0, targetRegionId:target.id };
-    var result = global.HujiEngine.transferPopulation({
-      sourceRegionIds:source.leafIds,
-      targetRegionId:target.id,
-      mouths:amount,
-      cause:'environment-policy:migration-relief'
+  function _snapshotEnvironmentMigrationRows() {
+    var E = global.GM && global.GM.environment;
+    if (!E || !E.byRegion) return [];
+    return Object.keys(E.byRegion).sort().map(function(rid) {
+      var reg = E.byRegion[rid];
+      var scope = _environmentPopulationScope(rid);
+      if (!scope.ok || !scope.leafIds.length) {
+        throw new Error('环境政策地区无法解析人口层级: ' + rid);
+      }
+      var target = _pickEnvironmentMigrationTarget(scope);
+      if (!target) throw new Error('迁民减压缺少可用叶级地区: ' + rid);
+      return {
+        regionId:rid,
+        currentLoad:_envFiniteNumber(reg && reg.currentLoad, 0.5),
+        mouths:Math.max(0, Math.round(_envFiniteNumber(scope.mouths, 0))),
+        leafIds:scope.leafIds.slice(),
+        targetLeafRegionId:String(target.id)
+      };
     });
-    if (!result || result.ok === false) return result || { ok:false, reason:'population-transfer-failed' };
-    if (Number(result.mouths) !== amount) return { ok:false, reason:'population-transfer-incomplete' };
-    return result;
+  }
+
+  function _compareEnvironmentMigrationRows(a, b) {
+    return a.currentLoad - b.currentLoad
+      || a.mouths - b.mouths
+      || String(a.regionId).localeCompare(String(b.regionId));
+  }
+
+  function _planEnvironmentMigrations(regionIds, share, allRegions) {
+    var rows = _snapshotEnvironmentMigrationRows();
+    var selected = {};
+    (regionIds || []).forEach(function(rid) { selected[String(rid)] = true; });
+    var sources = rows.filter(function(row) { return !!selected[row.regionId]; });
+    var receiver = rows.slice().sort(_compareEnvironmentMigrationRows)[0] || null;
+    if (!receiver || rows.length < 2) throw new Error('迁民减压缺少接纳地区');
+    if (allRegions) {
+      sources = sources.filter(function(row) {
+        return row.regionId !== receiver.regionId
+          && row.currentLoad > 1
+          && row.currentLoad > receiver.currentLoad;
+      });
+    } else {
+      receiver = rows.filter(function(row) { return row.regionId !== sources[0].regionId; })
+        .sort(_compareEnvironmentMigrationRows)[0] || null;
+      if (!receiver) throw new Error('迁民减压缺少接纳地区: ' + (sources[0] && sources[0].regionId || 'unknown'));
+    }
+    var ratio = Math.max(0, Number(share) || 0);
+    return sources.slice().sort(function(a, b) {
+      return String(a.regionId).localeCompare(String(b.regionId));
+    }).map(function(source) {
+      return {
+        sourceRegionId:source.regionId,
+        sourceLeafIds:source.leafIds.slice(),
+        targetRegionId:receiver.regionId,
+        targetLeafRegionId:receiver.targetLeafRegionId,
+        mouths:Math.max(0, Math.min(source.mouths, Math.round(source.mouths * ratio)))
+      };
+    }).filter(function(item) { return item.mouths > 0; });
+  }
+
+  function _executeEnvironmentMigrationPlan(plan) {
+    if (!global.HujiEngine || typeof global.HujiEngine.transferPopulation !== 'function') {
+      throw new Error('迁民减压人口账本不可用');
+    }
+    var bySource = {};
+    var affected = {};
+    (plan || []).forEach(function(item) {
+      var result = global.HujiEngine.transferPopulation({
+        sourceRegionIds:item.sourceLeafIds,
+        targetRegionId:item.targetLeafRegionId,
+        mouths:item.mouths,
+        cause:'environment-policy:migration-relief'
+      });
+      if (!result || result.ok === false) {
+        throw new Error('迁民减压人口落账失败: ' + String(result && result.reason || 'unknown'));
+      }
+      if (Number(result.mouths) !== item.mouths) throw new Error('迁民减压人口落账不完整');
+      result.toRegionId = item.targetRegionId;
+      bySource[item.sourceRegionId] = result;
+      affected[item.sourceRegionId] = true;
+      affected[item.targetRegionId] = true;
+    });
+    return { bySource:bySource, affectedRegionIds:Object.keys(affected).sort() };
   }
 
   function _applyPolicyImmediateEffect(policy, policyId, regionId) {
@@ -706,21 +755,24 @@
     if (!G || !E || !E.byRegion || !policy) return { regions: [] };
     var effect = policy.effect || {};
     var summary = { regions: [], migrated: 0, techBoosted: 0, restored: 0 };
-    _envRegionIds(regionId).forEach(function(rid) {
+    var regionIds = _envRegionIds(regionId);
+    var migrationBatch = { bySource:{}, affectedRegionIds:[] };
+    if (effect.migrateShare) {
+      var migrationPlan = _planEnvironmentMigrations(regionIds, effect.migrateShare, regionId === 'all');
+      migrationBatch = _executeEnvironmentMigrationPlan(migrationPlan);
+    }
+    regionIds.forEach(function(rid) {
       var reg = E.byRegion[rid];
       if (!reg) return;
       if (!_environmentPopulationScope(rid).ok) throw new Error('环境政策地区无法解析人口层级: ' + rid);
       var row = { regionId: rid };
 
-      if (effect.migrateShare) {
-        var destId = _findEnvReceivingRegion(rid);
-        if (!destId) throw new Error('迁民减压缺少接纳地区: ' + rid);
-        var migration = _applyEnvironmentMigration(rid, effect.migrateShare, destId);
-        if (!migration || migration.ok === false) throw new Error('迁民减压人口落账失败: ' + String(migration && migration.reason || 'unknown'));
+      var migration = migrationBatch.bySource[rid];
+      if (migration) {
         row.migrated = Number(migration.mouths) || 0;
         row.migratedHouseholds = Number(migration.households) || 0;
         row.migratedDing = Number(migration.ding) || 0;
-        row.toRegionId = destId;
+        row.toRegionId = migration.toRegionId || '';
         row.toLeafRegionId = migration.targetRegionId || '';
         summary.migrated += row.migrated;
       }
@@ -775,8 +827,15 @@
         row.loadRelief = effect.loadRelief;
       }
 
-      _recomputeRegionCarrying(rid, reg);
       summary.regions.push(row);
+    });
+    var recomputeIds = {};
+    regionIds.concat(migrationBatch.affectedRegionIds || []).forEach(function(rid) {
+      recomputeIds[String(rid)] = true;
+    });
+    Object.keys(recomputeIds).sort().forEach(function(rid) {
+      var reg = E.byRegion[rid];
+      if (reg) _recomputeRegionCarrying(rid, reg);
     });
     _recomputeNationalCarrying();
     _pushEnvPolicyHistory({

--- a/web/tm-economy-engine.js
+++ b/web/tm-economy-engine.js
@@ -551,7 +551,9 @@
       var deaths = Math.min(scope.mouths, Math.max(0, Math.round(scope.mouths * deathRate * mr / 12)));
       var mortality = _applyEnvironmentPopulationLoss(rid, deaths, 'environment-overload:' + String(level));
       if (!mortality || mortality.ok === false) throw new Error('环境过载人口损失落账失败: ' + String(mortality && mortality.reason || 'unknown'));
-      if (level === 2) {
+      if (level === 1) {
+        // 轻度压力仅兑现对应死亡率；不得落入三级崩溃的社会惩罚。
+      } else if (level === 2) {
         var region = (G.regions || []).find(function(r) { return r.id === rid; });
         if (region) region.unrest = Math.min(100, (region.unrest || 30) + 3 * mr);
         if (global._adjAuthority) global._adjAuthority('minxin', -0.2 * mr);

--- a/web/tm-economy-engine.js
+++ b/web/tm-economy-engine.js
@@ -214,22 +214,22 @@
       var customScars = (config.initialScars && config.initialScars.byRegion && config.initialScars.byRegion[r.id]) || {};
       out[r.id] = {
         carrying: {
-          farmlandSupport: custom.farmlandSupport || 1000000,
-          waterSupport:    custom.waterSupport    || 1500000,
-          fuelSupport:     custom.fuelSupport     || 800000,
-          housingSupport:  custom.housingSupport  || 1200000,
-          sanitationSupport: custom.sanitationSupport || 1000000
+          farmlandSupport: _envFiniteNumber(custom.farmlandSupport, 1000000),
+          waterSupport:    _envFiniteNumber(custom.waterSupport, 1500000),
+          fuelSupport:     _envFiniteNumber(custom.fuelSupport, 800000),
+          housingSupport:  _envFiniteNumber(custom.housingSupport, 1200000),
+          sanitationSupport: _envFiniteNumber(custom.sanitationSupport, 1000000)
         },
         carryingMax: 0,
         ecoScars: _defaultScars(customScars),
         currentLoad: 0.5,
         overloadYears: 0,
-        forestArea: custom.forestArea || 500000,
-        coalReserve: custom.coalReserve || 0,
-        aquiferLevel: custom.aquiferLevel || 1.0,
-        riverFlow: custom.riverFlow || 1.0,
-        arableArea: custom.arableArea || 500000,
-        soilFertility: custom.soilFertility || 0.85,
+        forestArea: _envFiniteNumber(custom.forestArea, 500000),
+        coalReserve: _envFiniteNumber(custom.coalReserve, 0),
+        aquiferLevel: _envFiniteNumber(custom.aquiferLevel, 1.0),
+        riverFlow: _envFiniteNumber(custom.riverFlow, 1.0),
+        arableArea: _envFiniteNumber(custom.arableArea, 500000),
+        soilFertility: _envFiniteNumber(custom.soilFertility, 0.85),
         techLevel: Object.assign({ agriculture: 1, irrigation: 1, fertilizer: 1, seedSelection: 1, toolImprovement: 1 }, custom.techLevel || {})
       };
       _recomputeRegionCarrying(r.id, out[r.id]);
@@ -408,20 +408,20 @@
     var G = global.GM;
     var popCount = _environmentPopulationScope(rid).mouths;
     var techEra = G.environment ? G.environment.techEra : '唐';
-    var yieldMult = _getTechEraMult('agriculture', techEra, 'yieldMult') || 1.0;
-    var irrigMult = _getTechEraMult('irrigation', techEra, 'capMult') || 1.0;
-    var seedMult = _getTechEraMult('seedSelection', techEra, 'yieldMult') || 1.0;
-    var farmland = (reg.arableArea || 500000) * (reg.soilFertility || 0.85) * yieldMult * seedMult * irrigMult
+    var yieldMult = _envFiniteNumber(_getTechEraMult('agriculture', techEra, 'yieldMult'), 1.0);
+    var irrigMult = _envFiniteNumber(_getTechEraMult('irrigation', techEra, 'capMult'), 1.0);
+    var seedMult = _envFiniteNumber(_getTechEraMult('seedSelection', techEra, 'yieldMult'), 1.0);
+    var farmland = _envFiniteNumber(reg.arableArea, 500000) * _envFiniteNumber(reg.soilFertility, 0.85) * yieldMult * seedMult * irrigMult
                    - (reg.ecoScars.salinization || 0) * 200000
                    - (reg.ecoScars.soilErosion || 0) * 150000;
     reg.carrying.farmlandSupport = Math.max(100000, farmland);
     // 2) 水
-    var water = (reg.aquiferLevel || 1.0) * 1500000 * (reg.riverFlow || 1.0)
+    var water = _envFiniteNumber(reg.aquiferLevel, 1.0) * 1500000 * _envFiniteNumber(reg.riverFlow, 1.0)
                 - (reg.ecoScars.waterTableDrop || 0) * 300000
                 - (reg.ecoScars.riverSilting || 0) * 200000;
     reg.carrying.waterSupport = Math.max(100000, water);
     // 3) 燃料
-    var fuel = (reg.forestArea || 500000) * 1.5 + (reg.coalReserve || 0) * 3
+    var fuel = _envFiniteNumber(reg.forestArea, 500000) * 1.5 + _envFiniteNumber(reg.coalReserve, 0) * 3
                - (reg.ecoScars.deforestation || 0) * 400000;
     reg.carrying.fuelSupport = Math.max(50000, fuel);
     // 4) 住房
@@ -447,7 +447,7 @@
     if (!levels) return 1.0;
     var lv = levels.find(function(l) { return l.era === era; });
     if (!lv) lv = levels[levels.length - 1];
-    return lv[key] || 1.0;
+    return _envFiniteNumber(lv[key], 1.0);
   }
 
   function _recomputeNationalCarrying() {
@@ -481,7 +481,7 @@
       var populationScope = _environmentPopulationScope(rid);
       if (!populationScope.ok) throw new Error('环境地区无法解析人口层级: ' + rid);
       var popCount = populationScope.mouths;
-      var load = reg.currentLoad || 0.5;
+      var load = _envFiniteNumber(reg.currentLoad, 0.5);
       // 过载加速疤痕
       var overloadMult = Math.max(1.0, load);
       // 森林退化（按人口烧柴）
@@ -493,9 +493,11 @@
       // 河道淤积
       reg.ecoScars.riverSilting = Math.min(1, (reg.ecoScars.riverSilting || 0) + 0.0002 * mr);
       // 地力衰退（按技术）
-      var fertDecay = _getTechEraMult('fertilizer', E.techEra, 'fertilityDecay') || 0.03;
+      var fertDecay = _envFiniteNumber(_getTechEraMult('fertilizer', E.techEra, 'fertilityDecay'), 0.03);
       reg.ecoScars.soilFertilityLoss = Math.min(1, (reg.ecoScars.soilFertilityLoss || 0) + fertDecay / 12 * mr);
-      reg.soilFertility = Math.max(0.3, reg.soilFertility - fertDecay / 12 * mr);
+      var currentFertility = _envFiniteNumber(reg.soilFertility, 0.85);
+      var fertilityFloor = currentFertility >= 0.3 ? 0.3 : 0;
+      reg.soilFertility = Math.max(fertilityFloor, currentFertility - fertDecay / 12 * mr);
       // 盐碱化（灌溉过度）
       reg.ecoScars.salinization = Math.min(1, (reg.ecoScars.salinization || 0) + 0.0001 * overloadMult * mr);
       // 沙漠化（干旱+过伐）
@@ -521,7 +523,7 @@
           });
         }
         if (policy && policy.effect && policy.effect.loadRelief) {
-          reg.currentLoad = Math.max(0.05, (reg.currentLoad || 0.5) - policy.effect.loadRelief * mr / 24);
+          reg.currentLoad = Math.max(0.05, _envFiniteNumber(reg.currentLoad, 0.5) - policy.effect.loadRelief * mr / 24);
         }
       });
       _recomputeRegionCarrying(rid, reg);
@@ -539,7 +541,7 @@
     var G = global.GM;
     Object.keys(E.byRegion).forEach(function(rid) {
       var reg = E.byRegion[rid];
-      var load = reg.currentLoad || 0.5;
+      var load = _envFiniteNumber(reg.currentLoad, 0.5);
       if (load < 1.0) return;
       // 级别 1: 1.0-1.2 压力
       // 级别 2: 1.2-1.5 饥荒
@@ -555,11 +557,11 @@
         // 轻度压力仅兑现对应死亡率；不得落入三级崩溃的社会惩罚。
       } else if (level === 2) {
         var region = (G.regions || []).find(function(r) { return r.id === rid; });
-        if (region) region.unrest = Math.min(100, (region.unrest || 30) + 3 * mr);
+        if (region) region.unrest = Math.min(100, _envFiniteNumber(region.unrest, 30) + 3 * mr);
         if (global._adjAuthority) global._adjAuthority('minxin', -0.2 * mr);
       } else {
         var region2 = (G.regions || []).find(function(r) { return r.id === rid; });
-        if (region2) { region2.unrest = Math.min(100, (region2.unrest || 30) + 8 * mr); region2.disasterLevel = Math.min(1, (region2.disasterLevel || 0) + 0.05 * mr); }
+        if (region2) { region2.unrest = Math.min(100, _envFiniteNumber(region2.unrest, 30) + 8 * mr); region2.disasterLevel = Math.min(1, _envFiniteNumber(region2.disasterLevel, 0) + 0.05 * mr); }
         if (global._adjAuthority) global._adjAuthority('minxin', -0.5 * mr);
       }
     });
@@ -618,7 +620,7 @@
         var G = global.GM;
         if (rid) {
           var reg = (G.regions || []).find(function(r) { return r.id === rid; });
-          if (reg) reg.unrest = Math.min(100, (reg.unrest || 30) + ef.unrest);
+          if (reg) reg.unrest = Math.min(100, _envFiniteNumber(reg.unrest, 30) + ef.unrest);
         } else {
           if (typeof G.unrest === 'number') G.unrest = Math.min(100, G.unrest + ef.unrest / 2);
         }
@@ -742,20 +744,20 @@
       }
 
       if (effect.carryingBoost) {
-        reg.arableArea = (reg.arableArea || 500000) * (1 + effect.carryingBoost);
-        reg.forestArea = (reg.forestArea || 500000) * (1 + effect.carryingBoost / 2);
+        reg.arableArea = _envFiniteNumber(reg.arableArea, 500000) * (1 + effect.carryingBoost);
+        reg.forestArea = _envFiniteNumber(reg.forestArea, 500000) * (1 + effect.carryingBoost / 2);
         row.carryingBoost = effect.carryingBoost;
       }
 
       if (effect.arableRestore) {
-        var beforeArable = reg.arableArea || 500000;
+        var beforeArable = _envFiniteNumber(reg.arableArea, 500000);
         reg.arableArea = beforeArable * (1 + effect.arableRestore);
         row.arableRestored = Math.round(reg.arableArea - beforeArable);
         summary.restored += row.arableRestored;
       }
 
       if (effect.soilFertilityBoost) {
-        reg.soilFertility = Math.min(1.2, (reg.soilFertility || 0.85) + effect.soilFertilityBoost);
+        reg.soilFertility = Math.min(1.2, _envFiniteNumber(reg.soilFertility, 0.85) + effect.soilFertilityBoost);
         row.soilFertilityBoost = effect.soilFertilityBoost;
       }
 
@@ -769,7 +771,7 @@
       }
 
       if (effect.loadRelief) {
-        reg.currentLoad = Math.max(0.05, (reg.currentLoad || 0.5) - effect.loadRelief);
+        reg.currentLoad = Math.max(0.05, _envFiniteNumber(reg.currentLoad, 0.5) - effect.loadRelief);
         row.loadRelief = effect.loadRelief;
       }
 

--- a/web/tm-endturn-systems.js
+++ b/web/tm-endturn-systems.js
@@ -197,7 +197,7 @@ async function _endTurn_updateSystems(timeRatio, zhengwen) {
   // 6.08 环境承载力（五维/疤痕/过载/危机/技术/政策）
   try {
     if (typeof EnvCapacityEngine !== 'undefined') {
-      EnvCapacityEngine.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio });
+      EnvCapacityEngine.tick({ turn: GM.turn, monthRatio: monthRatio, _monthRatio: monthRatio, strict: true });
     }
   } catch(e) { (window.TM && TM.errors && TM.errors.capture) ? TM.errors.capture(e, 'endTurn] EnvCapacityEngine.tick 失败:') : console.error('[endTurn] EnvCapacityEngine.tick 失败:', e); throw e; }
 

--- a/web/tm-huji-runtime-bridge.js
+++ b/web/tm-huji-runtime-bridge.js
@@ -41,6 +41,16 @@
     return isFinite(n) ? n : (Number(fallback) || 0);
   }
 
+  function firstDefinedFinite(values, fallback) {
+    for (var i = 0; i < values.length; i++) {
+      var value = values[i];
+      if (value === undefined || value === null || (typeof value === 'string' && value.trim() === '')) continue;
+      var n = Number(value);
+      if (isFinite(n)) return { found:true, value:n };
+    }
+    return { found:false, value:number(fallback, 0) };
+  }
+
   function round(v) {
     return Math.max(0, Math.round(number(v, 0)));
   }
@@ -316,14 +326,19 @@
     region = region || {};
     var raw = region.populationDetail || region.population || region.hukou || {};
     if (typeof raw === 'number') raw = { mouths: raw };
-    var mouths = round(raw.mouths || raw.people || raw.population || region.mouths || region.people || region.population || 0);
-    var households = round(raw.households || raw.hh || raw.registeredHouseholds || region.households || 0);
-    var ding = round(raw.ding || raw.laborDing || raw.maleDing || raw.adultMale || region.ding || 0);
-    if (!households && mouths) households = round(mouths / DEFAULT_MOUTHS_PER_HOUSEHOLD);
-    if (!mouths && households) mouths = round(households * DEFAULT_MOUTHS_PER_HOUSEHOLD);
-    if (!ding && mouths) ding = round(mouths * 0.30);
-    var hidden = round(raw.hiddenCount || raw.hidden || raw.hiddenPopulation || raw.unregistered || region.hiddenCount || region.hidden || 0);
-    var fugitives = round(raw.fugitives || raw.refugees || raw.escapees || raw.taoohu || region.fugitives || region.refugees || 0);
+    var mouthValue = firstDefinedFinite([raw.mouths, raw.people, raw.population, region.mouths, region.people, region.population], 0);
+    var householdValue = firstDefinedFinite([raw.households, raw.hh, raw.registeredHouseholds, region.households], 0);
+    var dingValue = firstDefinedFinite([raw.ding, raw.laborDing, raw.maleDing, raw.adultMale, region.ding], 0);
+    var hiddenValue = firstDefinedFinite([raw.hiddenCount, raw.hidden, raw.hiddenPopulation, raw.unregistered, region.hiddenCount, region.hidden], 0);
+    var fugitiveValue = firstDefinedFinite([raw.fugitives, raw.refugees, raw.escapees, raw.taoohu, region.fugitives, region.refugees], 0);
+    var mouths = round(mouthValue.value);
+    var households = round(householdValue.value);
+    var ding = round(dingValue.value);
+    if (!householdValue.found && mouths) households = round(mouths / DEFAULT_MOUTHS_PER_HOUSEHOLD);
+    if (!mouthValue.found && households) mouths = round(households * DEFAULT_MOUTHS_PER_HOUSEHOLD);
+    if (!dingValue.found && mouths) ding = round(mouths * 0.30);
+    var hidden = round(hiddenValue.value);
+    var fugitives = round(fugitiveValue.value);
     return {
       households: households,
       mouths: mouths,
@@ -336,6 +351,23 @@
     };
   }
 
+  function hasExplicitFiniteField(object, fields) {
+    if (!object || typeof object !== 'object') return false;
+    return fields.some(function(field) {
+      return Object.prototype.hasOwnProperty.call(object, field)
+        && firstDefinedFinite([object[field]], 0).found;
+    });
+  }
+
+  function regionHasAuthoritativeAux(region, fields) {
+    if (!region || typeof region !== 'object') return false;
+    if (region.populationDetail && typeof region.populationDetail === 'object') {
+      return hasExplicitFiniteField(region.populationDetail, fields);
+    }
+    var raw = region.population || region.hukou;
+    return hasExplicitFiniteField(raw, fields) || hasExplicitFiniteField(region, fields);
+  }
+
   function aggregatePopulation(root, config, leaves, options) {
     options = options || {};
     var initial = (config && config.initial) || {};
@@ -344,7 +376,13 @@
     var byAge = {};
     var byGender = {};
     var byLegalStatus = {};
+    var hiddenAuthorityComplete = leaves.length > 0;
+    var fugitiveAuthorityComplete = leaves.length > 0;
     leaves.forEach(function(region, idx) {
+      hiddenAuthorityComplete = hiddenAuthorityComplete
+        && regionHasAuthoritativeAux(region, ['hiddenCount', 'hidden', 'hiddenPopulation', 'unregistered']);
+      fugitiveAuthorityComplete = fugitiveAuthorityComplete
+        && regionHasAuthoritativeAux(region, ['fugitives', 'refugees', 'escapees', 'taoohu']);
       var d = detailFromRegion(region);
       var id = String(region.id || region.name || ('region-' + idx));
       totals.households += d.households;
@@ -392,16 +430,23 @@
 
     var hasRegionalTotals = leaves.length > 0 || totals.households || totals.mouths || totals.ding;
     var useRegionalTruth = options.authoritativePlayerPopulation === true || !!hasRegionalTotals;
-    var households = useRegionalTruth ? totals.households : round(initial.nationalHouseholds || (root.population && root.population.national && root.population.national.households) || 0);
-    var mouths = useRegionalTruth ? totals.mouths : round(initial.nationalMouths || (root.population && root.population.national && root.population.national.mouths) || households * DEFAULT_MOUTHS_PER_HOUSEHOLD);
-    var ding = useRegionalTruth ? totals.ding : round(initial.nationalDing || (root.population && root.population.national && root.population.national.ding) || mouths * 0.30);
-    var scenarioHidden = round(initial.hiddenPopulation || initial.hiddenCount || initial.unregisteredPopulation || 0);
-    var existingHidden = round(root.population && (root.population.hiddenCount || root.population.hiddenPopulation || root.population.unregisteredPopulation) || 0);
+    var households = useRegionalTruth ? totals.households : round(firstDefinedFinite([initial.nationalHouseholds, root.population && root.population.national && root.population.national.households], 0).value);
+    var mouths = useRegionalTruth ? totals.mouths : round(firstDefinedFinite([initial.nationalMouths, root.population && root.population.national && root.population.national.mouths], households * DEFAULT_MOUTHS_PER_HOUSEHOLD).value);
+    var ding = useRegionalTruth ? totals.ding : round(firstDefinedFinite([initial.nationalDing, root.population && root.population.national && root.population.national.ding], mouths * 0.30).value);
+    var scenarioHidden = round(firstDefinedFinite([initial.hiddenPopulation, initial.hiddenCount, initial.unregisteredPopulation], 0).value);
+    var existingHidden = round(firstDefinedFinite([root.population && root.population.hiddenCount, root.population && root.population.hiddenPopulation, root.population && root.population.unregisteredPopulation], 0).value);
     var emptyAuthoritativePlayer = options.authoritativePlayerPopulation === true && leaves.length === 0;
-    var existingFugitives = Math.max(round(root.population && root.population.fugitives || 0), round(root.hukou && (root.hukou.refugees || root.hukou.fugitives) || 0));
+    var existingFugitives = Math.max(
+      round(firstDefinedFinite([root.population && root.population.fugitives], 0).value),
+      round(firstDefinedFinite([root.hukou && root.hukou.refugees, root.hukou && root.hukou.fugitives], 0).value)
+    );
     if (options.authoritativePlayerPopulation === true && leaves.length && root.population._leafPopulationAuxAuthoritative !== true) {
-      var targetHidden = Math.max(totals.hiddenCount, scenarioHidden, existingHidden);
-      var targetFugitives = Math.max(totals.fugitives, existingFugitives);
+      // 剧本 initial.hiddenPopulation 是新局一次性播种来源；旧 national/hukou
+      // 镜像仅在叶级没有明确 hidden 字段时迁入，避免显式 0 被旧值复活。
+      var targetHidden = hiddenAuthorityComplete
+        ? Math.max(totals.hiddenCount, scenarioHidden)
+        : Math.max(totals.hiddenCount, scenarioHidden, existingHidden);
+      var targetFugitives = fugitiveAuthorityComplete ? totals.fugitives : Math.max(totals.fugitives, existingFugitives);
       var weights = {};
       leaves.forEach(function(region, index) {
         var id = String(region.id || region.name || ('region-' + index));

--- a/web/tm-integration-bridge.js
+++ b/web/tm-integration-bridge.js
@@ -72,9 +72,14 @@
     return isFinite(n) ? n : fallback;
   }
 
+  function _hasAuthoritativePopulationDetail(detail) {
+    return !!(detail && typeof detail === 'object' && [detail.mouths, detail.households, detail.ding]
+      .some(function(value) { return _bridgeFiniteNumber(value, null) !== null; }));
+  }
+
   function _divisionPopulationWeight(div) {
     var pd = div && div.populationDetail;
-    if (pd && typeof pd === 'object' && (pd.mouths || pd.households)) return Number(pd.mouths) || 0;
+    if (_hasAuthoritativePopulationDetail(pd)) return _bridgeFiniteNumber(pd.mouths, 0);
     var pop = div && div.population;
     if (pop && typeof pop === 'object') return Number(pop.mouths) || 0;
     if (typeof pop === 'number') return pop;
@@ -323,8 +328,8 @@
 
     // 为每个顶级区划确保数据字段
     var topLevel = getTopLevelDivisions(adminHierarchy, 'player');
-    var nationalMouths = G.population && G.population.national && G.population.national.mouths || 50000000;
-    var nationalHouseholds = G.population && G.population.national && G.population.national.households || 10000000;
+    var nationalMouths = _bridgeFiniteNumber(G.population && G.population.national && G.population.national.mouths, 50000000);
+    var nationalHouseholds = _bridgeFiniteNumber(G.population && G.population.national && G.population.national.households, 10000000);
     var avgMx = G.minxin && typeof G.minxin.trueIndex === 'number' ? G.minxin.trueIndex : 60;
     var avgCorrRaw = G.corruption && (typeof G.corruption === 'object'
       ? (typeof G.corruption.trueIndex === 'number' ? G.corruption.trueIndex : G.corruption.overall)
@@ -344,10 +349,10 @@
       // 顶级人口代理已从叶级 byRegion 拆到 byProvince；旧档仍兼容读取 byRegion。
       var provincePopulation = G.population && (G.population.byProvince || G.population.byRegion);
       var legacyPop = provincePopulation && (provincePopulation[div.id] || provincePopulation[div.name]);
-      if (legacyPop && legacyPop.mouths && !div._migrated) {
-        div.population.mouths = legacyPop.mouths;
-        div.population.households = legacyPop.households || Math.floor(legacyPop.mouths / 5);
-        div.population.ding = legacyPop.ding || Math.floor(legacyPop.mouths * 0.25);
+      if (legacyPop && _bridgeFiniteNumber(legacyPop.mouths, null) !== null && !div._migrated) {
+        div.population.mouths = _bridgeFiniteNumber(legacyPop.mouths, 0);
+        div.population.households = _bridgeFiniteNumber(legacyPop.households, Math.floor(div.population.mouths / 5));
+        div.population.ding = _bridgeFiniteNumber(legacyPop.ding, Math.floor(div.population.mouths * 0.25));
         div._migrated = true;
       }
       // 旧 GM.minxin.byRegion
@@ -476,12 +481,12 @@
       var claimed=0, actual=0, remit=0, retain=0;
       var pubM=0, pubG=0, pubC=0;
       n.children.forEach(function(c) {
-        if (c.populationDetail && typeof c.populationDetail === 'object' && (c.populationDetail.mouths || c.populationDetail.households)) {
-          hh += c.populationDetail.households || 0;
-          mo += c.populationDetail.mouths || 0;
-          ding += c.populationDetail.ding || 0;
-          fug += c.populationDetail.fugitives || 0;
-          hid += c.populationDetail.hiddenCount || 0;
+        if (_hasAuthoritativePopulationDetail(c.populationDetail)) {
+          hh += _bridgeFiniteNumber(c.populationDetail.households, 0);
+          mo += _bridgeFiniteNumber(c.populationDetail.mouths, 0);
+          ding += _bridgeFiniteNumber(c.populationDetail.ding, 0);
+          fug += _bridgeFiniteNumber(c.populationDetail.fugitives, 0);
+          hid += _bridgeFiniteNumber(c.populationDetail.hiddenCount, 0);
         } else if (c.population && typeof c.population === 'object') {
           hh += c.population.households || 0;
           mo += c.population.mouths || 0;
@@ -556,12 +561,12 @@
     leaves.forEach(function(div) {
       // 优先读 populationDetail（剧本规范字段）
       var pd = div.populationDetail;
-      if (pd && typeof pd === 'object' && (pd.mouths || pd.households)) {
-        totalHH += pd.households || 0;
-        totalMouths += pd.mouths || 0;
-        totalDing += pd.ding || 0;
-        totalFug += pd.fugitives || 0;
-        totalHidden += pd.hiddenCount || 0;
+      if (_hasAuthoritativePopulationDetail(pd)) {
+        totalHH += _bridgeFiniteNumber(pd.households, 0);
+        totalMouths += _bridgeFiniteNumber(pd.mouths, 0);
+        totalDing += _bridgeFiniteNumber(pd.ding, 0);
+        totalFug += _bridgeFiniteNumber(pd.fugitives, 0);
+        totalHidden += _bridgeFiniteNumber(pd.hiddenCount, 0);
         return;
       }
       if (div.population && typeof div.population === 'object') {

--- a/web/tm-patches-start.js
+++ b/web/tm-patches-start.js
@@ -1017,6 +1017,15 @@ function _tmResetScenarioScopedConfig(target) {
 }
 if (typeof window !== 'undefined') window._tmResetScenarioScopedConfig = _tmResetScenarioScopedConfig;
 
+// 剧本注册对象是同一会话内可重复开局的不可变模板。跨入 P 前统一深拷贝，
+// sid/type 等运行标记只能写在副本上，禁止反向污染 sc 与下一局。
+function _tmStartCloneScenarioRows(rows, sid) {
+  return deepClone(Array.isArray(rows) ? rows : []).filter(Boolean).map(function(row) {
+    if (row && typeof row === 'object') row.sid = sid;
+    return row;
+  });
+}
+
 function doActualStart(sid, requestToken){
   if (!_tmStartRequestCurrent(requestToken)) return;
   // 每次开新局先废止上一局仍在飞行中的 AI 预热结果。
@@ -1245,7 +1254,7 @@ function doActualStart(sid, requestToken){
   // rules保持对象格式{base,combat,economy,diplomacy}——这是文本规则描述，供AI推演参考
   // 不转为数组（旧版兼容：如果rules已经是数组则保持）
   if(sc.openingText) P.openingText = sc.openingText;
-  if(sc.globalRules) P.globalRules = sc.globalRules;
+  if(sc.globalRules) P.globalRules = deepClone(sc.globalRules);
   if(sc.mapData) P.mapData = deepClone(sc.mapData);
   // 剧本地图进入可变运行态：GM.mapData 为唯一 live state；P.map/P.mapData
   // 始终保留不可变模板，防止运行时变化污染下一局。
@@ -1290,27 +1299,27 @@ function doActualStart(sid, requestToken){
   if(sc.characters) {
     // 移除旧的该剧本的角色，添加新的
     P.characters = (P.characters||[]).filter(function(c){return c.sid!==sid;});
-    P.characters = P.characters.concat(sc.characters.map(function(c){c.sid=sid;return c;}));
+    P.characters = P.characters.concat(_tmStartCloneScenarioRows(sc.characters, sid));
   }
   if(sc.factions) {
     P.factions = (P.factions||[]).filter(function(f){return f.sid!==sid;});
-    P.factions = P.factions.concat(sc.factions.map(function(f){f.sid=sid;return f;}));
+    P.factions = P.factions.concat(_tmStartCloneScenarioRows(sc.factions, sid));
   }
   if(sc.parties) {
     P.parties = (P.parties||[]).filter(function(p){return p.sid!==sid;});
-    P.parties = P.parties.concat(sc.parties.map(function(p){p.sid=sid;return p;}));
+    P.parties = P.parties.concat(_tmStartCloneScenarioRows(sc.parties, sid));
   }
   if(sc.classes) {
     P.classes = (P.classes||[]).filter(function(c){return c.sid!==sid;});
-    P.classes = P.classes.concat(sc.classes.map(function(c){c.sid=sid;return c;}));
+    P.classes = P.classes.concat(_tmStartCloneScenarioRows(sc.classes, sid));
   }
   if(sc.items) {
     P.items = (P.items||[]).filter(function(i){return i.sid!==sid;});
-    P.items = P.items.concat(sc.items.map(function(i){i.sid=sid;return i;}));
+    P.items = P.items.concat(_tmStartCloneScenarioRows(sc.items, sid));
   }
   if(sc.relations) {
     P.relations = (P.relations||[]).filter(function(r){return r.sid!==sid;});
-    P.relations = P.relations.concat(sc.relations.map(function(r){r.sid=sid;return r;}));
+    P.relations = P.relations.concat(_tmStartCloneScenarioRows(sc.relations, sid));
   }
 
   if(sc.events) {
@@ -1320,13 +1329,13 @@ function doActualStart(sid, requestToken){
       // 根治：旧加载器只认 {historical/random/conditional/story/chain} 对象格式，
       // 官方天启/绍宋的 sc.events 是扁平数组 → allEvents 恒空 → GM.events 空 → 开局事件无法激活成御案时政。
       // （1.3.4.1 旧天启靠 split-rows 把事件直接塞 P.events 绕过此处；换成扁平内置脚本后暴露。绍宋靠预制 currentIssues 兜底未暴露。）
-      allEvents = sc.events.filter(Boolean).map(function(e){ e.sid=sid; if(!e.type) e.type='story'; return e; });
+      allEvents = _tmStartCloneScenarioRows(sc.events, sid).map(function(e){ if(!e.type) e.type='story'; return e; });
     } else {
-      if(sc.events.historical) allEvents = allEvents.concat(sc.events.historical.map(function(e){e.sid=sid;e.type='historical';return e;}));
-      if(sc.events.random) allEvents = allEvents.concat(sc.events.random.map(function(e){e.sid=sid;e.type='random';return e;}));
-      if(sc.events.conditional) allEvents = allEvents.concat(sc.events.conditional.map(function(e){e.sid=sid;e.type='conditional';return e;}));
-      if(sc.events.story) allEvents = allEvents.concat(sc.events.story.map(function(e){e.sid=sid;e.type='story';return e;}));
-      if(sc.events.chain) allEvents = allEvents.concat(sc.events.chain.map(function(e){e.sid=sid;e.type='chain';return e;}));
+      if(sc.events.historical) allEvents = allEvents.concat(_tmStartCloneScenarioRows(sc.events.historical, sid).map(function(e){e.type='historical';return e;}));
+      if(sc.events.random) allEvents = allEvents.concat(_tmStartCloneScenarioRows(sc.events.random, sid).map(function(e){e.type='random';return e;}));
+      if(sc.events.conditional) allEvents = allEvents.concat(_tmStartCloneScenarioRows(sc.events.conditional, sid).map(function(e){e.type='conditional';return e;}));
+      if(sc.events.story) allEvents = allEvents.concat(_tmStartCloneScenarioRows(sc.events.story, sid).map(function(e){e.type='story';return e;}));
+      if(sc.events.chain) allEvents = allEvents.concat(_tmStartCloneScenarioRows(sc.events.chain, sid).map(function(e){e.type='chain';return e;}));
     }
     // 移除旧的该剧本的事件，添加新的
     P.events = (P.events||[]).filter(function(e){return e.sid!==sid;});
@@ -1339,7 +1348,7 @@ function doActualStart(sid, requestToken){
   // 补齐后所有剧本一致。幂等：同 sid 旧条目先 filter 掉再 concat，重复 doActualStart 不累积。
   if(Array.isArray(sc.rigidHistoryEvents)) {
     P.rigidHistoryEvents = (P.rigidHistoryEvents||[]).filter(function(e){return e && e.sid!==sid;});
-    P.rigidHistoryEvents = P.rigidHistoryEvents.concat(sc.rigidHistoryEvents.map(function(e){e.sid=sid;return e;}));
+    P.rigidHistoryEvents = P.rigidHistoryEvents.concat(_tmStartCloneScenarioRows(sc.rigidHistoryEvents, sid));
   }
 
   // 开局内容（御案时政 currentIssues / 奏疏 memorials / 开场书信 openingLetters→鸿雁 letters）→ GM。


### PR DESCRIPTION
## Summary

- align province-scoped environment rows with authoritative leaf population ledgers
- route overload/crisis mortality and migration relief through Huji demographic operations
- propagate strict environment failures into the end-turn transaction
- make environment policy payment and effects atomic
- preserve explicit zero population values across both runtime bridges
- add nested-hierarchy, rollback, conservation, and zero-value regressions

## Follow-up audit fixes

- restore distinct level-1, level-2, and level-3 overload social effects
- deep-clone every scenario row and global rules object crossing from `sc` into `P`
- preserve explicit zero environment resources through init, recomputation, and policy effects
- plan `migration_relief` from an immutable pre-policy snapshot, move each source at most once, and recompute every affected source and destination load
- add regressions for overload monotonicity, scenario-source isolation, zero-resource semantics, target-load refresh, demographic conservation, and insertion-order independence

## Verification

- `node web/scripts/ci-smokes.js`: 850/852 direct pass; 2 existing missing-large-asset allowlist exemptions
- `node web/scripts/lint-arch-all.js`: 8/8 pass
- `node web/scripts/verify-official-scenario-parity.js`: 27 assertions pass
- `node scripts/verify-release-contract.js`: 166 assertions pass
- `node web/scripts/smoke-economy-env-huangquan.js`: 27 assertions pass
- `node web/scripts/smoke-population-faction-ledger.js`: 50 assertions pass
- `node web/scripts/smoke-endturn-transaction-failures.js`: 56 assertions pass
- canonical hot baseline: 670 tracked files pass; full 1082-file asset overlay pass
- `npm audit --omit=dev --audit-level=high --registry=https://registry.npmjs.org`: 0 vulnerabilities

No package, release, merge, or production publish was performed.