### PR TITLE
refactor: introduce explicit feature loading boundaries

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-25T07:50:07.730Z",
+  "generatedAt": "2026-08-25T10:31:20.712Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -2606,8 +2606,8 @@
     },
     {
       "path": "phase8-formal-map.js",
-      "sha256": "f65eb63fd2c3fe8133cd63055764824e01a4836fca13f2a6651b8d0b298d5946",
-      "size": 142189
+      "sha256": "89df207343b7d69f46d76f428b49cfbbf20086633026d339f8b056f4b1b217d2",
+      "size": 142375
     },
     {
       "path": "phase8-formal-modules.js",
@@ -3746,8 +3746,8 @@
     },
     {
       "path": "tm-content-manager.js",
-      "sha256": "41daab9d49c273d7418b8bbfab09d17a7317b45fe0a3299124124246db10f192",
-      "size": 185554
+      "sha256": "0043226d895b1883eb2d60f9574715d796b8c5eb83fac6e6886b438581c3d162",
+      "size": 185772
     },
     {
       "path": "tm-context-zones.js",
@@ -4201,8 +4201,8 @@
     },
     {
       "path": "tm-feature-loader.js",
-      "sha256": "2a7bc0d5e91fb67d6440a6ecd85bb24a30dfece19d3307f9b3a60d7508fd5e6f",
-      "size": 12368
+      "sha256": "0e5c7f3780da0c687c08eb4a19b9cdcb7ca499a1ba6d36a898d21a3fc21d434c",
+      "size": 22646
     },
     {
       "path": "tm-feedback-loops.js",

--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-25T06:18:26.878Z",
+  "generatedAt": "2026-08-25T07:50:07.730Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -2155,14 +2155,19 @@
       "size": 112795
     },
     {
+      "path": "feature-manifest.js",
+      "sha256": "5b92308a6bfb374497b38a5fab8b5f30334736e6297b74ab46f512a95983b9b5",
+      "size": 2146
+    },
+    {
       "path": "icon.png",
       "sha256": "8a2c8ae36d6b4665f16cd53e64f4f365c022d07b318d32998996f87e79cecbf4",
       "size": 12525
     },
     {
       "path": "index.html",
-      "sha256": "f93fd52306728b82a974813e6d241de5db9fd1bf1c84d947fcb9c7bdbf48c078",
-      "size": 69794
+      "sha256": "9cb1fc8a49cb173c3fd07bbb9998a42445f82796330bd68c0d986128b3447b6b",
+      "size": 69443
     },
     {
       "path": "INDEX.md",
@@ -2601,8 +2606,8 @@
     },
     {
       "path": "phase8-formal-map.js",
-      "sha256": "468b6a8cd3ab0e29443717be656666dcc56a0ac5a124254717e78c9c43b8b43c",
-      "size": 140996
+      "sha256": "f65eb63fd2c3fe8133cd63055764824e01a4836fca13f2a6651b8d0b298d5946",
+      "size": 142189
     },
     {
       "path": "phase8-formal-modules.js",
@@ -3346,8 +3351,8 @@
     },
     {
       "path": "startup-script-phases.json",
-      "sha256": "85dc8b20d9719658cf1bfbd81fde1e60706bdaf7ae3da0d6eb59842c57b865f6",
-      "size": 317195
+      "sha256": "ab24704b5248f10883f100f7a6348fae6da72832acca154ed4c7cced1c3052ce",
+      "size": 347245
     },
     {
       "path": "styles.css",
@@ -3741,8 +3746,8 @@
     },
     {
       "path": "tm-content-manager.js",
-      "sha256": "fd7cc4c65fa8e81bd50feb757e04fdd9bf98578efbe877db25f71af550152831",
-      "size": 184923
+      "sha256": "41daab9d49c273d7418b8bbfab09d17a7317b45fe0a3299124124246db10f192",
+      "size": 185554
     },
     {
       "path": "tm-context-zones.js",
@@ -3791,8 +3796,8 @@
     },
     {
       "path": "tm-desktop-update.js",
-      "sha256": "c76e96cd4af239515b2696a3400b7c0e5c76ba467bbe0b52f759ea0c10b6a8a3",
-      "size": 16825
+      "sha256": "51de8bcb409aa96af379cefc15315ce06dabd8c82a5acf83f12f13e6594defaa",
+      "size": 18521
     },
     {
       "path": "tm-diagnostics-foundation.js",
@@ -4193,6 +4198,11 @@
       "path": "tm-faction-personality.js",
       "sha256": "96442e5f82d0166e9ed265b7bf7b0f7d14604d9a545ecdbdd9bc6dc909f5de69",
       "size": 5923
+    },
+    {
+      "path": "tm-feature-loader.js",
+      "sha256": "2a7bc0d5e91fb67d6440a6ecd85bb24a30dfece19d3307f9b3a60d7508fd5e6f",
+      "size": 12368
     },
     {
       "path": "tm-feedback-loops.js",
@@ -4926,8 +4936,8 @@
     },
     {
       "path": "tm-online-update.js",
-      "sha256": "bbb67929bfb2029d8d67294176209c282c5cfbb34aac25e1374897023f74176f",
-      "size": 11886
+      "sha256": "0ad5d0310a5013d14f29b878ba2de94f2bdb4b143d9efbbd7a85cac6d1582ce4",
+      "size": 12551
     },
     {
       "path": "tm-party-class-action-scheduler.js",
@@ -5166,8 +5176,8 @@
     },
     {
       "path": "tm-startup-contract.js",
-      "sha256": "f090358ae9e5191e935844b6d7b4ff4b952b5f279fa8361866819ae40bad360f",
-      "size": 3217
+      "sha256": "a3c87446e6b7e2b7f2bb2d5a6fbcdab2786d8c5282212ce45bf1130a70d2920f",
+      "size": 3897
     },
     {
       "path": "tm-startup-phases.js",

--- a/web/feature-manifest.js
+++ b/web/feature-manifest.js
@@ -1,0 +1,59 @@
+// feature-manifest.js — declarative runtime feature definitions for TM.Features.
+(function (root) {
+  'use strict';
+  if (!root || !root.TM || !root.TM.Features || typeof root.TM.Features.registerManifest !== 'function') {
+    throw new Error('TM.Features must load before feature-manifest.js');
+  }
+
+  root.TM.Features.registerManifest({
+    version: 1,
+    features: {
+      browserTestHarness: {
+        scripts: ['tm-test-harness.js?v=2026042714'],
+        dependsOn: [],
+        platform: 'any',
+        loadPolicy: 'query-only',
+        sideEffects: 'test-provider',
+        provides: ['TM.test']
+      },
+      desktopUpdate: {
+        scripts: [
+          'tm-update-card.js?v=20260611-upd1',
+          'tm-desktop-update.js?v=20260825-feature-loader-v2'
+        ],
+        dependsOn: [],
+        platform: 'desktop',
+        loadPolicy: 'on-demand',
+        sideEffects: 'explicit-lifecycle',
+        provides: ['TMUpdateCard', 'TMDesktopUpdate'],
+        init: function () { return root.TMDesktopUpdate.init(); },
+        dispose: function () { return root.TMDesktopUpdate.dispose(); }
+      },
+      onlineUpdate: {
+        scripts: ['tm-online-update.js?v=20260825-feature-loader-v2'],
+        dependsOn: [],
+        platform: 'web',
+        loadPolicy: 'idle-after-load',
+        sideEffects: 'explicit-lifecycle',
+        provides: ['TM_OnlineUpdate'],
+        init: function () { return root.TM_OnlineUpdate.init(); },
+        dispose: function () { return root.TM_OnlineUpdate.dispose(); }
+      },
+      formalMapLabels: {
+        scripts: [
+          'tm-map-label-geo.js?v=20260705-noframe',
+          'tm-map-label-collide.js?v=20260705-noframe'
+        ],
+        dependsOn: [],
+        platform: 'any',
+        loadPolicy: 'first-formal-map-render',
+        sideEffects: 'none',
+        provides: ['TMMapLabelGeo', 'TMMapLabelCollide'],
+        init: function () {
+          var map = root.TMFormalBridge && root.TMFormalBridge.map;
+          if (map && typeof map.onMapLabelFeatureReady === 'function') map.onMapLabelFeatureReady();
+        }
+      }
+    }
+  });
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/web/index.html
+++ b/web/index.html
@@ -511,6 +511,7 @@ console.log('天命游戏脚本开始加载...');
 
 <script src="tm-env-detect.js?v=2026042714"></script>
 <script src="tm-platform.js?v=20260823-ipc1"></script>
+<script src="tm-feature-loader.js?v=20260825-feature-loader-v2"></script>
 <!-- 固定虚拟分辨率+整体等比缩放适配（移植 Phase 2 重做）·仅 capacitor/?fit=1·须在 platform 后尽早加载防闪 -->
 <script src="tm-fixed-fit.js?v=20260723-modern-viewport-units"></script>
 <script src="tm-debug-logger.js?v=2026052801"></script>
@@ -954,8 +955,7 @@ console.log('天命游戏脚本开始加载...');
 <!-- 旧 Tianqi runtime snapshot 仍可作为兼容产物生成，但在线入口不再空闲时无条件下载。
      完整官方脚本已包含同源地图与运行时数组，由 TMOfficialScenarioLoader 在选中剧本时一次性加载。 -->
 
-<!-- 测试框架（?test=1 自动运行） -->
-<script src="tm-test-harness.js?v=2026042714" defer></script>
+<!-- 浏览器测试框架仅在 ?test=1 / ?devHarness=1 时由 TM.Features 按需加载。 -->
 
 <!-- 邸报·更新公告 -->
 <script src="tm-changelog.js?v=20260519-remote-changelog"></script>
@@ -972,8 +972,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="phase8-formal-bridge.js?v=20260706-split27"></script>
 <!-- phase8-formal·按 surface family 拆 6 module·主 bridge 必先 load·skeleton + alias 块·body 0 改动·2026-05-26 -->
 <script src="phase8-formal-topbar.js?v=20260621-optland"></script>
-<script src="tm-map-label-geo.js?v=20260705-noframe"></script>
-<script src="tm-map-label-collide.js?v=20260705-noframe"></script>
+<!-- 地图标签几何/碰撞由正式地图首次渲染时通过 TM.Features 加载；地图可先用安全 fallback。 -->
 <script src="phase8-formal-map.js?v=20260706-split25"></script>
 <!-- 勿动位置·第二十五拆：phase8-formal-map-dossier 必须【紧随 origin 之后】装载(②b origin-first 双向 bucket·origin 先导出 __p8MapParts→本片捕获回填) -->
 <script src="phase8-formal-map-dossier.js?v=20260706-split25"></script>
@@ -993,12 +992,7 @@ console.log('天命游戏脚本开始加载...');
 <!-- Capacitor 启动钩子（移植 Phase 3）·Capgo 热更 notifyAppReady + 在线·仅原生端·桌面/web no-op -->
 <script src="tm-capacitor-boot.js?v=20260604-ota-progress3"></script>
 
-<!-- 更新进度卡·三端共用 UI 组件·自身不判平台不发请求·由消费方挂载（不挂载即惰性） -->
-<script src="tm-update-card.js?v=20260611-upd1"></script>
-<!-- 桌面端启动自动检查更新·仅 window.tianming 在时生效·dev 静默·安卓/在线 no-op -->
-<script src="tm-desktop-update.js?v=20260611-upd1"></script>
-<!-- 在线版更新提示（仅 web 端查 version.json·桌面/安卓只同步 footer 版本号） -->
-<script src="tm-online-update.js?v=20260611-upd1"></script>
+<!-- 更新卡/桌面更新由更新中心按需加载；在线更新在 Web 首屏完成后 idle 加载。 -->
 
 <!-- 触屏手势桥（移植 Phase 2·S2.x）·长按=右键(contextmenu)·仅触屏设备挂载·鼠标零影响 -->
 <script src="tm-touch-gestures.js?v=20260603-longpress-rclick"></script>

--- a/web/phase8-formal-map.js
+++ b/web/phase8-formal-map.js
@@ -418,35 +418,40 @@
   // ── 地图标签几何：委托纯几何/字号/配色引擎 tm-map-label-geo.js（跨朝代通用·零游戏依赖·独立单测）──
   //   本文件只留「region 适配层」：pointsForRegion 取环 + WeakMap 按几何签名缓存(几何静态·frozen 剧本对象亦安全)。
   //   引擎未加载时全部安全回落(面积→bbox·锚点→actualCenter·字号→min·亮色→null)·不崩。
-  var _TMGeo = (typeof window !== 'undefined' && window.TMMapLabelGeo) ||
-               (typeof TMMapLabelGeo !== 'undefined' ? TMMapLabelGeo : null);
+  function getTMGeo(){ return (typeof window !== 'undefined' && window.TMMapLabelGeo) || null; }
   function _tmGeoSig(pts){ return pts.length + (pts.length ? (':' + pts[0].x.toFixed(1) + ',' + pts[0].y.toFixed(1)) : ''); }
   var _tmAreaCache = (typeof WeakMap !== 'undefined') ? new WeakMap() : null;
   var _tmAnchorCache = (typeof WeakMap !== 'undefined') ? new WeakMap() : null;
+  function invalidateMapLabelGeometryCaches(){
+    _tmAreaCache = (typeof WeakMap !== 'undefined') ? new WeakMap() : null;
+    _tmAnchorCache = (typeof WeakMap !== 'undefined') ? new WeakMap() : null;
+  }
   // region 真面积(缓存·shoelace)·引擎缺失或无点→回落 bbox 面积。
   function regionTrueArea(r){
     if (!r) return 0;
     var pts = pointsForRegion(r), sig = _tmGeoSig(pts);
-    if (_tmAreaCache) { var hit = _tmAreaCache.get(r); if (hit && hit.sig === sig) return hit.area; }
-    var area = _TMGeo ? Math.abs(_TMGeo.polyAreaSigned(pts)) : 0;
+    var geo = getTMGeo();
+    if (geo && _tmAreaCache) { var hit = _tmAreaCache.get(r); if (hit && hit.sig === sig) return hit.area; }
+    var area = geo ? Math.abs(geo.polyAreaSigned(pts)) : 0;
     if (!(area > 0)) { var ext = regionExtent(r); area = ext.area || 0; }
-    if (_tmAreaCache) { try { _tmAreaCache.set(r, { sig: sig, area: area }); } catch (_) {} }
+    if (geo && _tmAreaCache) { try { _tmAreaCache.set(r, { sig: sig, area: area }); } catch (_) {} }
     return area;
   }
   // region 标签锚点(缓存·polylabel 内接圆心)·引擎缺失/无点→回落 actualCenter。
   function labelAnchor(r){
     if (!r) return { x: 0, y: 0 };
     var pts = pointsForRegion(r), sig = _tmGeoSig(pts);
-    if (_tmAnchorCache) { var hit = _tmAnchorCache.get(r); if (hit && hit.sig === sig) return hit.anchor; }
-    var a = (_TMGeo && pts.length >= 3) ? _TMGeo.polylabel(pts) : null;
+    var geo = getTMGeo();
+    if (geo && _tmAnchorCache) { var hit = _tmAnchorCache.get(r); if (hit && hit.sig === sig) return hit.anchor; }
+    var a = (geo && pts.length >= 3) ? geo.polylabel(pts) : null;
     if (!a || !isFinite(a.x) || !isFinite(a.y)) a = actualCenter(r);
-    if (_tmAnchorCache) { try { _tmAnchorCache.set(r, { sig: sig, anchor: a }); } catch (_) {} }
+    if (geo && _tmAnchorCache) { try { _tmAnchorCache.set(r, { sig: sig, anchor: a }); } catch (_) {} }
     return a;
   }
   // 面积→字号 平滑幂律(委托引擎·缺失回落 min)。
-  function _tmAreaFont(area, ref, base, k, min, max){ return _TMGeo ? _TMGeo.areaFont(area, ref, base, k, min, max) : min; }
+  function _tmAreaFont(area, ref, base, k, min, max){ var geo = getTMGeo(); return geo ? geo.areaFont(area, ref, base, k, min, max) : min; }
   // 势力色亮化(委托引擎·缺失回落 null → CSS fallback 金)。
-  function _tmBrightenLabelColor(color){ return _TMGeo ? _TMGeo.brightenLabelColor(color) : null; }
+  function _tmBrightenLabelColor(color){ var geo = getTMGeo(); return geo ? geo.brightenLabelColor(color) : null; }
 
   // perf round6 (2026-06-10): 归一化结果 memo·载档/回合末地图刷新对同一批字符串
   // 反复 trim+regex+lower 数百万次·见 _admIdxCache 注释
@@ -1055,10 +1060,11 @@
   function _factionLabelAnchor(g, avgx, avgy){
     var cx = g._wsum > 0 ? g._wx / g._wsum : avgx, cy = g._wsum > 0 ? g._wy / g._wsum : avgy;
     var regs = g._regs || [];
-    if (_TMGeo && regs.length) {
+    var geo = getTMGeo();
+    if (geo && regs.length) {
       for (var i = 0; i < regs.length; i++) {                     // 质心是否落在本势力某地块内
         var pts = pointsForRegion(regs[i]);
-        if (pts.length >= 3 && _TMGeo.pointToPolyDist(cx, cy, pts) > 0) return { x: cx, y: cy };
+        if (pts.length >= 3 && geo.pointToPolyDist(cx, cy, pts) > 0) return { x: cx, y: cy };
       }
       var best = null, bestD = Infinity;                          // 落缝隙/飞地外→吸附最近本势力地块内接圆心
       for (var j = 0; j < regs.length; j++) {
@@ -1079,13 +1085,14 @@
     var maxArea = Math.max.apply(null, groups.map(function(g){ return Number(g.area || 0); }).concat([1]));
     var maxN = Math.max.apply(null, groups.map(function(g){ return Number(g.n || 0); }).concat([1]));
     var maxSpan = Math.max.apply(null, groups.map(function(g){ return Number(g.span || 0); }).concat([1]));
+    var geo = getTMGeo();
     // 势力名字号按疆域「真面积」铺满区间：最小势力→MINF、最大→MAXF·中间 area^K 平滑铺开(owner: 大够大/小够小/均匀按面积)
     var facAreas = groups.map(function(g){ return Number(g.area || 0); }).filter(function(a){ return a > 0; });
     var minA = facAreas.length ? Math.min.apply(null, facAreas) : 1;
     var maxA = facAreas.length ? Math.max.apply(null, facAreas) : 1;
     return groups.map(function(g){
       var name = realmFactionName(g), nlen = String(name).length || 1;
-      var size = (legacy && _TMGeo) ? _TMGeo.legacyFactionSize(Number(g.area||0), maxArea, Number(g.n||0), maxN, Number(g.span||0), maxSpan, nlen) : realmLabelSize(Number(g.area||0), minA, maxA);
+      var size = (legacy && geo) ? geo.legacyFactionSize(Number(g.area||0), maxArea, Number(g.n||0), maxN, Number(g.span||0), maxSpan, nlen) : realmLabelSize(Number(g.area||0), minA, maxA);
       var rotate = realmLabelRotation(g.key || name);
       var lw = Math.max(size * 1.05, nlen * size * 1.12), lh = size * 1.25;   // 纯文字盒(无框·含 .34em 字距)·供防重叠
       var style = '--realm-label-size:' + size + 'px';
@@ -1140,6 +1147,15 @@
   function renderFormalMapSoon(){
     clearTimeout(state.mapRenderTimer);
     state.mapRenderTimer = setTimeout(renderFormalMap, 0);
+  }
+
+  var _labelFeatureRequested = false;
+  function requestMapLabelFeature(){
+    if (_labelFeatureRequested || !window.TM || !TM.Features || typeof TM.Features.ensure !== 'function') return;
+    _labelFeatureRequested = true;
+    TM.Features.ensure('formalMapLabels').catch(function(error){
+      if (window.console && typeof window.console.warn === 'function') window.console.warn('[phase8-formal-map] 标签 feature 加载失败', error);
+    });
   }
 
   // ── 阶段3·zoom 联动(CK3)：缩放跨阈值自动切 mapScale 层级·按钮切层亦带动缩放·单一真相=mapView.scale ──
@@ -1254,6 +1270,7 @@
     return filtered;
   }
   function renderFormalMap(){
+    requestMapLabelFeature();
     var shell = document.getElementById('tm-phase8-main-shell');
     var stage = mapStage();
     if (!shell || !stage || !isGameVisible()) {
@@ -2547,8 +2564,18 @@
   bridge.map.__liveOwnerFromProvinceMap = liveOwnerFromProvinceMap;
   bridge.map.__regionKeyNorm = regionKeyNorm;
   bridge.map.__regionMatchFields = regionMatchFields;
+  bridge.map.__regionTrueArea = regionTrueArea;
+  bridge.map.__labelAnchor = labelAnchor;
+  bridge.map.__requestMapLabelFeature = requestMapLabelFeature;
   // perf round7: 强制下次 renderFormalMap 重建 SVG(清 dirty 签名)·供几何变更等绕过守卫
   bridge.map.invalidateFormalMap = function(){ try { state._lastFormalMapSig = null; } catch(_){} };
+  bridge.map.invalidateMapLabelGeometryCaches = invalidateMapLabelGeometryCaches;
+  bridge.map.onMapLabelFeatureReady = function(){
+    invalidateMapLabelGeometryCaches();
+    state._lastFormalMapSig = null;
+    renderFormalMapSoon();
+    scheduleLabelLayout();
+  };
   bridge.map.__formalMapSignature = formalMapSignature;
 
   // ── re-attach bridge exposes that previously came from bridge.js ──

--- a/web/phase8-formal-map.js
+++ b/web/phase8-formal-map.js
@@ -1153,7 +1153,10 @@
   function requestMapLabelFeature(){
     if (_labelFeatureRequested || !window.TM || !TM.Features || typeof TM.Features.ensure !== 'function') return;
     _labelFeatureRequested = true;
-    TM.Features.ensure('formalMapLabels').catch(function(error){
+    var load = typeof TM.Features.ensureRecoverable === 'function'
+      ? TM.Features.ensureRecoverable('formalMapLabels', { retryLoadError: true, retryInitError: true })
+      : TM.Features.ensure('formalMapLabels');
+    load.catch(function(error){
       if (window.console && typeof window.console.warn === 'function') window.console.warn('[phase8-formal-map] 标签 feature 加载失败', error);
     });
   }
@@ -1270,7 +1273,6 @@
     return filtered;
   }
   function renderFormalMap(){
-    requestMapLabelFeature();
     var shell = document.getElementById('tm-phase8-main-shell');
     var stage = mapStage();
     if (!shell || !stage || !isGameVisible()) {
@@ -1281,6 +1283,7 @@
       }
       return;
     }
+    requestMapLabelFeature();
     var map = getMapData();
     if (!map || !Array.isArray(map.regions) || !map.regions.length) {
       stage.innerHTML = '<div class="tmf-map-loading">舆图数据尚未载入</div>';

--- a/web/scripts/arch-baselines/intentional-global-overrides.json
+++ b/web/scripts/arch-baselines/intentional-global-overrides.json
@@ -555,14 +555,6 @@
         "phase8-formal-drafts.js"
       ]
     },
-    "getTributeRatio": {
-      "owner": "tm-economy.js",
-      "reason": "Pre-existing classic-script provider chain retained as an explicit load-order contract; later providers intentionally extend or replace the compatibility surface.",
-      "expectedOrder": [
-        "tm-economy.js",
-        "tm-test-harness.js"
-      ]
-    },
     "GM": {
       "owner": "tm-data-model.js",
       "reason": "Pre-existing classic-script provider chain retained as an explicit load-order contract; later providers intentionally extend or replace the compatibility surface.",
@@ -637,8 +629,7 @@
       "expectedOrder": [
         "tm-data-model.js",
         "tm-save-lifecycle.js",
-        "tm-content-manager.js",
-        "tm-test-harness.js"
+        "tm-content-manager.js"
       ]
     },
     "renderEvtTab": {

--- a/web/scripts/build-feature-manifest.js
+++ b/web/scripts/build-feature-manifest.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const WEB_ROOT = path.resolve(__dirname, '..');
+const SOURCE = path.join(WEB_ROOT, 'feature-manifest.js');
+
+function loadFeatureManifest() {
+  let captured = null;
+  const root = {
+    TM: {
+      Features: {
+        registerManifest(manifest) {
+          if (captured) throw new Error('feature manifest registered more than once');
+          captured = manifest;
+        }
+      }
+    }
+  };
+  root.window = root;
+  root.globalThis = root;
+  vm.runInNewContext(fs.readFileSync(SOURCE, 'utf8'), root, { filename: SOURCE });
+  if (!captured) throw new Error('feature-manifest.js did not register a manifest');
+  return captured;
+}
+
+function scriptPath(src) {
+  return String(src || '').replace(/[?#].*$/, '').replace(/^\.\//, '');
+}
+
+function validateFeatureManifest(manifest) {
+  const errors = [];
+  if (!manifest || manifest.version !== 1) errors.push('manifest.version must equal 1');
+  const features = manifest && manifest.features;
+  if (!features || typeof features !== 'object' || Array.isArray(features)) errors.push('manifest.features must be an object');
+  const seenScripts = new Map();
+  Object.entries(features || {}).forEach(([name, feature]) => {
+    if (!/^[A-Za-z][A-Za-z0-9]*$/.test(name)) errors.push(`invalid feature name: ${name}`);
+    if (!Array.isArray(feature.scripts) || !feature.scripts.length) errors.push(`${name}: scripts must be non-empty`);
+    if (!Array.isArray(feature.dependsOn)) errors.push(`${name}: dependsOn must be an array`);
+    if (!Array.isArray(feature.provides) || !feature.provides.length) errors.push(`${name}: provides must be non-empty`);
+    if (!feature.platform) errors.push(`${name}: platform is required`);
+    if (!feature.loadPolicy) errors.push(`${name}: loadPolicy is required`);
+    if (!feature.sideEffects) errors.push(`${name}: sideEffects is required`);
+    (feature.scripts || []).forEach((src) => {
+      const clean = scriptPath(src);
+      if (!clean || path.isAbsolute(clean) || clean.includes('..')) errors.push(`${name}: unsafe script path ${src}`);
+      if (!fs.existsSync(path.join(WEB_ROOT, clean))) errors.push(`${name}: missing script ${clean}`);
+      if (seenScripts.has(clean)) errors.push(`${clean}: owned by both ${seenScripts.get(clean)} and ${name}`);
+      seenScripts.set(clean, name);
+    });
+  });
+  Object.entries(features || {}).forEach(([name, feature]) => {
+    (feature.dependsOn || []).forEach((dependency) => {
+      if (!Object.prototype.hasOwnProperty.call(features, dependency)) errors.push(`${name}: unknown dependency ${dependency}`);
+      if (dependency === name) errors.push(`${name}: feature cannot depend on itself`);
+    });
+  });
+  if (errors.length) throw new Error('feature manifest invalid:\n- ' + errors.join('\n- '));
+  return { featureCount: Object.keys(features).length, scriptCount: seenScripts.size };
+}
+
+if (require.main === module) {
+  const manifest = loadFeatureManifest();
+  const result = validateFeatureManifest(manifest);
+  if (process.argv.includes('--print')) {
+    const serializable = JSON.parse(JSON.stringify(manifest, (key, value) => typeof value === 'function' ? '[lifecycle]' : value));
+    process.stdout.write(JSON.stringify(serializable, null, 2) + '\n');
+  }
+  console.log(`[feature-manifest] PASS features=${result.featureCount} scripts=${result.scriptCount}`);
+}
+
+module.exports = { loadFeatureManifest, validateFeatureManifest, scriptPath };

--- a/web/scripts/build-feature-manifest.js
+++ b/web/scripts/build-feature-manifest.js
@@ -59,6 +59,25 @@ function validateFeatureManifest(manifest) {
       if (dependency === name) errors.push(`${name}: feature cannot depend on itself`);
     });
   });
+  const visiting = new Set();
+  const visited = new Set();
+  function visit(name, trail) {
+    if (visiting.has(name)) {
+      const start = trail.indexOf(name);
+      const cycle = trail.slice(start >= 0 ? start : 0).concat(name);
+      errors.push(`feature dependency cycle: ${cycle.join(' -> ')}`);
+      return;
+    }
+    if (visited.has(name) || !features || !features[name]) return;
+    visiting.add(name);
+    const nextTrail = trail.concat(name);
+    (features[name].dependsOn || []).forEach((dependency) => {
+      if (features[dependency]) visit(dependency, nextTrail);
+    });
+    visiting.delete(name);
+    visited.add(name);
+  }
+  Object.keys(features || {}).forEach((name) => visit(name, []));
   if (errors.length) throw new Error('feature manifest invalid:\n- ' + errors.join('\n- '));
   return { featureCount: Object.keys(features).length, scriptCount: seenScripts.size };
 }

--- a/web/scripts/build-startup-phase-manifest.js
+++ b/web/scripts/build-startup-phase-manifest.js
@@ -4,11 +4,14 @@
 const fs = require('fs');
 const path = require('path');
 const lib = require('./lib-arch-guard');
+const featureBuild = require('./build-feature-manifest');
 
 const INDEX = path.join(lib.WEB_ROOT, 'index.html');
 const PROVIDERS = path.join(lib.REPORT_DIR, 'global-providers.json');
 const OUTPUT = path.join(lib.WEB_ROOT, 'startup-script-phases.json');
 const CHECK = process.argv.includes('--check');
+const featureManifest = featureBuild.loadFeatureManifest();
+featureBuild.validateFeatureManifest(featureManifest);
 
 if (!fs.existsSync(PROVIDERS)) {
   throw new Error('global provider report missing; run node web/scripts/lint-global-providers.js first');
@@ -46,16 +49,34 @@ const scripts = parsed.map((row, index) => ({
   script: row.src,
   order: index,
   phase: phaseFor(index),
+  loadPolicy: 'eager-ordered',
+  platform: 'any',
+  sideEffects: 'legacy-unknown',
   provides: Array.from(providedByScript.get(row.src) || []).sort(),
   consumes: Array.from(consumedByScript.get(row.src) || []).sort(),
-  mustLoadBefore: index + 1 < parsed.length ? [parsed[index + 1].src] : [],
-  mustLoadAfter: index > 0 ? [parsed[index - 1].src] : [],
+  dependsOn: [],
+  mustLoadBefore: [],
+  mustLoadAfter: [],
   lazySafe: false,
-  reason: 'Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider.'
+  reason: 'Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js.'
 }));
 
+const features = Object.keys(featureManifest.features).sort().map((name) => {
+  const feature = featureManifest.features[name];
+  return {
+    feature: name,
+    scripts: feature.scripts.map(featureBuild.scriptPath),
+    loadPolicy: feature.loadPolicy,
+    platform: feature.platform,
+    sideEffects: feature.sideEffects,
+    dependsOn: feature.dependsOn.slice(),
+    provides: feature.provides.slice()
+  };
+});
+const deferredScriptCount = features.reduce((count, feature) => count + feature.scripts.length, 0);
+
 const manifest = {
-  version: 1,
+  version: 2,
   source: 'index.html',
   generatedBy: 'web/scripts/build-startup-phase-manifest.js',
   scriptCount: scripts.length,
@@ -63,9 +84,10 @@ const manifest = {
     out[row.phase] = (out[row.phase] || 0) + 1;
     return out;
   }, {}),
-  deferredChangesApproved: 0,
-  auditConclusion: 'No classic-script group was deferred in Round 20: 414+ ordered providers, immediate registrations, split-provider adjacency contracts, and two approved early reads make bulk defer unsafe without a dedicated loader migration.',
-  scripts
+  deferredChangesApproved: deferredScriptCount,
+  auditConclusion: 'Feature Loader V2 defers only six audited scripts behind explicit lifecycle and platform boundaries. All other classic scripts retain document order; adjacency alone is no longer emitted as a false dependency.',
+  scripts,
+  features
 };
 const text = JSON.stringify(manifest, null, 2) + '\n';
 
@@ -75,8 +97,8 @@ if (CHECK) {
     console.error('[startup-phase-manifest] stale: ' + lib.rel(OUTPUT));
     process.exit(1);
   }
-  console.log('[startup-phase-manifest] PASS scripts=' + scripts.length + ' phases=' + JSON.stringify(manifest.phaseCounts));
+  console.log('[startup-phase-manifest] PASS scripts=' + scripts.length + ' deferred=' + deferredScriptCount + ' phases=' + JSON.stringify(manifest.phaseCounts));
 } else {
   fs.writeFileSync(OUTPUT, text, 'utf8');
-  console.log('[startup-phase-manifest] wrote ' + lib.rel(OUTPUT) + ' scripts=' + scripts.length);
+  console.log('[startup-phase-manifest] wrote ' + lib.rel(OUTPUT) + ' scripts=' + scripts.length + ' deferred=' + deferredScriptCount);
 }

--- a/web/scripts/lint-arch-all.js
+++ b/web/scripts/lint-arch-all.js
@@ -16,6 +16,7 @@ const CHECKS = [
   { name: 'lint-gm-writes', file: 'lint-gm-writes.js' },
   { name: 'lint-dep-graph', file: 'lint-dep-graph.js' },
   { name: 'lint-global-providers', file: 'lint-global-providers.js' },
+  { name: 'lint-feature-boundaries', file: 'lint-feature-boundaries.js' },
   { name: 'lint-runtime-template-immutability', file: 'lint-runtime-template-immutability.js' },
   { name: 'lint-renderer-writeback-boundaries', file: 'lint-renderer-writeback-boundaries.js' },
   { name: 'lint-file-size', file: 'lint-file-size.js' },

--- a/web/scripts/lint-dep-graph.js
+++ b/web/scripts/lint-dep-graph.js
@@ -25,6 +25,7 @@
 const lib = require('./lib-arch-guard');
 const fs = require('fs');
 const path = require('path');
+const featureBuild = require('./build-feature-manifest');
 
 const BASELINE_FILE = path.join(lib.BASELINE_DIR, 'dep-dangling.json');
 const MANIFEST_FILE = path.join(lib.REPORT_DIR, 'deps-manifest.json');
@@ -112,6 +113,18 @@ function analyzeEntry(entry) {
     if (f.isData) return;
     manifest.push({ order, src: f.src, provides: [...s.provides].sort(), requires: [...s.requires].sort() });
   });
+  if (entry === 'index.html') {
+    const featureManifest = featureBuild.loadFeatureManifest();
+    featureBuild.validateFeatureManifest(featureManifest);
+    Object.entries(featureManifest.features).forEach(([featureName, feature]) => {
+      feature.provides.forEach((providerPath) => {
+        const match = String(providerPath).match(/^TM\.([A-Za-z_$][\w$]*)/);
+        if (!match) return;
+        if (!definers.has(match[1])) definers.set(match[1], []);
+        definers.get(match[1]).push(`feature:${featureName}`);
+      });
+    });
+  }
   const dangling = [...users.keys()].filter(ns => !definers.has(ns)).sort();
   const shared = [...definers.entries()].filter(([, v]) => v.length > 1).map(([k, v]) => ({ ns: k, files: v }));
   return { entry, files, definers, users, dangling, shared, dynamicDefiners, manifest };

--- a/web/scripts/lint-feature-boundaries.js
+++ b/web/scripts/lint-feature-boundaries.js
@@ -33,6 +33,10 @@ assert(featureResult.scriptCount === EAGER_REMOVALS.length, 'first feature cohor
 const loaderSource = fs.readFileSync(path.join(lib.WEB_ROOT, 'tm-feature-loader.js'), 'utf8');
 assert(!/(?:\beval\s*\(|new\s+Function\s*\()/.test(loaderSource), 'feature loader must not execute strings');
 assert(!/TM\.__[A-Za-z0-9]+Parts/.test(loaderSource), 'feature loader must not introduce a parts bucket');
+assert(/feature-reload-required/.test(loaderSource) && /scriptRequiresReload/.test(loaderSource), 'timed-out scripts must require a document reload instead of duplicate insertion');
+assert(/ensureRecoverable/.test(loaderSource), 'feature loader must expose one controlled recovery entry point');
+assert(/disposeRequested/.test(loaderSource), 'feature loader must coordinate dispose requests with in-flight loads');
+assert(/feature-dependency-cycle/.test(loaderSource), 'feature loader must reject dependency cycles at runtime');
 
 const desktopSource = fs.readFileSync(path.join(lib.WEB_ROOT, 'tm-desktop-update.js'), 'utf8');
 assert(/function\s+init\s*\(/.test(desktopSource) && /function\s+dispose\s*\(/.test(desktopSource), 'desktop update must expose an explicit lifecycle');
@@ -44,8 +48,15 @@ assert(!/addEventListener\(\s*['"]DOMContentLoaded['"]\s*,\s*(?:arm|init)/.test(
 
 const mapSource = fs.readFileSync(path.join(lib.WEB_ROOT, 'phase8-formal-map.js'), 'utf8');
 assert(!/var\s+_TMGeo\s*=/.test(mapSource), 'formal map must not capture the optional geometry provider at module load');
-assert(/TM\.Features\.ensure\(['"]formalMapLabels['"]\)/.test(mapSource), 'formal map must request its label feature at first render');
+assert(/TM\.Features\.ensureRecoverable\(['"]formalMapLabels['"]/.test(mapSource), 'formal map must use controlled feature recovery');
 assert(/invalidateMapLabelGeometryCaches/.test(mapSource), 'formal map must invalidate fallback geometry caches after late load');
+const renderStart = mapSource.indexOf('function renderFormalMap(){');
+const renderEnd = mapSource.indexOf('var map = getMapData();', renderStart);
+const renderGate = mapSource.slice(renderStart, renderEnd);
+assert(renderGate.indexOf('if (!shell || !stage || !isGameVisible())') < renderGate.indexOf('requestMapLabelFeature();'), 'formal map must request labels only after its visibility gate');
+
+const contentSource = fs.readFileSync(path.join(lib.WEB_ROOT, 'tm-content-manager.js'), 'utf8');
+assert(/TM\.Features\.ensureRecoverable\(['"]desktopUpdate['"]/.test(contentSource), 'desktop content manager must use controlled feature recovery');
 
 if (fs.existsSync(STARTUP)) {
   const startup = JSON.parse(fs.readFileSync(STARTUP, 'utf8'));

--- a/web/scripts/lint-feature-boundaries.js
+++ b/web/scripts/lint-feature-boundaries.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const lib = require('./lib-arch-guard');
+const featureBuild = require('./build-feature-manifest');
+
+const INDEX = path.join(lib.WEB_ROOT, 'index.html');
+const STARTUP = path.join(lib.WEB_ROOT, 'startup-script-phases.json');
+const EAGER_REMOVALS = [
+  'tm-test-harness.js',
+  'tm-update-card.js',
+  'tm-desktop-update.js',
+  'tm-online-update.js',
+  'tm-map-label-geo.js',
+  'tm-map-label-collide.js'
+];
+
+const failures = [];
+function assert(condition, message) { if (!condition) failures.push(message); }
+
+const manifest = featureBuild.loadFeatureManifest();
+const featureResult = featureBuild.validateFeatureManifest(manifest);
+const eager = lib.parseIndexScripts(INDEX).filter((row) => /\.js$/i.test(row.src || '')).map((row) => row.src);
+assert(eager.filter((src) => src === 'tm-feature-loader.js').length === 1, 'index.html must eagerly load exactly one tm-feature-loader.js');
+EAGER_REMOVALS.forEach((src) => assert(!eager.includes(src), `${src} must not remain in the eager startup chain`));
+
+const declaredScripts = Object.values(manifest.features).flatMap((feature) => feature.scripts.map(featureBuild.scriptPath));
+EAGER_REMOVALS.forEach((src) => assert(declaredScripts.includes(src), `${src} must be owned by a declared feature`));
+assert(featureResult.scriptCount === EAGER_REMOVALS.length, 'first feature cohort must own exactly six deferred scripts');
+
+const loaderSource = fs.readFileSync(path.join(lib.WEB_ROOT, 'tm-feature-loader.js'), 'utf8');
+assert(!/(?:\beval\s*\(|new\s+Function\s*\()/.test(loaderSource), 'feature loader must not execute strings');
+assert(!/TM\.__[A-Za-z0-9]+Parts/.test(loaderSource), 'feature loader must not introduce a parts bucket');
+
+const desktopSource = fs.readFileSync(path.join(lib.WEB_ROOT, 'tm-desktop-update.js'), 'utf8');
+assert(/function\s+init\s*\(/.test(desktopSource) && /function\s+dispose\s*\(/.test(desktopSource), 'desktop update must expose an explicit lifecycle');
+assert(!/addEventListener\(\s*['"]load['"]\s*,\s*(?:arm|init)/.test(desktopSource), 'desktop update must not self-initialize at module load');
+
+const onlineSource = fs.readFileSync(path.join(lib.WEB_ROOT, 'tm-online-update.js'), 'utf8');
+assert(/function\s+init\s*\(/.test(onlineSource) && /function\s+dispose\s*\(/.test(onlineSource), 'online update must expose an explicit lifecycle');
+assert(!/addEventListener\(\s*['"]DOMContentLoaded['"]\s*,\s*(?:arm|init)/.test(onlineSource), 'online update must not self-initialize at module load');
+
+const mapSource = fs.readFileSync(path.join(lib.WEB_ROOT, 'phase8-formal-map.js'), 'utf8');
+assert(!/var\s+_TMGeo\s*=/.test(mapSource), 'formal map must not capture the optional geometry provider at module load');
+assert(/TM\.Features\.ensure\(['"]formalMapLabels['"]\)/.test(mapSource), 'formal map must request its label feature at first render');
+assert(/invalidateMapLabelGeometryCaches/.test(mapSource), 'formal map must invalidate fallback geometry caches after late load');
+
+if (fs.existsSync(STARTUP)) {
+  const startup = JSON.parse(fs.readFileSync(STARTUP, 'utf8'));
+  assert(startup.version === 2, 'startup manifest must use schema version 2');
+  assert(startup.deferredChangesApproved >= 6, 'startup manifest must record at least six approved deferred scripts');
+  assert(Array.isArray(startup.features) && startup.features.length >= 4, 'startup manifest must include explicit feature definitions');
+}
+
+if (failures.length) {
+  failures.forEach((failure) => console.error('[lint-feature-boundaries] ' + failure));
+  process.exit(1);
+}
+console.log(`[lint-feature-boundaries] PASS eager=${eager.length} features=${featureResult.featureCount} deferredScripts=${featureResult.scriptCount}`);

--- a/web/scripts/smoke-feature-lifecycle.js
+++ b/web/scripts/smoke-feature-lifecycle.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const WEB = path.resolve(__dirname, '..');
+
+function testDesktopLifecycle() {
+  const source = fs.readFileSync(path.join(WEB, 'tm-desktop-update.js'), 'utf8');
+  let hotSubscriptions = 0;
+  let installerSubscriptions = 0;
+  const tianming = {
+    checkHotUpdate() { return Promise.resolve({ success: true, hasUpdate: false }); },
+    hotUpdateStatus() { return Promise.resolve({ success: true, status: { isPackaged: true } }); },
+    onHotUpdateStatus() {
+      hotSubscriptions += 1;
+      let active = true;
+      return function dispose() { if (active) { active = false; hotSubscriptions -= 1; } };
+    },
+    onUpdateStatus() {
+      installerSubscriptions += 1;
+      let active = true;
+      return function dispose() { if (active) { active = false; installerSubscriptions -= 1; } };
+    }
+  };
+  const window = { tianming, performance: { now: Date.now }, console: { warn() {}, log() {} } };
+  const document = { getElementById() { return null; }, querySelector() { return null; } };
+  new Function('window', 'document', 'localStorage', 'setTimeout', 'setInterval', source)(
+    window, document, { getItem() { return null; }, setItem() {} }, setTimeout, setInterval
+  );
+  assert(window.TMDesktopUpdate, 'desktop provider is defined without initializing');
+  assert.strictEqual(hotSubscriptions + installerSubscriptions, 0, 'module evaluation installs no IPC subscription');
+  window.TMDesktopUpdate.init();
+  window.TMDesktopUpdate.init();
+  assert.strictEqual(hotSubscriptions, 1, 'repeated init retains one hot-update subscription');
+  assert.strictEqual(installerSubscriptions, 1, 'repeated init retains one installer subscription');
+  assert.strictEqual(window.TMDesktopUpdate.state().subscriptions, 2, 'provider reports its exact subscriptions');
+  window.TMDesktopUpdate.dispose();
+  window.TMDesktopUpdate.dispose();
+  assert.strictEqual(hotSubscriptions + installerSubscriptions, 0, 'repeated dispose removes exact IPC listeners once');
+}
+
+function testOnlineLifecycle() {
+  const source = fs.readFileSync(path.join(WEB, 'tm-online-update.js'), 'utf8');
+  const timers = new Map();
+  const intervals = new Map();
+  const listeners = new Map();
+  let nextId = 1;
+  const document = {
+    hidden: false,
+    head: { appendChild() {} },
+    body: { appendChild() {} },
+    documentElement: { appendChild() {} },
+    createElement() { return { addEventListener() {}, appendChild() {}, classList: { add() {} } }; },
+    getElementById() { return null; },
+    querySelector(selector) {
+      if (selector === 'meta[name="tm-version"]') return { getAttribute() { return '1.3.4.11'; } };
+      return null;
+    },
+    addEventListener(type, fn) { if (!listeners.has(type)) listeners.set(type, new Set()); listeners.get(type).add(fn); },
+    removeEventListener(type, fn) { if (listeners.has(type)) listeners.get(type).delete(fn); }
+  };
+  const window = { location: { search: '', pathname: '/', replace() {}, reload() {} } };
+  function setTimeoutStub(fn, ms) { const id = nextId++; timers.set(id, { fn, ms }); return id; }
+  function clearTimeoutStub(id) { timers.delete(id); }
+  function setIntervalStub(fn, ms) { const id = nextId++; intervals.set(id, { fn, ms }); return id; }
+  function clearIntervalStub(id) { intervals.delete(id); }
+  new Function('window', 'document', 'localStorage', 'fetch', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', source)(
+    window,
+    document,
+    { getItem() { return null; }, setItem() {} },
+    function fetchStub() { return Promise.resolve({ ok: false }); },
+    setTimeoutStub,
+    clearTimeoutStub,
+    setIntervalStub,
+    clearIntervalStub
+  );
+  assert(window.TM_OnlineUpdate, 'online update provider is defined without initializing');
+  assert.strictEqual(timers.size + intervals.size, 0, 'module evaluation schedules no update timer');
+  assert.strictEqual((listeners.get('visibilitychange') || new Set()).size, 0, 'module evaluation installs no visibility listener');
+  window.TM_OnlineUpdate.init();
+  window.TM_OnlineUpdate.init();
+  assert.strictEqual(timers.size, 1, 'repeated init retains one first-check timer');
+  assert.strictEqual(intervals.size, 1, 'repeated init retains one recheck interval');
+  assert.strictEqual(listeners.get('visibilitychange').size, 1, 'repeated init retains one visibility listener');
+  window.TM_OnlineUpdate.dispose();
+  window.TM_OnlineUpdate.dispose();
+  assert.strictEqual(timers.size + intervals.size, 0, 'dispose clears all update timers');
+  assert.strictEqual(listeners.get('visibilitychange').size, 0, 'dispose removes the exact visibility listener');
+}
+
+testDesktopLifecycle();
+testOnlineLifecycle();
+console.log('[smoke-feature-lifecycle] PASS assertions=14');

--- a/web/scripts/smoke-feature-loader-v2.js
+++ b/web/scripts/smoke-feature-loader-v2.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const WEB = path.resolve(__dirname, '..');
+const LOADER = fs.readFileSync(path.join(WEB, 'tm-feature-loader.js'), 'utf8');
+const MANIFEST = fs.readFileSync(path.join(WEB, 'feature-manifest.js'), 'utf8');
+
+function tick() { return new Promise((resolve) => setImmediate(resolve)); }
+async function settle(rounds = 8) { for (let i = 0; i < rounds; i++) await tick(); }
+
+function makeEnvironment(options = {}) {
+  const loads = [];
+  const loadHandlers = [];
+  const idleHandlers = [];
+  const lifecycle = { desktopInit: 0, desktopDispose: 0, onlineInit: 0, onlineDispose: 0 };
+  const failures = Object.assign({}, options.failures || {});
+  let context;
+
+  const document = {
+    readyState: options.readyState || 'loading',
+    createElement(tag) { return { tagName: String(tag).toUpperCase(), dataset: {}, async: true, onload: null, onerror: null }; },
+    head: { appendChild: appendScript },
+    documentElement: { appendChild: appendScript }
+  };
+
+  function clean(src) { return String(src).replace(/[?#].*$/, ''); }
+  function appendScript(script) {
+    const src = clean(script.src);
+    loads.push(src);
+    Promise.resolve().then(() => {
+      if (failures[src] > 0) {
+        failures[src] -= 1;
+        if (script.onerror) script.onerror(new Error('injected load failure'));
+        return;
+      }
+      if (src === 'feature-manifest.js') vm.runInContext(MANIFEST, context, { filename: src });
+      else if (src === 'tm-test-harness.js') context.TM.test = { run() {} };
+      else if (src === 'tm-update-card.js') context.TMUpdateCard = {};
+      else if (src === 'tm-desktop-update.js') {
+        context.TMDesktopUpdate = {
+          init() { lifecycle.desktopInit += 1; },
+          dispose() { lifecycle.desktopDispose += 1; }
+        };
+      } else if (src === 'tm-online-update.js') {
+        context.TM_OnlineUpdate = {
+          init() { lifecycle.onlineInit += 1; },
+          dispose() { lifecycle.onlineDispose += 1; }
+        };
+      } else if (src === 'tm-map-label-geo.js') context.TMMapLabelGeo = {};
+      else if (src === 'tm-map-label-collide.js') context.TMMapLabelCollide = {};
+      else if (src === 'retry-once.js') context.RetryOnce = {};
+      else if (src === 'always-fail.js') {
+        if (script.onerror) script.onerror(new Error('always fails'));
+        return;
+      }
+      if (script.onload) script.onload();
+    });
+    return script;
+  }
+
+  const root = {
+    console: { warn() {}, log() {}, error() {} },
+    Promise,
+    Map,
+    Object,
+    Array,
+    Error,
+    Number,
+    String,
+    RegExp,
+    Date,
+    setTimeout,
+    clearTimeout,
+    document,
+    location: { search: options.search || '' },
+    TM: { platform: { kind: options.platform || 'web' } },
+    addEventListener(type, fn) { if (type === 'load') loadHandlers.push(fn); },
+    requestIdleCallback(fn) { idleHandlers.push(fn); return idleHandlers.length; }
+  };
+  root.window = root;
+  root.globalThis = root;
+  context = vm.createContext(root);
+  vm.runInContext(LOADER, context, { filename: 'tm-feature-loader.js' });
+  return {
+    root,
+    loads,
+    lifecycle,
+    fireLoad() { document.readyState = 'complete'; loadHandlers.splice(0).forEach((fn) => fn()); },
+    fireIdle() { idleHandlers.splice(0).forEach((fn) => fn()); }
+  };
+}
+
+(async function main() {
+  const desktop = makeEnvironment({ platform: 'electron' });
+  assert.strictEqual(desktop.root.TM.test, undefined, 'normal production startup does not expose TM.test');
+  const concurrent = Array.from({ length: 10 }, () => desktop.root.TM.Features.ensure('desktopUpdate'));
+  const results = await Promise.all(concurrent);
+  assert(results.every((row) => row.ok), 'ten concurrent ensure calls resolve successfully');
+  assert.strictEqual(desktop.loads.filter((src) => src === 'feature-manifest.js').length, 1, 'manifest script loads once');
+  assert.strictEqual(desktop.loads.filter((src) => src === 'tm-update-card.js').length, 1, 'first feature script loads once');
+  assert.strictEqual(desktop.loads.filter((src) => src === 'tm-desktop-update.js').length, 1, 'second feature script loads once');
+  assert(desktop.loads.indexOf('tm-update-card.js') < desktop.loads.indexOf('tm-desktop-update.js'), 'classic scripts load in declared sequence');
+  assert.strictEqual(desktop.lifecycle.desktopInit, 1, 'feature init executes once');
+  await desktop.root.TM.Features.dispose('desktopUpdate');
+  await desktop.root.TM.Features.dispose('desktopUpdate');
+  assert.strictEqual(desktop.lifecycle.desktopDispose, 1, 'feature dispose is idempotent');
+  await desktop.root.TM.Features.ensure('desktopUpdate');
+  assert.strictEqual(desktop.lifecycle.desktopInit, 2, 'disposed feature can initialize again without reloading scripts');
+  assert.strictEqual(desktop.loads.filter((src) => src === 'tm-desktop-update.js').length, 1, 'reinitialization reuses loaded script');
+
+  const mismatch = await desktop.root.TM.Features.ensure('onlineUpdate');
+  assert.strictEqual(mismatch.code, 'not-applicable', 'desktop rejects web-only feature with a structured result');
+
+  desktop.root.TM.Features.define('missingProvider', {
+    scripts: ['missing-provider.js'], dependsOn: [], platform: 'any', provides: ['NeverDefined']
+  });
+  await assert.rejects(desktop.root.TM.Features.ensure('missingProvider'), (error) => error.code === 'feature-provider-missing');
+
+  const retry = makeEnvironment({ platform: 'web', failures: { 'retry-once.js': 1 } });
+  retry.root.TM.Features.define('retryOnce', {
+    scripts: ['retry-once.js'], dependsOn: [], platform: 'any', provides: ['RetryOnce']
+  });
+  await assert.rejects(retry.root.TM.Features.ensure('retryOnce'), (error) => error.code === 'feature-script-load-failed');
+  await assert.rejects(retry.root.TM.Features.ensure('retryOnce'), (error) => error.code === 'feature-retry-required');
+  const retried = await retry.root.TM.Features.retry('retryOnce');
+  assert.strictEqual(retried.ok, true, 'one explicit retry can recover a failed feature');
+  assert.strictEqual(retry.loads.filter((src) => src === 'retry-once.js').length, 2, 'retry inserts the failed script exactly once more');
+
+  retry.root.TM.Features.define('alwaysFail', {
+    scripts: ['always-fail.js'], dependsOn: [], platform: 'any', provides: ['Never']
+  });
+  await assert.rejects(retry.root.TM.Features.ensure('alwaysFail'));
+  await assert.rejects(retry.root.TM.Features.retry('alwaysFail'));
+  await assert.rejects(retry.root.TM.Features.retry('alwaysFail'), (error) => error.code === 'feature-retry-limit');
+
+  const normal = makeEnvironment({ platform: 'web' });
+  normal.fireLoad();
+  await settle();
+  assert.strictEqual(normal.root.TM.test, undefined, 'window load without a test query still does not load the harness');
+  assert(!normal.loads.includes('tm-online-update.js'), 'web update waits for the idle boundary');
+  normal.fireIdle();
+  await settle();
+  assert(normal.loads.includes('tm-online-update.js'), 'web idle boundary loads online update');
+  assert.strictEqual(normal.lifecycle.onlineInit, 1, 'web update lifecycle initializes once');
+
+  const harness = makeEnvironment({ platform: 'web', search: '?devHarness=1' });
+  harness.fireLoad();
+  await settle();
+  assert(harness.root.TM.test && typeof harness.root.TM.test.run === 'function', 'development query loads the browser harness after window load');
+  assert.strictEqual(harness.loads.filter((src) => src === 'tm-test-harness.js').length, 1, 'query path loads the harness once');
+
+  const touch = makeEnvironment({ platform: 'capacitor' });
+  const mapLabels = await touch.root.TM.Features.ensure('formalMapLabels');
+  assert.strictEqual(mapLabels.ok, true, 'platform any feature loads on touch/capacitor');
+  assert(touch.root.TMMapLabelGeo && touch.root.TMMapLabelCollide, 'touch branch receives both map label providers');
+  assert.strictEqual((await touch.root.TM.Features.ensure('desktopUpdate')).code, 'not-applicable', 'touch branch rejects desktop-only feature');
+
+  console.log('[smoke-feature-loader-v2] PASS assertions=27');
+})().catch((error) => {
+  console.error(error && error.stack || error);
+  process.exit(1);
+});

--- a/web/scripts/smoke-feature-loader-v2.js
+++ b/web/scripts/smoke-feature-loader-v2.js
@@ -5,6 +5,7 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const featureBuild = require('./build-feature-manifest');
 
 const WEB = path.resolve(__dirname, '..');
 const LOADER = fs.readFileSync(path.join(WEB, 'tm-feature-loader.js'), 'utf8');
@@ -15,15 +16,27 @@ async function settle(rounds = 8) { for (let i = 0; i < rounds; i++) await tick(
 
 function makeEnvironment(options = {}) {
   const loads = [];
+  const scriptNodes = [];
   const loadHandlers = [];
   const idleHandlers = [];
   const lifecycle = { desktopInit: 0, desktopDispose: 0, onlineInit: 0, onlineDispose: 0 };
   const failures = Object.assign({}, options.failures || {});
+  const manualScripts = new Set(options.manualScripts || []);
   let context;
 
   const document = {
     readyState: options.readyState || 'loading',
-    createElement(tag) { return { tagName: String(tag).toUpperCase(), dataset: {}, async: true, onload: null, onerror: null }; },
+    createElement(tag) {
+      return {
+        tagName: String(tag).toUpperCase(),
+        dataset: {},
+        async: true,
+        onload: null,
+        onerror: null,
+        removed: false,
+        remove() { this.removed = true; }
+      };
+    },
     head: { appendChild: appendScript },
     documentElement: { appendChild: appendScript }
   };
@@ -32,6 +45,8 @@ function makeEnvironment(options = {}) {
   function appendScript(script) {
     const src = clean(script.src);
     loads.push(src);
+    scriptNodes.push(script);
+    if (manualScripts.has(src)) return script;
     Promise.resolve().then(() => {
       if (failures[src] > 0) {
         failures[src] -= 1;
@@ -89,7 +104,16 @@ function makeEnvironment(options = {}) {
   return {
     root,
     loads,
+    scriptNodes,
     lifecycle,
+    completeManual(src, install) {
+      const cleanSrc = clean(src);
+      const script = scriptNodes.find((row) => clean(row.src) === cleanSrc);
+      if (!script) throw new Error('manual script was not inserted: ' + cleanSrc);
+      if (typeof install === 'function') install(context);
+      if (script.onload) script.onload();
+      return script;
+    },
     fireLoad() { document.readyState = 'complete'; loadHandlers.splice(0).forEach((fn) => fn()); },
     fireIdle() { idleHandlers.splice(0).forEach((fn) => fn()); }
   };
@@ -131,12 +155,127 @@ function makeEnvironment(options = {}) {
   assert.strictEqual(retried.ok, true, 'one explicit retry can recover a failed feature');
   assert.strictEqual(retry.loads.filter((src) => src === 'retry-once.js').length, 2, 'retry inserts the failed script exactly once more');
 
+  const recoverable = makeEnvironment({ platform: 'web', failures: { 'retry-once.js': 1 } });
+  recoverable.root.TM.Features.define('recoverableLoad', {
+    scripts: ['retry-once.js'], dependsOn: [], platform: 'any', provides: ['RetryOnce']
+  });
+  const recovered = await recoverable.root.TM.Features.ensureRecoverable('recoverableLoad');
+  assert.strictEqual(recovered.ok, true, 'controlled recovery retries an explicit network load error');
+  assert.strictEqual(recoverable.loads.filter((src) => src === 'retry-once.js').length, 2, 'controlled recovery performs at most one second insertion after onerror');
+
+  const initRecovery = makeEnvironment({ platform: 'web' });
+  let initAttempts = 0;
+  let initRollbacks = 0;
+  initRecovery.root.TM.Features.define('recoverableInit', {
+    scripts: ['retry-once.js'],
+    dependsOn: [],
+    platform: 'any',
+    provides: ['RetryOnce'],
+    init() {
+      initAttempts += 1;
+      if (initAttempts === 1) throw new Error('injected init failure');
+    },
+    dispose() { initRollbacks += 1; }
+  });
+  const initRecovered = await initRecovery.root.TM.Features.ensureRecoverable('recoverableInit');
+  assert.strictEqual(initRecovered.ok, true, 'controlled recovery retries init only after rollback');
+  assert.strictEqual(initAttempts, 2, 'init retry executes exactly twice');
+  assert.strictEqual(initRollbacks, 1, 'failed init performs exactly one rollback before retry');
+
   retry.root.TM.Features.define('alwaysFail', {
     scripts: ['always-fail.js'], dependsOn: [], platform: 'any', provides: ['Never']
   });
   await assert.rejects(retry.root.TM.Features.ensure('alwaysFail'));
   await assert.rejects(retry.root.TM.Features.retry('alwaysFail'));
   await assert.rejects(retry.root.TM.Features.retry('alwaysFail'), (error) => error.code === 'feature-retry-limit');
+
+  const late = makeEnvironment({ platform: 'web', manualScripts: ['slow-late.js'] });
+  let lateInit = 0;
+  late.root.TM.Features.define('slowLate', {
+    scripts: ['slow-late.js'],
+    dependsOn: [],
+    platform: 'any',
+    provides: ['SlowLate'],
+    timeoutMs: 5,
+    init() { lateInit += 1; }
+  });
+  await assert.rejects(late.root.TM.Features.ensure('slowLate'), (error) => error.code === 'feature-script-timeout');
+  assert.strictEqual(late.scriptNodes.length, 1, 'timeout inserts only one script node');
+  assert.strictEqual(late.scriptNodes[0].removed, true, 'timeout best-effort removes the orphaned script node');
+  late.completeManual('slow-late.js', (ctx) => {
+    ctx.SlowLate = {};
+    ctx.__lateScriptExecutions = (ctx.__lateScriptExecutions || 0) + 1;
+  });
+  await settle();
+  await assert.rejects(late.root.TM.Features.retry('slowLate'), (error) => error.code === 'feature-reload-required');
+  await assert.rejects(late.root.TM.Features.ensureRecoverable('slowLate'), (error) => error.code === 'feature-reload-required');
+  assert.strictEqual(late.loads.filter((src) => src === 'slow-late.js').length, 1, 'late completion cannot trigger a duplicate same-src insertion');
+  assert.strictEqual(late.root.__lateScriptExecutions, 1, 'late classic script executes at most once in the document');
+  assert.strictEqual(lateInit, 0, 'late completion does not run feature init after timeout');
+
+  const disposeBeforeInit = makeEnvironment({ platform: 'web', manualScripts: ['dispose-before-init.js'] });
+  let skippedInitCalls = 0;
+  let skippedDisposeCalls = 0;
+  disposeBeforeInit.root.TM.Features.define('disposeBeforeInit', {
+    scripts: ['dispose-before-init.js'],
+    dependsOn: [],
+    platform: 'any',
+    provides: ['DisposeBeforeInit'],
+    init() { skippedInitCalls += 1; },
+    dispose() { skippedDisposeCalls += 1; }
+  });
+  const pendingBeforeInit = disposeBeforeInit.root.TM.Features.ensure('disposeBeforeInit');
+  await settle(2);
+  const disposeBeforeInitResult = disposeBeforeInit.root.TM.Features.dispose('disposeBeforeInit');
+  disposeBeforeInit.completeManual('dispose-before-init.js', (ctx) => { ctx.DisposeBeforeInit = {}; });
+  const beforeInitResults = await Promise.all([pendingBeforeInit, disposeBeforeInitResult]);
+  assert.strictEqual(beforeInitResults[0].state, 'disposed', 'load resolves deterministically as disposed when disposal wins before init');
+  assert.strictEqual(skippedInitCalls, 0, 'dispose requested during script loading skips init');
+  assert.strictEqual(skippedDisposeCalls, 0, 'skipped init does not invoke an unnecessary disposer');
+  assert.strictEqual(disposeBeforeInit.root.TM.Features.status('disposeBeforeInit').state, 'disposed', 'in-flight dispose leaves a stable disposed state');
+
+  const disposeDuringInit = makeEnvironment({ platform: 'web' });
+  let releaseInit;
+  let duringInitCalls = 0;
+  let duringDisposeCalls = 0;
+  disposeDuringInit.root.TM.Features.define('disposeDuringInit', {
+    scripts: ['retry-once.js'],
+    dependsOn: [],
+    platform: 'any',
+    provides: ['RetryOnce'],
+    init() {
+      duringInitCalls += 1;
+      return new Promise((resolve) => { releaseInit = resolve; });
+    },
+    dispose() { duringDisposeCalls += 1; }
+  });
+  const pendingDuringInit = disposeDuringInit.root.TM.Features.ensure('disposeDuringInit');
+  await settle(4);
+  assert.strictEqual(duringInitCalls, 1, 'async init is in flight before disposal');
+  const disposeDuringInitResult = disposeDuringInit.root.TM.Features.dispose('disposeDuringInit');
+  releaseInit();
+  await Promise.all([pendingDuringInit, disposeDuringInitResult]);
+  assert.strictEqual(duringDisposeCalls, 1, 'dispose waits for in-flight init and runs the disposer exactly once');
+  assert.strictEqual(disposeDuringInit.root.TM.Features.status('disposeDuringInit').state, 'disposed', 'dispose during init cannot later become ready');
+
+  const runtimeCycle = makeEnvironment({ platform: 'web' });
+  assert.throws(() => runtimeCycle.root.TM.Features.registerManifest({
+    version: 1,
+    features: {
+      cycleA: { scripts: ['a.js'], dependsOn: ['cycleB'], platform: 'any', provides: ['CycleA'] },
+      cycleB: { scripts: ['b.js'], dependsOn: ['cycleA'], platform: 'any', provides: ['CycleB'] }
+    }
+  }), (error) => error.code === 'feature-dependency-cycle', 'runtime manifest registration rejects a two-node dependency cycle');
+  assert.strictEqual(runtimeCycle.root.TM.Features.status('cycleA').state, 'unknown', 'cycle rejection is atomic and installs no partial definitions');
+
+  assert.throws(() => featureBuild.validateFeatureManifest({
+    version: 1,
+    features: {
+      cycleA: { scripts: ['tm-update-card.js'], dependsOn: ['cycleB'], platform: 'any', loadPolicy: 'on-demand', sideEffects: 'none', provides: ['CycleA'] },
+      cycleB: { scripts: ['tm-desktop-update.js'], dependsOn: ['cycleC'], platform: 'any', loadPolicy: 'on-demand', sideEffects: 'none', provides: ['CycleB'] },
+      cycleC: { scripts: ['tm-online-update.js'], dependsOn: ['cycleA'], platform: 'any', loadPolicy: 'on-demand', sideEffects: 'none', provides: ['CycleC'] }
+    }
+  }), /feature dependency cycle: cycleA -> cycleB -> cycleC -> cycleA/, 'build-time manifest validation rejects a three-node dependency cycle');
 
   const normal = makeEnvironment({ platform: 'web' });
   normal.fireLoad();
@@ -160,7 +299,7 @@ function makeEnvironment(options = {}) {
   assert(touch.root.TMMapLabelGeo && touch.root.TMMapLabelCollide, 'touch branch receives both map label providers');
   assert.strictEqual((await touch.root.TM.Features.ensure('desktopUpdate')).code, 'not-applicable', 'touch branch rejects desktop-only feature');
 
-  console.log('[smoke-feature-loader-v2] PASS assertions=27');
+  console.log('[smoke-feature-loader-v2] PASS assertions=51');
 })().catch((error) => {
   console.error(error && error.stack || error);
   process.exit(1);

--- a/web/scripts/smoke-map-label-feature-late-binding.js
+++ b/web/scripts/smoke-map-label-feature-late-binding.js
@@ -11,17 +11,31 @@ const mapSource = fs.readFileSync(path.join(WEB, 'phase8-formal-map.js'), 'utf8'
 const geoSource = fs.readFileSync(path.join(WEB, 'tm-map-label-geo.js'), 'utf8');
 const timers = [];
 let ensureCalls = 0;
+let gameVisible = false;
 
 const state = { mapView: { scale: 1, tx: 0, ty: 0 }, mapScale: 'region' };
+const shell = {};
+const stage = { innerHTML: '' };
+function ensureLabels(name) {
+  ensureCalls += 1;
+  assert.strictEqual(name, 'formalMapLabels');
+  return Promise.resolve({ ok: true });
+}
 const bridge = {
   _state: state,
   map: {},
   _esc: String,
   _attr: String,
-  _isGameVisible() { return false; }
+  _isGameVisible() { return gameVisible; },
+  _hasRegionMap() { return false; },
+  _getScenarioMapData() { return null; }
 };
 const document = {
-  getElementById() { return null; },
+  getElementById(id) {
+    if (id === 'tm-phase8-main-shell') return shell;
+    if (id === 'ming-map-layer' || id === 'tmf-map-stage') return stage;
+    return null;
+  },
   querySelector() { return null; },
   addEventListener() {},
   elementsFromPoint() { return []; }
@@ -31,7 +45,7 @@ const root = {
   document,
   TMPhase8FormalBridge: bridge,
   TM_PHASE8_FORMAL: state,
-  TM: { Features: { ensure(name) { ensureCalls += 1; assert.strictEqual(name, 'formalMapLabels'); return Promise.resolve({ ok: true }); } } },
+  TM: { Features: { ensure: ensureLabels, ensureRecoverable: ensureLabels } },
   setTimeout(fn, ms) { timers.push({ fn, ms }); return timers.length; },
   clearTimeout() {},
   setInterval() {},
@@ -60,6 +74,9 @@ vm.runInContext(mapSource, context, { filename: 'phase8-formal-map.js' });
 const triangle = { points: [[0, 0], [10, 0], [0, 10]] };
 assert.strictEqual(bridge.map.__regionTrueArea(triangle), 100, 'before the optional provider loads, formal map uses the bbox fallback');
 bridge.map.renderFormalMap();
+assert.strictEqual(ensureCalls, 0, 'hidden formal map does not load the optional label feature');
+gameVisible = true;
+bridge.map.renderFormalMap();
 bridge.map.renderFormalMap();
 assert.strictEqual(ensureCalls, 1, 'repeated map renders request the label feature once');
 
@@ -72,4 +89,4 @@ bridge.map.onMapLabelFeatureReady();
 assert.strictEqual(state._lastFormalMapSig, null, 'late provider invalidates the formal map signature');
 assert(timers.length >= beforeTimers + 2, 'late provider schedules both rerender and collision layout');
 
-console.log('[smoke-map-label-feature-late-binding] PASS assertions=6');
+console.log('[smoke-map-label-feature-late-binding] PASS assertions=7');

--- a/web/scripts/smoke-map-label-feature-late-binding.js
+++ b/web/scripts/smoke-map-label-feature-late-binding.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const WEB = path.resolve(__dirname, '..');
+const mapSource = fs.readFileSync(path.join(WEB, 'phase8-formal-map.js'), 'utf8');
+const geoSource = fs.readFileSync(path.join(WEB, 'tm-map-label-geo.js'), 'utf8');
+const timers = [];
+let ensureCalls = 0;
+
+const state = { mapView: { scale: 1, tx: 0, ty: 0 }, mapScale: 'region' };
+const bridge = {
+  _state: state,
+  map: {},
+  _esc: String,
+  _attr: String,
+  _isGameVisible() { return false; }
+};
+const document = {
+  getElementById() { return null; },
+  querySelector() { return null; },
+  addEventListener() {},
+  elementsFromPoint() { return []; }
+};
+const root = {
+  console: { warn() {}, error() {}, log() {} },
+  document,
+  TMPhase8FormalBridge: bridge,
+  TM_PHASE8_FORMAL: state,
+  TM: { Features: { ensure(name) { ensureCalls += 1; assert.strictEqual(name, 'formalMapLabels'); return Promise.resolve({ ok: true }); } } },
+  setTimeout(fn, ms) { timers.push({ fn, ms }); return timers.length; },
+  clearTimeout() {},
+  setInterval() {},
+  clearInterval() {},
+  addEventListener() {},
+  getComputedStyle() { return {}; },
+  Map,
+  WeakMap,
+  Set,
+  Promise,
+  Date,
+  Math,
+  JSON,
+  Number,
+  String,
+  Array,
+  Object,
+  RegExp,
+  isFinite
+};
+root.window = root;
+root.globalThis = root;
+const context = vm.createContext(root);
+vm.runInContext(mapSource, context, { filename: 'phase8-formal-map.js' });
+
+const triangle = { points: [[0, 0], [10, 0], [0, 10]] };
+assert.strictEqual(bridge.map.__regionTrueArea(triangle), 100, 'before the optional provider loads, formal map uses the bbox fallback');
+bridge.map.renderFormalMap();
+bridge.map.renderFormalMap();
+assert.strictEqual(ensureCalls, 1, 'repeated map renders request the label feature once');
+
+vm.runInContext(geoSource, context, { filename: 'tm-map-label-geo.js' });
+assert(root.TMMapLabelGeo, 'production geometry provider loads after the map module');
+assert.strictEqual(bridge.map.__regionTrueArea(triangle), 50, 'fallback area was not permanently cached before the provider arrived');
+
+const beforeTimers = timers.length;
+bridge.map.onMapLabelFeatureReady();
+assert.strictEqual(state._lastFormalMapSig, null, 'late provider invalidates the formal map signature');
+assert(timers.length >= beforeTimers + 2, 'late provider schedules both rerender and collision layout');
+
+console.log('[smoke-map-label-feature-late-binding] PASS assertions=6');

--- a/web/scripts/smoke-startup-contract.js
+++ b/web/scripts/smoke-startup-contract.js
@@ -26,10 +26,13 @@ function criticalWorld() {
 
 function load(world) {
   const appended = [];
+  const footer = { textContent: 'stale' };
+  const meta = { getAttribute(name) { return name === 'content' ? '1.3.4.11' : null; } };
   const document = {
     body: { appendChild(node) { appended.push(node); } },
     documentElement: { dataset: {} },
-    getElementById() { return null; },
+    getElementById(id) { return id === 'tm-foot-ver' ? footer : null; },
+    querySelector(selector) { return selector === 'meta[name="tm-version"]' ? meta : null; },
     createElement() {
       return {
         id: '', textContent: '', style: {}, attributes: {},
@@ -47,13 +50,14 @@ function load(world) {
   context.globalThis = context;
   vm.createContext(context);
   vm.runInContext(SOURCE, context, { filename: 'tm-startup-contract.js' });
-  return { context, document, appended };
+  return { context, document, appended, footer };
 }
 
 let fixture = load(criticalWorld());
 check(fixture.context.__tmStartupContract.ok === true, 'complete runtime satisfies the startup contract');
 check(fixture.appended.length === 0, 'complete runtime does not render a failure surface');
 check(fixture.context.TMStartupContract.required.includes('endTurn'), 'contract publishes its critical global inventory');
+check(fixture.footer.textContent === '1.3.4.11', 'startup contract synchronizes footer version on every platform');
 
 const broken = criticalWorld();
 delete broken.endTurn;

--- a/web/scripts/smoke-startup-phase-observability.js
+++ b/web/scripts/smoke-startup-phase-observability.js
@@ -19,9 +19,14 @@ const scriptNames = Array.from(html.matchAll(/<script\b[^>]*\bsrc=["']([^"']+\.j
 
 assert.strictEqual(manifest.scriptCount, scriptNames.length, 'startup manifest should cover every external JavaScript loaded by index.html');
 assert.deepStrictEqual(manifest.scripts.map((row) => row.script), scriptNames, 'startup manifest order should match index.html exactly');
-assert.strictEqual(manifest.deferredChangesApproved, 0, 'Round 20 should not pretend an unproven classic-script group is lazy safe');
-assert(manifest.scripts.every((row) => row.lazySafe === false), 'every retained script should record the conservative dependency-audit result');
+assert.strictEqual(manifest.version, 2, 'startup manifest should use the explicit feature-boundary schema');
+assert.strictEqual(manifest.deferredChangesApproved, 6, 'Feature Loader V2 should approve exactly the audited six-script cohort');
+assert.strictEqual(manifest.scriptCount, 411, 'Feature Loader V2 should reduce the eager startup chain from 416 to 411 scripts');
+assert(manifest.scripts.every((row) => row.lazySafe === false && row.loadPolicy === 'eager-ordered'), 'retained classic scripts should remain explicitly eager');
 assert(manifest.scripts.every((row) => Array.isArray(row.provides) && Array.isArray(row.consumes)), 'manifest should expose machine-readable provider and immediate-consumer inventories');
+assert(manifest.scripts.every((row) => row.mustLoadBefore.length === 0 && row.mustLoadAfter.length === 0), 'adjacent scripts must not be emitted as fake dependencies');
+assert(Array.isArray(manifest.features) && manifest.features.length === 4, 'startup manifest should expose four approved lazy features');
+assert.strictEqual(manifest.features.reduce((count, row) => count + row.scripts.length, 0), 6, 'feature definitions should own six deferred scripts');
 
 const sandbox = { console, Date, Math, JSON, performance, Promise, window: {} };
 sandbox.window.window = sandbox.window;

--- a/web/scripts/verify-online-update.js
+++ b/web/scripts/verify-online-update.js
@@ -80,10 +80,12 @@ function load(opts) {
 }
 
 (async function main() {
-  // ── A·web 端·远端相同 → 静默；footer 同步 ──
+  // ── A·web 端·显式 init 后远端相同 → 静默；footer 由 startup contract 同步 ──
   {
     const env = load({ localVersion: '1.3.3.5', remote: { version: '1.3.3.5' } });
-    assert(env.footSpan.textContent === '1.3.3.5', 'A·footer 从 meta 同步');
+    assert(env.footSpan.textContent === '0.0.0.0', 'A·模块装载不再为 footer 产生副作用');
+    assert(env.timers.length === 0, 'A·模块装载不自动排程');
+    env.windowStub.TM_OnlineUpdate.init();
     assert(env.timers.some(t => t.ms === 20000), 'A·20s 首查排程');
     assert(env.timers.some(t => t.interval && t.ms === 30 * 60 * 1000), 'A·30min 周期排程');
     env.fire(20000);
@@ -95,6 +97,7 @@ function load(opts) {
   // ── B·远端更高 → 横幅·立即刷新带 ?r= ──
   {
     const env = load({ localVersion: '1.3.3.5', remote: { version: '1.3.4.0' } });
+    env.windowStub.TM_OnlineUpdate.init();
     env.fire(20000);
     await flush();
     const banner = env.banner();
@@ -109,6 +112,7 @@ function load(opts) {
   // ── C·稍后记账·同版本不再弹·更高版本再弹 ──
   {
     const env = load({ localVersion: '1.3.3.5', remote: { version: '1.3.4.0' } });
+    env.windowStub.TM_OnlineUpdate.init();
     env.fire(20000);
     await flush();
     const later = env.banner()._children.find(c => c.className === 'tm-olu-later');
@@ -118,6 +122,7 @@ function load(opts) {
     const r2 = await env.windowStub.TM_OnlineUpdate.check(false);
     assert(r2 === 'dismissed' && env.banner() === null, 'C·同版本被记账压制');
     const env2 = load({ localVersion: '1.3.3.5', remote: { version: '1.3.5.0' }, localStorage: { 'tm.onlineUpdate.dismissedVersion': '1.3.4.0' } });
+    env2.windowStub.TM_OnlineUpdate.init();
     env2.fire(20000);
     await flush();
     assert(!!env2.banner(), 'C·更高版本突破记账再弹');
@@ -127,6 +132,7 @@ function load(opts) {
   {
     for (const remote of [null, 'badjson', { version: 'not-a-version' }, { version: '' }]) {
       const env = load({ localVersion: '1.3.3.5', remote });
+      env.windowStub.TM_OnlineUpdate.init();
       env.fire(20000);
       await flush();
       assert(env.banner() === null, 'D·异常远端静默·' + JSON.stringify(remote && remote.version || remote));
@@ -136,15 +142,16 @@ function load(opts) {
   // ── E·自举·本地无 meta + 远端有 → 弹（发版当天还开着的旧会话） ──
   {
     const env = load({ noMeta: true, remote: { version: '1.3.4.0' } });
+    env.windowStub.TM_OnlineUpdate.init();
     env.fire(20000);
     await flush();
     assert(!!env.banner(), 'E·无本地 meta（旧会话）→ 提示刷新');
   }
 
-  // ── F·桌面端 → 零检查·footer 照常同步 ──
+  // ── F·桌面端 → 显式 not-applicable·零检查 ──
   {
     const env = load({ desktop: true, localVersion: '1.3.3.5', remote: { version: '9.9.9.9' } });
-    assert(env.footSpan.textContent === '1.3.3.5', 'F·桌面 footer 同步');
+    assert(env.windowStub.TM_OnlineUpdate.init().code === 'not-applicable', 'F·桌面 init 明确 not-applicable');
     assert(!env.timers.some(t => t.ms === 20000), 'F·桌面不排检查');
     env.timers.forEach(t => { if (!t.fired) { t.fired = true; t.fn && t.fn(); } });
     await flush();
@@ -154,12 +161,14 @@ function load(opts) {
   // ── G·安卓端 → 零检查 ──
   {
     const env = load({ capacitor: true, localVersion: '1.3.3.5', remote: { version: '9.9.9.9' } });
+    assert(env.windowStub.TM_OnlineUpdate.init().code === 'not-applicable', 'G·安卓 init 明确 not-applicable');
     assert(!env.timers.some(t => t.ms === 20000), 'G·安卓不排检查');
   }
 
   // ── H·测试缝·?tmOluTest=1 → 500ms 首查 ──
   {
     const env = load({ localVersion: '1.3.3.5', remote: { version: '1.3.4.0' }, search: '?tmOluTest=1' });
+    env.windowStub.TM_OnlineUpdate.init();
     assert(env.timers.some(t => t.ms === 500), 'H·测试模式 500ms 首查');
   }
 

--- a/web/startup-script-phases.json
+++ b/web/startup-script-phases.json
@@ -1,36 +1,41 @@
 {
-  "version": 1,
+  "version": 2,
   "source": "index.html",
   "generatedBy": "web/scripts/build-startup-phase-manifest.js",
-  "scriptCount": 416,
+  "scriptCount": 411,
   "phaseCounts": {
-    "menu": 13,
+    "menu": 14,
     "core": 80,
-    "world": 296,
-    "optional": 27
+    "world": 295,
+    "optional": 22
   },
-  "deferredChangesApproved": 0,
-  "auditConclusion": "No classic-script group was deferred in Round 20: 414+ ordered providers, immediate registrations, split-provider adjacency contracts, and two approved early reads make bulk defer unsafe without a dedicated loader migration.",
+  "deferredChangesApproved": 6,
+  "auditConclusion": "Feature Loader V2 defers only six audited scripts behind explicit lifecycle and platform boundaries. All other classic scripts retain document order; adjacency alone is no longer emitted as a false dependency.",
   "scripts": [
     {
       "script": "tm-home-ui.js",
       "order": 0,
       "phase": "menu",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "map-converter.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
       "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "map-converter.js",
       "order": 1,
       "phase": "menu",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "convertGameToGeoJSON",
         "convertGeoJSONToGame",
@@ -42,19 +47,19 @@
         "validateMapData"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "map-integration.js"
-      ],
-      "mustLoadAfter": [
-        "tm-home-ui.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "map-integration.js",
       "order": 2,
       "phase": "menu",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "MAP_DEFAULTS",
         "_mapCfg",
@@ -72,19 +77,19 @@
         "getTerrainName"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "map-display.js"
-      ],
-      "mustLoadAfter": [
-        "map-converter.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "map-display.js",
       "order": 3,
       "phase": "menu",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_mapEsc",
         "_mapEscHandler",
@@ -97,19 +102,19 @@
         "showProvinceDetails"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "map-editor-to-game.js"
-      ],
-      "mustLoadAfter": [
-        "map-integration.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "map-editor-to-game.js",
       "order": 4,
       "phase": "menu",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "MapEditorBridge",
         "convertMapEditorToAdminHierarchy",
@@ -121,143 +126,160 @@
         "loadMapEditorJSON"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-perf.js"
-      ],
-      "mustLoadAfter": [
-        "map-display.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-perf.js",
       "order": 5,
       "phase": "menu",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_tmPerfHotkey"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-startup-phases.js"
-      ],
-      "mustLoadAfter": [
-        "map-editor-to-game.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-startup-phases.js",
       "order": 6,
       "phase": "menu",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "TMStartupPhases"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-env-detect.js"
-      ],
-      "mustLoadAfter": [
-        "tm-perf.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-env-detect.js",
       "order": 7,
       "phase": "menu",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-platform.js"
-      ],
-      "mustLoadAfter": [
-        "tm-startup-phases.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-platform.js",
       "order": 8,
       "phase": "menu",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-fixed-fit.js"
-      ],
-      "mustLoadAfter": [
-        "tm-env-detect.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
+    },
+    {
+      "script": "tm-feature-loader.js",
+      "order": 9,
+      "phase": "menu",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
+      "provides": [
+        "TM"
+      ],
+      "consumes": [],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
+      "lazySafe": false,
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-fixed-fit.js",
-      "order": 9,
+      "order": 10,
       "phase": "menu",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-debug-logger.js"
-      ],
-      "mustLoadAfter": [
-        "tm-platform.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-debug-logger.js",
-      "order": 10,
+      "order": 11,
       "phase": "menu",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_tmDebugLoggerInstalled"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-diagnostics-foundation.js"
-      ],
-      "mustLoadAfter": [
-        "tm-fixed-fit.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-diagnostics-foundation.js",
-      "order": 11,
+      "order": 12,
       "phase": "menu",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_tmErrorsInstalled",
         "_tmErrorsPanelHotkey"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-ui-foundation.js"
-      ],
-      "mustLoadAfter": [
-        "tm-debug-logger.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-ui-foundation.js",
-      "order": 12,
+      "order": 13,
       "phase": "menu",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "TM_ICONS",
@@ -271,19 +293,19 @@
         "tmIcon"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-data-model.js"
-      ],
-      "mustLoadAfter": [
-        "tm-diagnostics-foundation.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-data-model.js",
-      "order": 13,
+      "order": 14,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "GM",
         "P",
@@ -294,19 +316,19 @@
         "_tmActiveVars"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-utils.js"
-      ],
-      "mustLoadAfter": [
-        "tm-ui-foundation.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-utils.js",
-      "order": 14,
+      "order": 15,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "CORE_METRIC_LABELS",
         "ErrorMonitor",
@@ -415,72 +437,72 @@
       "consumes": [
         "TM_SaveDB"
       ],
-      "mustLoadBefore": [
-        "tm-qiju-ledger.js"
-      ],
-      "mustLoadAfter": [
-        "tm-data-model.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-qiju-ledger.js",
-      "order": 15,
+      "order": 16,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "ChronicleLedger",
         "QijuLedger",
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-prompt-composer.js"
-      ],
-      "mustLoadAfter": [
-        "tm-utils.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-prompt-composer.js",
-      "order": 16,
+      "order": 17,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-ai-infra-json.js"
-      ],
-      "mustLoadAfter": [
-        "tm-qiju-ledger.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-ai-infra-json.js",
-      "order": 17,
+      "order": 18,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "robustParseJSON"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-ai-infra.js"
-      ],
-      "mustLoadAfter": [
-        "tm-prompt-composer.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-ai-infra.js",
-      "order": 18,
+      "order": 19,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "AISubCallRegistry",
         "BALANCE_CONFIG",
@@ -592,19 +614,19 @@
         "xml"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-ai-infra-model-detect.js"
-      ],
-      "mustLoadAfter": [
-        "tm-ai-infra-json.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-ai-infra-model-detect.js",
-      "order": 19,
+      "order": 20,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_MODEL_CTX_MAP",
         "_charRangeDefaults",
@@ -632,259 +654,259 @@
         "runSelfTests"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-trace.js"
-      ],
-      "mustLoadAfter": [
-        "tm-ai-infra.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-trace.js",
-      "order": 20,
+      "order": 21,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-evidence-registry.js"
-      ],
-      "mustLoadAfter": [
-        "tm-ai-infra-model-detect.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-evidence-registry.js",
-      "order": 21,
+      "order": 22,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-source-bound.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-trace.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-source-bound.js",
-      "order": 22,
+      "order": 23,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-issue-governance.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-evidence-registry.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-issue-governance.js",
-      "order": 23,
+      "order": 24,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-context-zones.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-source-bound.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-context-zones.js",
-      "order": 24,
+      "order": 25,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-envelope.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-issue-governance.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-envelope.js",
-      "order": 25,
+      "order": 26,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-governance.js"
-      ],
-      "mustLoadAfter": [
-        "tm-context-zones.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-governance.js",
-      "order": 26,
+      "order": 27,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-writegate.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-envelope.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-writegate.js",
-      "order": 27,
+      "order": 28,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-turn-inference.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-governance.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-turn-inference.js",
-      "order": 28,
+      "order": 29,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-turn-archive.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-writegate.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-turn-archive.js",
-      "order": 29,
+      "order": 30,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-turn-rollup.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-turn-inference.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-turn-rollup.js",
-      "order": 30,
+      "order": 31,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-turn-backfill.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-turn-archive.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-turn-backfill.js",
-      "order": 31,
+      "order": 32,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-controls.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-turn-rollup.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-controls.js",
-      "order": 32,
+      "order": 33,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-retrieval.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-turn-backfill.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-retrieval.js",
-      "order": 33,
+      "order": 34,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-context-compiler.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-controls.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-context-compiler.js",
-      "order": 34,
+      "order": 35,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-workshop.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-retrieval.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-workshop.js",
-      "order": 35,
+      "order": 36,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-traits-data.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-context-compiler.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-traits-data.js",
-      "order": 36,
+      "order": 37,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TRAIT_CATEGORIES",
         "TRAIT_LIBRARY",
@@ -895,54 +917,54 @@
         "traitsConflict"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-chronicle-tracker.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-workshop.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-chronicle-tracker.js",
-      "order": 37,
+      "order": 38,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "ChronicleTracker"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-chronicle-effects.js"
-      ],
-      "mustLoadAfter": [
-        "tm-traits-data.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-chronicle-effects.js",
-      "order": 38,
+      "order": 39,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "listTerminableTracks",
         "terminateChronicleTrack"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-relations.js"
-      ],
-      "mustLoadAfter": [
-        "tm-chronicle-tracker.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-relations.js",
-      "order": 39,
+      "order": 40,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "CONFLICT_LEVELS",
         "FACTION_INTERACTION_TYPES",
@@ -986,91 +1008,91 @@
         "upsertFactionRelationRecord"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-engine-constants.js"
-      ],
-      "mustLoadAfter": [
-        "tm-chronicle-effects.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-engine-constants.js",
-      "order": 40,
+      "order": 41,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "EngineConstants",
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-rel-graph.js"
-      ],
-      "mustLoadAfter": [
-        "tm-relations.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-rel-graph.js",
-      "order": 41,
+      "order": 42,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "RelGraph",
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-migration.js"
-      ],
-      "mustLoadAfter": [
-        "tm-engine-constants.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-migration.js",
-      "order": 42,
+      "order": 43,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "EngineMigration",
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-influence-groups.js"
-      ],
-      "mustLoadAfter": [
-        "tm-rel-graph.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-influence-groups.js",
-      "order": 43,
+      "order": 44,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "InfluenceGroups",
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-edict-lifecycle.js"
-      ],
-      "mustLoadAfter": [
-        "tm-migration.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-edict-lifecycle.js",
-      "order": 44,
+      "order": 45,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "EDICT_STAGES",
         "EDICT_TYPES",
@@ -1089,19 +1111,19 @@
         "getReformPhaseTurns"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-time-utils.js"
-      ],
-      "mustLoadAfter": [
-        "tm-influence-groups.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-time-utils.js",
-      "order": 45,
+      "order": 46,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TimeUtils",
         "_buildTimeRef",
@@ -1109,51 +1131,51 @@
         "_formatRelativeTime"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-world-era.js"
-      ],
-      "mustLoadAfter": [
-        "tm-edict-lifecycle.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-world-era.js",
-      "order": 46,
+      "order": 47,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMWorldEra"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-world-snapshot.js"
-      ],
-      "mustLoadAfter": [
-        "tm-time-utils.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-world-snapshot.js",
-      "order": 47,
+      "order": 48,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-tables.js"
-      ],
-      "mustLoadAfter": [
-        "tm-world-era.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-tables.js",
-      "order": 48,
+      "order": 49,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "MemTables",
         "_mtApply",
@@ -1168,19 +1190,19 @@
         "_mtUpdate"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-world-identity.js"
-      ],
-      "mustLoadAfter": [
-        "tm-world-snapshot.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-world-identity.js",
-      "order": 49,
+      "order": 50,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMWorldIdentity",
         "_tmEnsureTimelineId",
@@ -1189,102 +1211,102 @@
         "_tmNewTimelineId"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-state-snapshot.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-tables.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-state-snapshot.js",
-      "order": 50,
+      "order": 51,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-semantic-recall.js"
-      ],
-      "mustLoadAfter": [
-        "tm-world-identity.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-semantic-recall.js",
-      "order": 51,
+      "order": 52,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "SemanticRecall"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-recall-gate.js"
-      ],
-      "mustLoadAfter": [
-        "tm-state-snapshot.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-recall-gate.js",
-      "order": 52,
+      "order": 53,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "RecallGate"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-ui.js"
-      ],
-      "mustLoadAfter": [
-        "tm-semantic-recall.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-ui.js",
-      "order": 53,
+      "order": 54,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "MemoryUI"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-adapter.js"
-      ],
-      "mustLoadAfter": [
-        "tm-recall-gate.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-adapter.js",
-      "order": 54,
+      "order": 55,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TianmingMemoryAdapter"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-mechanics.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-ui.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-mechanics.js",
-      "order": 55,
+      "order": 56,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "AutoReboundSystem",
         "GoalSatisfactionSystem",
@@ -1299,19 +1321,19 @@
         "VacantPositionReminder"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-mechanics-memory.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-adapter.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-mechanics-memory.js",
-      "order": 56,
+      "order": 57,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "CharacterGrowthSystem",
         "NpcMemorySystem",
@@ -1350,19 +1372,19 @@
         "evaluateReformFeasibility"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-mechanics-world.js"
-      ],
-      "mustLoadAfter": [
-        "tm-mechanics.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-mechanics-world.js",
-      "order": 57,
+      "order": 58,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "ContradictionSystem",
         "EnYuanSystem",
@@ -1402,36 +1424,36 @@
         "updateFamilyRenown"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-agent-kernel.js"
-      ],
-      "mustLoadAfter": [
-        "tm-mechanics-memory.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-agent-kernel.js",
-      "order": 58,
+      "order": 59,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-agent-flags.js"
-      ],
-      "mustLoadAfter": [
-        "tm-mechanics-world.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-agent-flags.js",
-      "order": 59,
+      "order": 60,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "agentFlagOn",
@@ -1439,104 +1461,104 @@
         "agentModeOn"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-agent-tools.js"
-      ],
-      "mustLoadAfter": [
-        "tm-agent-kernel.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-agent-tools.js",
-      "order": 60,
+      "order": 61,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-steward.js"
-      ],
-      "mustLoadAfter": [
-        "tm-agent-flags.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-steward.js",
-      "order": 61,
+      "order": 62,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-reflection-agent.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-agent-tools.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-reflection-agent.js",
-      "order": 62,
+      "order": 63,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-edict-oversight.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-steward.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-edict-oversight.js",
-      "order": 63,
+      "order": 64,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-history-advisor.js"
-      ],
-      "mustLoadAfter": [
-        "tm-reflection-agent.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-history-advisor.js",
-      "order": 64,
+      "order": 65,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-change-queue.js"
-      ],
-      "mustLoadAfter": [
-        "tm-edict-oversight.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-change-queue.js",
-      "order": 65,
+      "order": 66,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "AccountingSystem",
         "ChangeQueue",
@@ -1557,19 +1579,19 @@
         "triggerPropertyChange"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-indices.js"
-      ],
-      "mustLoadAfter": [
-        "tm-history-advisor.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-indices.js",
-      "order": 66,
+      "order": 67,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "WorldHelper",
@@ -1610,19 +1632,19 @@
         "removeScenarioFromIndex"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-world.js"
-      ],
-      "mustLoadAfter": [
-        "tm-change-queue.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-world.js",
-      "order": 67,
+      "order": 68,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "EVENT_ROLE_MAP",
         "_sysEnabled",
@@ -1640,19 +1662,19 @@
         "validateTraits"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memorials.js"
-      ],
-      "mustLoadAfter": [
-        "tm-indices.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memorials.js",
-      "order": 68,
+      "order": 69,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_annotateMemorial",
         "_approveMemorial",
@@ -1681,19 +1703,19 @@
         "renderMemorials"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-wendui.js"
-      ],
-      "mustLoadAfter": [
-        "tm-world.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-wendui.js",
-      "order": 69,
+      "order": 70,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_WD_ENVOY_EFFECTS",
         "_registerImperialPromise",
@@ -1777,19 +1799,19 @@
         "sendWendui"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-wendui-persona-views.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memorials.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-wendui-persona-views.js",
-      "order": 70,
+      "order": 71,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_jishiCharFilter",
         "_jishiCharTitle",
@@ -1817,36 +1839,36 @@
         "renderJishi"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-wendui-prison.js"
-      ],
-      "mustLoadAfter": [
-        "tm-wendui.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-wendui-prison.js",
-      "order": 71,
+      "order": 72,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "WenduiPrison"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-office-system.js"
-      ],
-      "mustLoadAfter": [
-        "tm-wendui-persona-views.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-office-system.js",
-      "order": 72,
+      "order": 73,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "RANK_HIERARCHY",
         "_JINGCHA_CFG",
@@ -1936,19 +1958,19 @@
         "normalizeRankLevel"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-region-magnate.js"
-      ],
-      "mustLoadAfter": [
-        "tm-wendui-prison.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-region-magnate.js",
-      "order": 73,
+      "order": 74,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_buildingPolitics",
         "_suppressProvinceMagnate",
@@ -1956,73 +1978,73 @@
         "_transferAttritionRate"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-era-language-pack.js"
-      ],
-      "mustLoadAfter": [
-        "tm-office-system.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-era-language-pack.js",
-      "order": 74,
+      "order": 75,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "ERA_LANGUAGE_PACKS",
         "eraLangField",
         "eraLanguagePack"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-ai-narrative-guards.js"
-      ],
-      "mustLoadAfter": [
-        "tm-region-magnate.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-ai-narrative-guards.js",
-      "order": 75,
+      "order": 76,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_validateLivingActorConsistency",
         "_validateNarrativeAnachronism"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-office-fallback.js"
-      ],
-      "mustLoadAfter": [
-        "tm-era-language-pack.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-office-fallback.js",
-      "order": 76,
+      "order": 77,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-office-runtime.js"
-      ],
-      "mustLoadAfter": [
-        "tm-ai-narrative-guards.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-office-runtime.js",
-      "order": 77,
+      "order": 78,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "OFFICE_SUBTABS",
         "OfficeDynastification",
@@ -2084,19 +2106,19 @@
         "toggleListDept"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-office-runtime-summary-appoint.js"
-      ],
-      "mustLoadAfter": [
-        "tm-office-fallback.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-office-runtime-summary-appoint.js",
-      "order": 78,
+      "order": 79,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_OFF_PICKER",
         "_offAutoFill",
@@ -2112,19 +2134,19 @@
         "_renderOfficeSummary"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-office-panel.js"
-      ],
-      "mustLoadAfter": [
-        "tm-office-runtime.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-office-panel.js",
-      "order": 79,
+      "order": 80,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_OFF_APPOINT_LOCKS",
         "_bnDownload",
@@ -2159,90 +2181,90 @@
         "renderOfficeDeptV2"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-office-flags.js"
-      ],
-      "mustLoadAfter": [
-        "tm-office-runtime-summary-appoint.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-office-flags.js",
-      "order": 80,
+      "order": 81,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "officeFlagOn"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-office-powermap.js"
-      ],
-      "mustLoadAfter": [
-        "tm-office-panel.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-office-powermap.js",
-      "order": 81,
+      "order": 82,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "buildOfficePowerMap",
         "queryOfficeDetail"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-office-dutystate.js"
-      ],
-      "mustLoadAfter": [
-        "tm-office-flags.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-office-dutystate.js",
-      "order": 82,
+      "order": 83,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "applyNpcActionToDuty",
         "tickOfficeDutyState"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-office-authority.js"
-      ],
-      "mustLoadAfter": [
-        "tm-office-powermap.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-office-authority.js",
-      "order": 83,
+      "order": 84,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "resolveOfficeAuthority"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-office-reform.js"
-      ],
-      "mustLoadAfter": [
-        "tm-office-dutystate.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-office-reform.js",
-      "order": 84,
+      "order": 85,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_offCharterPositions",
         "adjudicatePendingReforms",
@@ -2251,55 +2273,55 @@
         "enqueuePendingReform"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-office-charter.js"
-      ],
-      "mustLoadAfter": [
-        "tm-office-authority.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-office-charter.js",
-      "order": 85,
+      "order": 86,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_charterReviewOpen"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-office-recall-agent.js"
-      ],
-      "mustLoadAfter": [
-        "tm-office-reform.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-office-recall-agent.js",
-      "order": 86,
+      "order": 87,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "runOfficeRecall"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-npc-engine.js"
-      ],
-      "mustLoadAfter": [
-        "tm-office-charter.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-npc-engine.js",
-      "order": 87,
+      "order": 88,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "CentralizationSystem",
         "TM",
@@ -2311,37 +2333,37 @@
         "resetTurnChanges"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-npc-action-ledger.js"
-      ],
-      "mustLoadAfter": [
-        "tm-office-recall-agent.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-npc-action-ledger.js",
-      "order": 88,
+      "order": 89,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "NpcActionLedger",
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-npc-decision.js"
-      ],
-      "mustLoadAfter": [
-        "tm-npc-engine.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-npc-decision.js",
-      "order": 89,
+      "order": 90,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "NpcBehaviorRegistry",
         "WeightFactors",
@@ -2458,19 +2480,19 @@
         "npcDecisionLayer"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-npc-decision-ai-driven.js"
-      ],
-      "mustLoadAfter": [
-        "tm-npc-action-ledger.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-npc-decision-ai-driven.js",
-      "order": 90,
+      "order": 91,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_canRunNpcIdleAutonomy",
         "_cancelNpcIdleAutonomyLoop",
@@ -2499,53 +2521,53 @@
         "selectImportantNpcs"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-promotion.js"
-      ],
-      "mustLoadAfter": [
-        "tm-npc-decision.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-promotion.js",
-      "order": 91,
+      "order": 92,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMPromotion"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-gongming.js"
-      ],
-      "mustLoadAfter": [
-        "tm-npc-decision-ai-driven.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-gongming.js",
-      "order": 92,
+      "order": 93,
       "phase": "core",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMGongming"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-launch.js"
-      ],
-      "mustLoadAfter": [
-        "tm-promotion.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-launch.js",
-      "order": 93,
+      "order": 94,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_captureEnergySnapshot",
         "_cleanupOverlays",
@@ -2609,19 +2631,19 @@
         "updateEdBadges"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-player-settings.js"
-      ],
-      "mustLoadAfter": [
-        "tm-gongming.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-player-settings.js",
-      "order": 94,
+      "order": 95,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_probeClearCache",
         "_probeRunContext",
@@ -2650,19 +2672,19 @@
         "tmApplyInsecureTlsConfig"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-player-core.js"
-      ],
-      "mustLoadAfter": [
-        "tm-launch.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-player-core.js",
-      "order": 95,
+      "order": 96,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TmTooltip",
         "_CRED_META",
@@ -2758,19 +2780,19 @@
         "switchGTab"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-hongyan-office.js"
-      ],
-      "mustLoadAfter": [
-        "tm-player-settings.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-hongyan-office.js",
-      "order": 96,
+      "order": 97,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "LETTER_CIPHERS",
         "LETTER_TOKENS",
@@ -2821,37 +2843,37 @@
         "sendLetter"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-game-ui-shell.js"
-      ],
-      "mustLoadAfter": [
-        "tm-player-core.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-game-ui-shell.js",
-      "order": 97,
+      "order": 98,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_renderEdictArchiveBody",
         "renderGameState"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-hongyan-edict-ui.js"
-      ],
-      "mustLoadAfter": [
-        "tm-hongyan-office.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-hongyan-edict-ui.js",
-      "order": 98,
+      "order": 99,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_applyPolishedEdict",
         "_closeEdictMenu",
@@ -2864,19 +2886,19 @@
         "_showEdictAdoptMenu"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-game-loop.js"
-      ],
-      "mustLoadAfter": [
-        "tm-game-ui-shell.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-game-loop.js",
-      "order": 99,
+      "order": 100,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_applyA11y",
@@ -2907,19 +2929,19 @@
         "validateScenario"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-game-loop-wentian-hardchange.js"
-      ],
-      "mustLoadAfter": [
-        "tm-hongyan-edict-ui.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-game-loop-wentian-hardchange.js",
-      "order": 100,
+      "order": 101,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_WT_CREATABLE_ROOTS",
         "_WT_ENTITY_PREFIX_RE",
@@ -2986,19 +3008,19 @@
         "_wtUndoHardChange"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-map-system.js"
-      ],
-      "mustLoadAfter": [
-        "tm-game-loop.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-map-system.js",
-      "order": 101,
+      "order": 102,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "InteractiveMap",
         "TMMapRuntime",
@@ -3085,19 +3107,19 @@
         "updateMapState"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-dynamic-systems.js"
-      ],
-      "mustLoadAfter": [
-        "tm-game-loop-wentian-hardchange.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-dynamic-systems.js",
-      "order": 102,
+      "order": 103,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "PostTransfer",
         "appointToPost",
@@ -3117,19 +3139,19 @@
         "updateVariables"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-save-manager.js"
-      ],
-      "mustLoadAfter": [
-        "tm-map-system.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-save-manager.js",
-      "order": 103,
+      "order": 104,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "SaveManager",
         "_SCROLL_NUMS",
@@ -3160,36 +3182,36 @@
         "showScrollConfirm"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-resume-point.js"
-      ],
-      "mustLoadAfter": [
-        "tm-dynamic-systems.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-resume-point.js",
-      "order": 104,
+      "order": 105,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-help-social.js"
-      ],
-      "mustLoadAfter": [
-        "tm-save-manager.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-help-social.js",
-      "order": 105,
+      "order": 106,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "AIBatchQueue",
         "AICache",
@@ -3216,19 +3238,19 @@
         "triggerHistoricalEvent"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-economy.js"
-      ],
-      "mustLoadAfter": [
-        "tm-resume-point.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-economy.js",
-      "order": 106,
+      "order": 107,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "applyInheritanceOutcome",
         "calculateInheritanceScore",
@@ -3249,19 +3271,19 @@
         "updateParties"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-military.js"
-      ],
-      "mustLoadAfter": [
-        "tm-help-social.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-military.js",
-      "order": 107,
+      "order": 108,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "BUILDING_TYPES",
         "BattleEngine",
@@ -3312,19 +3334,19 @@
         "updateUnitSystem"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-feudal.js"
-      ],
-      "mustLoadAfter": [
-        "tm-economy.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-feudal.js",
-      "order": 108,
+      "order": 109,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "AUTONOMY_TYPES",
         "OFFICIAL_RANKS",
@@ -3370,19 +3392,19 @@
         "updateVassalSystem"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-feudal-warfare.js"
-      ],
-      "mustLoadAfter": [
-        "tm-military.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-feudal-warfare.js",
-      "order": 109,
+      "order": 110,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "CasusBelliSystem",
         "DecisionSystem",
@@ -3396,55 +3418,55 @@
         "updateMilitary"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-event-system.js"
-      ],
-      "mustLoadAfter": [
-        "tm-feudal.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-event-system.js",
-      "order": 110,
+      "order": 111,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "EffectRegistry",
         "StoryEventBus"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-storage.js"
-      ],
-      "mustLoadAfter": [
-        "tm-feudal-warfare.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-storage.js",
-      "order": 111,
+      "order": 112,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "SaveCompression",
         "TM_SaveDB"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-helpers.js"
-      ],
-      "mustLoadAfter": [
-        "tm-event-system.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-helpers.js",
-      "order": 112,
+      "order": 113,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "AGENDA_TEMPLATES",
         "HistoryIndex",
@@ -3489,105 +3511,105 @@
         "runAnnualReview"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-border-risk.js"
-      ],
-      "mustLoadAfter": [
-        "tm-storage.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-border-risk.js",
-      "order": 113,
+      "order": 114,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "BorderRisk"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-border-invasion.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-helpers.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-border-invasion.js",
-      "order": 114,
+      "order": 115,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-coastal-raid.js"
-      ],
-      "mustLoadAfter": [
-        "tm-border-risk.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-coastal-raid.js",
-      "order": 115,
+      "order": 116,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "CoastalRaid"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-office-vacancy.js"
-      ],
-      "mustLoadAfter": [
-        "tm-border-invasion.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-office-vacancy.js",
-      "order": 116,
+      "order": 117,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "OfficeVacancy"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-custom-build-agent.js"
-      ],
-      "mustLoadAfter": [
-        "tm-coastal-raid.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-custom-build-agent.js",
-      "order": 117,
+      "order": 118,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "CustomBuildAgent",
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-province.js"
-      ],
-      "mustLoadAfter": [
-        "tm-office-vacancy.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-province.js",
-      "order": 118,
+      "order": 119,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_aggregateDivisionStats",
         "_peBuiltContent",
@@ -3633,19 +3655,19 @@
         "updateProvinceEconomy"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-qiaozhi.js"
-      ],
-      "mustLoadAfter": [
-        "tm-custom-build-agent.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-qiaozhi.js",
-      "order": 119,
+      "order": 120,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_qiaozhiFindDivisionByName",
         "doQiaozhi",
@@ -3653,37 +3675,37 @@
         "restoreQiaozhiDivision"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-ai-apply-deaths.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-province.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-ai-apply-deaths.js",
-      "order": 120,
+      "order": 121,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "applyCharacterDeaths",
         "applyOneDeath"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-sidebar-ui.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-qiaozhi.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-sidebar-ui.js",
-      "order": 121,
+      "order": 122,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_palaceAction",
         "_palaceNewBuild",
@@ -3706,19 +3728,19 @@
         "unlockTech"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-renwu-ui.js"
-      ],
-      "mustLoadAfter": [
-        "tm-ai-apply-deaths.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-renwu-ui.js",
-      "order": 122,
+      "order": 123,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_rwAppendCardsChunked",
         "_rwFacChipStyle",
@@ -3748,19 +3770,19 @@
         "viewRenwu"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-shiji-qiju-ui.js"
-      ],
-      "mustLoadAfter": [
-        "tm-sidebar-ui.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-shiji-qiju-ui.js",
-      "order": 123,
+      "order": 124,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_qijuAnnotOnly",
         "_qijuAnnotate",
@@ -3796,19 +3818,19 @@
         "scheduleShijiListRender"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-court-meter.js"
-      ],
-      "mustLoadAfter": [
-        "tm-renwu-ui.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-court-meter.js",
-      "order": 124,
+      "order": 125,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_beginPostTurnCourtState",
         "_finishPostTurnCourtState",
@@ -3822,139 +3844,139 @@
         "recordCourtHeld"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-conspiracy.js"
-      ],
-      "mustLoadAfter": [
-        "tm-shiji-qiju-ui.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-conspiracy.js",
-      "order": 125,
+      "order": 126,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "ConspiracyEngine"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-globalrules.js"
-      ],
-      "mustLoadAfter": [
-        "tm-court-meter.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-globalrules.js",
-      "order": 126,
+      "order": 127,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "GlobalRules",
         "GlobalRulesEngine"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-dianzhang.js"
-      ],
-      "mustLoadAfter": [
-        "tm-conspiracy.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-dianzhang.js",
-      "order": 127,
+      "order": 128,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-world-digest.js"
-      ],
-      "mustLoadAfter": [
-        "tm-globalrules.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-world-digest.js",
-      "order": 128,
+      "order": 129,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "WorldDigest"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-benji.js"
-      ],
-      "mustLoadAfter": [
-        "tm-dianzhang.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-benji.js",
-      "order": 129,
+      "order": 130,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-world-reactors.js"
-      ],
-      "mustLoadAfter": [
-        "tm-world-digest.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-world-reactors.js",
-      "order": 130,
+      "order": 131,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "WorldReactors"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-systems.js"
-      ],
-      "mustLoadAfter": [
-        "tm-benji.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-systems.js",
-      "order": 131,
+      "order": 132,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_endTurn_updateSystems"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-ai-helpers.js"
-      ],
-      "mustLoadAfter": [
-        "tm-world-reactors.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-ai-helpers.js",
-      "order": 132,
+      "order": 133,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_tmAIHelperCaptureSession",
@@ -3970,36 +3992,36 @@
         "buildEdictEfficacyFollowUp"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-ai-context.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-systems.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-ai-context.js",
-      "order": 133,
+      "order": 134,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-history-events.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-ai-helpers.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-history-events.js",
-      "order": 134,
+      "order": 135,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_applyRigidHistoryDeath",
         "_historyEventToIssue",
@@ -4022,70 +4044,70 @@
         "triggerRigidEvent"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-tianji.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-ai-context.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-tianji.js",
-      "order": 135,
+      "order": 136,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMTianji"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-junqing-brief.js"
-      ],
-      "mustLoadAfter": [
-        "tm-history-events.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-junqing-brief.js",
-      "order": 136,
+      "order": 137,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMJunqing"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-xinjun-observe.js"
-      ],
-      "mustLoadAfter": [
-        "tm-tianji.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-xinjun-observe.js",
-      "order": 137,
+      "order": 138,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMXinjun"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-post-turn-jobs.js"
-      ],
-      "mustLoadAfter": [
-        "tm-junqing-brief.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-post-turn-jobs.js",
-      "order": 138,
+      "order": 139,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_POST_TURN_CRITICAL_IDS",
         "_POST_TURN_NEXT_REQUIRED_IDS",
@@ -4114,19 +4136,19 @@
         "_updateFactionArcs"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-arcs.js"
-      ],
-      "mustLoadAfter": [
-        "tm-xinjun-observe.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-arcs.js",
-      "order": 139,
+      "order": 140,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "getAllCharacterArcContext",
         "getCharacterArcSummary",
@@ -4135,19 +4157,19 @@
         "recordPlayerDecision"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-memory-anchors.js"
-      ],
-      "mustLoadAfter": [
-        "tm-post-turn-jobs.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-memory-anchors.js",
-      "order": 140,
+      "order": 141,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_ensureMemoryFreshness",
         "archiveOldMemories",
@@ -4159,19 +4181,19 @@
         "getMemoryAnchorsForAI"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-chronicle-system.js"
-      ],
-      "mustLoadAfter": [
-        "tm-arcs.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-chronicle-system.js",
-      "order": 141,
+      "order": 142,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "ChronicleSystem",
         "_chronicleBuildYearBasis",
@@ -4187,36 +4209,36 @@
         "_chronicleWaitForWorldCommit"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-number-parser.js"
-      ],
-      "mustLoadAfter": [
-        "tm-memory-anchors.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-number-parser.js",
-      "order": 142,
+      "order": 143,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMNumberParser"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-edict.js"
-      ],
-      "mustLoadAfter": [
-        "tm-chronicle-system.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-edict.js",
-      "order": 143,
+      "order": 144,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_edFindTargetFaction",
         "_edPlayerFacName",
@@ -4237,19 +4259,19 @@
         "processEdictEffects"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-ai-planning.js"
-      ],
-      "mustLoadAfter": [
-        "tm-number-parser.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-ai-planning.js",
-      "order": 144,
+      "order": 145,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "EndTurnHooks",
         "_tmPlanningCaptureSession",
@@ -4261,19 +4283,19 @@
         "openMemoryAnchors"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-prep.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-edict.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-prep.js",
-      "order": 145,
+      "order": 146,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_appointmentHasJealousTemper",
         "_appointmentIsPoliticalEnemy",
@@ -4288,486 +4310,486 @@
         "_reactToEdicts"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-class-engine.js"
-      ],
-      "mustLoadAfter": [
-        "tm-ai-planning.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-class-engine.js",
-      "order": 146,
+      "order": 147,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "ClassEngine",
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-minxin-ledger.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-prep.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-minxin-ledger.js",
-      "order": 147,
+      "order": 148,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "MinxinLedger",
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-class-minxin-bridge.js"
-      ],
-      "mustLoadAfter": [
-        "tm-class-engine.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-class-minxin-bridge.js",
-      "order": 148,
+      "order": 149,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-party-goals.js"
-      ],
-      "mustLoadAfter": [
-        "tm-minxin-ledger.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-party-goals.js",
-      "order": 149,
+      "order": 150,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-party-class-tuning.js"
-      ],
-      "mustLoadAfter": [
-        "tm-class-minxin-bridge.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-party-class-tuning.js",
-      "order": 150,
+      "order": 151,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "PartyClassTuning",
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-party-class-ecology.js"
-      ],
-      "mustLoadAfter": [
-        "tm-party-goals.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-party-class-ecology.js",
-      "order": 151,
+      "order": 152,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "PartyClassEcology",
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-social-political-signals.js"
-      ],
-      "mustLoadAfter": [
-        "tm-party-class-tuning.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-social-political-signals.js",
-      "order": 152,
+      "order": 153,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "SocialPoliticalSignals",
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-player-action-signals.js"
-      ],
-      "mustLoadAfter": [
-        "tm-party-class-ecology.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-player-action-signals.js",
-      "order": 153,
+      "order": 154,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-class-character-relations.js"
-      ],
-      "mustLoadAfter": [
-        "tm-social-political-signals.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-class-character-relations.js",
-      "order": 154,
+      "order": 155,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-minxin-pressure-actions.js"
-      ],
-      "mustLoadAfter": [
-        "tm-player-action-signals.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-minxin-pressure-actions.js",
-      "order": 155,
+      "order": 156,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "MinxinPressureActions",
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-minxin-commitment-tracker.js"
-      ],
-      "mustLoadAfter": [
-        "tm-class-character-relations.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-minxin-commitment-tracker.js",
-      "order": 156,
+      "order": 157,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "MinxinCommitmentTracker",
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-minxin-responsibility-chain.js"
-      ],
-      "mustLoadAfter": [
-        "tm-minxin-pressure-actions.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-minxin-responsibility-chain.js",
-      "order": 157,
+      "order": 158,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "MinxinResponsibilityChain",
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-minxin-hard-links.js"
-      ],
-      "mustLoadAfter": [
-        "tm-minxin-commitment-tracker.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-minxin-hard-links.js",
-      "order": 158,
+      "order": 159,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "MinxinHardLinks",
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-minxin-hard-link-consumers.js"
-      ],
-      "mustLoadAfter": [
-        "tm-minxin-responsibility-chain.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-minxin-hard-link-consumers.js",
-      "order": 159,
+      "order": 160,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "MinxinHardLinkConsumers",
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-party-class-actors.js"
-      ],
-      "mustLoadAfter": [
-        "tm-minxin-hard-links.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-party-class-actors.js",
-      "order": 160,
+      "order": 161,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-party-class-action-scheduler.js"
-      ],
-      "mustLoadAfter": [
-        "tm-minxin-hard-link-consumers.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-party-class-action-scheduler.js",
-      "order": 161,
+      "order": 162,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-party-class-llm-calibrator.js"
-      ],
-      "mustLoadAfter": [
-        "tm-party-class-actors.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-party-class-llm-calibrator.js",
-      "order": 162,
+      "order": 163,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-record-specs.js"
-      ],
-      "mustLoadAfter": [
-        "tm-party-class-action-scheduler.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-record-specs.js",
-      "order": 163,
+      "order": 164,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-prompt.js"
-      ],
-      "mustLoadAfter": [
-        "tm-party-class-llm-calibrator.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-prompt.js",
-      "order": 164,
+      "order": 165,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-ai-sc1-budget.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-record-specs.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-ai-sc1-budget.js",
-      "order": 165,
+      "order": 166,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-ai.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-prompt.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-ai.js",
-      "order": 166,
+      "order": 167,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-apply.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-ai-sc1-budget.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-apply.js",
-      "order": 167,
+      "order": 168,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-apply-stages.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-ai.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-apply-stages.js",
-      "order": 168,
+      "order": 169,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-followup-helpers.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-apply.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-followup-helpers.js",
-      "order": 169,
+      "order": 170,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-followup.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-apply-stages.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-followup.js",
-      "order": 170,
+      "order": 171,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-record.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-followup-helpers.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-record.js",
-      "order": 171,
+      "order": 172,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-ai-infer.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-followup.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-ai-infer.js",
-      "order": 172,
+      "order": 173,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_endTurn_aiInfer"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-core.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-record.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-core.js",
-      "order": 173,
+      "order": 174,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_endTurnCore",
         "_endTurnInternal",
@@ -4794,222 +4816,222 @@
         "endTurn"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-pipeline-types.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-ai-infer.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-pipeline-types.js",
-      "order": 174,
+      "order": 175,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-mode-contract.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-core.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-mode-contract.js",
-      "order": 175,
+      "order": 176,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-timing-ledger.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-pipeline-types.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-timing-ledger.js",
-      "order": 176,
+      "order": 177,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "openEndturnTimingDiagnostics"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-pipeline-executor.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-mode-contract.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-pipeline-executor.js",
-      "order": 177,
+      "order": 178,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-validity.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-timing-ledger.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-validity.js",
-      "order": 178,
+      "order": 179,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-pipeline-steps.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-pipeline-executor.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-pipeline-steps.js",
-      "order": 179,
+      "order": 180,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-agent-mode.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-validity.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-agent-mode.js",
-      "order": 180,
+      "order": 181,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-agent-read-tools.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-pipeline-steps.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-agent-read-tools.js",
-      "order": 181,
+      "order": 182,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-wentian-agent.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-agent-mode.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-wentian-agent.js",
-      "order": 182,
+      "order": 183,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-agent-write-tools.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-agent-read-tools.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-agent-write-tools.js",
-      "order": 183,
+      "order": 184,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-agent-depth-tools.js"
-      ],
-      "mustLoadAfter": [
-        "tm-wentian-agent.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-agent-depth-tools.js",
-      "order": 184,
+      "order": 185,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-agent-intent-plan.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-agent-write-tools.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-agent-intent-plan.js",
-      "order": 185,
+      "order": 186,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-shiji-compose.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-agent-depth-tools.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-shiji-compose.js",
-      "order": 186,
+      "order": 187,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_composeShijiHtml",
@@ -5019,19 +5041,19 @@
         "_sjcSwitchVol"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-render.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-agent-intent-plan.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-render.js",
-      "order": 187,
+      "order": 188,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_clearPreEndturnMarkerAfterSave",
         "_endTurn_clearCommittedInputs",
@@ -5048,19 +5070,19 @@
         "buildWorldChangeDigest"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-progress.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-shiji-compose.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-progress.js",
-      "order": 188,
+      "order": 189,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_loadingMaxPct",
@@ -5068,34 +5090,34 @@
         "showLoading"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-endturn-loading.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-render.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-endturn-loading.js",
-      "order": 189,
+      "order": 190,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-theme-font.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-progress.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-theme-font.js",
-      "order": 190,
+      "order": 191,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMThemeFont",
         "_tmApplyBodyFont",
@@ -5106,19 +5128,19 @@
         "_tmRenderThemeFontControls"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-patches.js"
-      ],
-      "mustLoadAfter": [
-        "tm-endturn-loading.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-patches.js",
-      "order": 191,
+      "order": 192,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "DEFAULT_PROMPT",
         "DEFAULT_RULES",
@@ -5177,19 +5199,19 @@
         "sToggleSecondaryEnabled"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-patches-start.js"
-      ],
-      "mustLoadAfter": [
-        "tm-theme-font.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-patches-start.js",
-      "order": 192,
+      "order": 193,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_tmResetScenarioScopedConfig",
@@ -5230,19 +5252,19 @@
         "doActualStart"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-military-ui.js"
-      ],
-      "mustLoadAfter": [
-        "tm-patches.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-military-ui.js",
-      "order": 193,
+      "order": 194,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "addArmy",
         "aiGenMil",
@@ -5252,19 +5274,19 @@
         "renderMilTab"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-world-view.js"
-      ],
-      "mustLoadAfter": [
-        "tm-patches-start.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-world-view.js",
-      "order": 194,
+      "order": 195,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "closeEraTrends",
         "closeHistoricalEvents",
@@ -5275,19 +5297,19 @@
         "openWorldSituation"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "editor-details.js"
-      ],
-      "mustLoadAfter": [
-        "tm-military-ui.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "editor-details.js",
-      "order": 195,
+      "order": 196,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "aiGenClasses",
         "aiGenEvents",
@@ -5309,19 +5331,19 @@
         "saveChrEdit"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-three-systems-ext.js"
-      ],
-      "mustLoadAfter": [
-        "tm-world-view.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-three-systems-ext.js",
-      "order": 196,
+      "order": 197,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "ThreeSystemsExt",
         "buildNpcDecisionsForSysP",
@@ -5331,549 +5353,549 @@
         "updateThreeSystemsOnEndTurn"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-army-units.js"
-      ],
-      "mustLoadAfter": [
-        "editor-details.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-army-units.js",
-      "order": 197,
+      "order": 198,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMArmyUnits"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-armory.js"
-      ],
-      "mustLoadAfter": [
-        "tm-three-systems-ext.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-armory.js",
-      "order": 198,
+      "order": 199,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMArmory"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-battle-adapter.js"
-      ],
-      "mustLoadAfter": [
-        "tm-army-units.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-battle-adapter.js",
-      "order": 199,
+      "order": 200,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMBattleAdapter"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-battle-embed.js"
-      ],
-      "mustLoadAfter": [
-        "tm-armory.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-battle-embed.js",
-      "order": 200,
+      "order": 201,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMBattleEmbed"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-battle-resolve.js"
-      ],
-      "mustLoadAfter": [
-        "tm-battle-adapter.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-battle-resolve.js",
-      "order": 201,
+      "order": 202,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMBattleResolve"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-battle-turn.js"
-      ],
-      "mustLoadAfter": [
-        "tm-battle-embed.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-battle-turn.js",
-      "order": 202,
+      "order": 203,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMBattleTurn",
         "_tmSetYujiaObserve",
         "_tmSetYujiaQinzheng"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-paradigm.js"
-      ],
-      "mustLoadAfter": [
-        "tm-battle-resolve.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-paradigm.js",
-      "order": 203,
+      "order": 204,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-personality.js"
-      ],
-      "mustLoadAfter": [
-        "tm-battle-turn.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-personality.js",
-      "order": 204,
+      "order": 205,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-npc-settings.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-paradigm.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-npc-settings.js",
-      "order": 205,
+      "order": 206,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-npc-news-bridge.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-personality.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-npc-news-bridge.js",
-      "order": 206,
+      "order": 207,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-action-engine.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-npc-settings.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-action-engine.js",
-      "order": 207,
+      "order": 208,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_tmSetFactionLivingWorld"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-goal-stack.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-npc-news-bridge.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-goal-stack.js",
-      "order": 208,
+      "order": 209,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-npc-intervention.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-action-engine.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-npc-intervention.js",
-      "order": 209,
+      "order": 210,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-npc-llm-enrich.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-goal-stack.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-npc-llm-enrich.js",
-      "order": 210,
+      "order": 211,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-npc-llm-decision.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-npc-intervention.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-npc-llm-decision.js",
-      "order": 211,
+      "order": 212,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-diplomacy.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-npc-llm-enrich.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-diplomacy.js",
-      "order": 212,
+      "order": 213,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-negotiation.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-npc-llm-decision.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-negotiation.js",
-      "order": 213,
+      "order": 214,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-decision-tools.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-diplomacy.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-decision-tools.js",
-      "order": 214,
+      "order": 215,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-npc-in-turn-driver.js"
-      ],
-      "mustLoadAfter": [
-        "tm-negotiation.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-npc-in-turn-driver.js",
-      "order": 215,
+      "order": 216,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-npc-dispatcher.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-decision-tools.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-npc-dispatcher.js",
-      "order": 216,
+      "order": 217,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-index.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-npc-in-turn-driver.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-index.js",
-      "order": 217,
+      "order": 218,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-derived-health.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-npc-dispatcher.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-derived-health.js",
-      "order": 218,
+      "order": 219,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-derived-economy.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-index.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-derived-economy.js",
-      "order": 219,
+      "order": 220,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-derived-cohesion.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-derived-health.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-derived-cohesion.js",
-      "order": 220,
+      "order": 221,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-derived-strength.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-derived-economy.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-derived-strength.js",
-      "order": 221,
+      "order": 222,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-npc-memorial.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-derived-cohesion.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-npc-memorial.js",
-      "order": 222,
+      "order": 223,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-npc-edict.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-derived-strength.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-npc-edict.js",
-      "order": 223,
+      "order": 224,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-npc-chaoyi.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-npc-memorial.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-npc-chaoyi.js",
-      "order": 224,
+      "order": 225,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-npc-office.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-npc-edict.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-npc-office.js",
-      "order": 225,
+      "order": 226,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-npc-guoku.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-npc-chaoyi.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-npc-guoku.js",
-      "order": 226,
+      "order": 227,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-faction-membership.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-npc-office.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-faction-membership.js",
-      "order": 227,
+      "order": 228,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-three-systems-ui.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-npc-guoku.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-three-systems-ui.js",
-      "order": 228,
+      "order": 229,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_originalOpenMilitaryDetailPanel",
         "_originalOpenPartyDetailPanel",
@@ -5907,19 +5929,19 @@
         "viewFac"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-char-arcs.js"
-      ],
-      "mustLoadAfter": [
-        "tm-faction-membership.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-char-arcs.js",
-      "order": 229,
+      "order": 230,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "CharArcs",
         "advanceCharArcs",
@@ -5927,36 +5949,36 @@
         "ensureCharArcsBeforeEndturn"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-learning-traits.js"
-      ],
-      "mustLoadAfter": [
-        "tm-three-systems-ui.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-learning-traits.js",
-      "order": 230,
+      "order": 231,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjInferLearningTraits"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-tier.js"
-      ],
-      "mustLoadAfter": [
-        "tm-char-arcs.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-tier.js",
-      "order": 231,
+      "order": 232,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_kjDeriveStageDurationDict",
@@ -5969,19 +5991,19 @@
         "_kjValidateTier"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-presets.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-learning-traits.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-presets.js",
-      "order": 232,
+      "order": 233,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_kjGetPresetByEra",
@@ -5989,38 +6011,38 @@
         "_kjPresetSummary"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-paradigm-presets.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-tier.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-paradigm-presets.js",
-      "order": 233,
+      "order": 234,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_kjpGetParadigmAddonByEra",
         "_kjpListAllParadigmAddons"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-paradigm.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-presets.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-paradigm.js",
-      "order": 234,
+      "order": 235,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_kjpDescribeParadigm",
@@ -6036,19 +6058,19 @@
         "_kjpValidateParadigm"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-reform-llm.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-paradigm-presets.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-reform-llm.js",
-      "order": 235,
+      "order": 236,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "ARCHETYPE_BIAS_TONE",
         "ARCHETYPE_LABELS",
@@ -6092,19 +6114,19 @@
         "_ty3_appendReformPromptIfReform"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-paradigm-panel-render.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-paradigm.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-paradigm-panel-render.js",
-      "order": 236,
+      "order": 237,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_kjpCurrentCeduiArchetype",
@@ -6113,19 +6135,19 @@
         "_kjpCurrentCeduiDraft"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-paradigm-panel.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-reform-llm.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-paradigm-panel.js",
-      "order": 237,
+      "order": 238,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_kjpAccumReformLean",
@@ -6170,19 +6192,19 @@
         "_kjpSubmitReform"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-topic-router.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-paradigm-panel-render.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-topic-router.js",
-      "order": 238,
+      "order": 239,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "KEYI_TOPIC_TYPES",
         "_kjListTopicTypes",
@@ -6190,37 +6212,37 @@
         "_kjTopicSummary"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-examiner-view.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-paradigm-panel.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-examiner-view.js",
-      "order": 239,
+      "order": 240,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kejuExaminerView",
         "_kjExaminerKeyiCallback"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-tension.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-topic-router.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-tension.js",
-      "order": 240,
+      "order": 241,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjCalcTotalPartyTension",
         "_kjDecayFactionTension",
@@ -6230,38 +6252,38 @@
         "_kjUpdateFactionTension"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-corruption.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-examiner-view.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-corruption.js",
-      "order": 241,
+      "order": 242,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_corrCalcExaminerCorruption",
         "_kjCalcPartyCorruption",
         "_kjGetDeptCorruption"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-question-ui.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-tension.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-question-ui.js",
-      "order": 242,
+      "order": 243,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjApplyAlignmentEvent",
         "_kjCalcTopicAlignment",
@@ -6272,36 +6294,36 @@
         "_kjUpdateAlignmentUI"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-budget-ui.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-corruption.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-budget-ui.js",
-      "order": 243,
+      "order": 244,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjRenderBudgetRow"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-dianshi-events.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-question-ui.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-dianshi-events.js",
-      "order": 244,
+      "order": 245,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjBumpSatisfaction",
         "_kjCommonerZhuangyuanEvent",
@@ -6311,19 +6333,19 @@
         "_kjResolveClassName"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-mentor.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-budget-ui.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-mentor.js",
-      "order": 245,
+      "order": 246,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjAddMentorEdge",
         "_kjBuildMentorIndex",
@@ -6333,19 +6355,19 @@
         "_kjInitMentorIndex"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-disciple-graph.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-dianshi-events.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-disciple-graph.js",
-      "order": 246,
+      "order": 247,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjAddDiscipleEdge",
         "_kjBumpDiscipleStrength",
@@ -6357,19 +6379,19 @@
         "_kjUpgradeMentorIndexToDiscipleGraph"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-disciple-memorial.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-mentor.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-disciple-memorial.js",
-      "order": 247,
+      "order": 248,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjCheckDiscipleMemorialTriggers",
         "_kjConsumeDiscipleMemorialsForAgenda",
@@ -6378,76 +6400,76 @@
         "_kjIsCrossPartyMemorial"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-cohort-meet.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-disciple-graph.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-cohort-meet.js",
-      "order": 248,
+      "order": 249,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjCheckCohortMeetTriggers",
         "_kjConsumeCohortMeetsForAgenda",
         "_kjF3InjectMemorialPrompt"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-yanguan-attribution.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-disciple-memorial.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-yanguan-attribution.js",
-      "order": 249,
+      "order": 250,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjYanguanClassify",
         "_kjYanguanPromptHint",
         "_kjYanguanResolveAttribution"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-yanguan-qingyi.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-cohort-meet.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-yanguan-qingyi.js",
-      "order": 250,
+      "order": 251,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjCheckYanguanQingyiTriggers",
         "_kjConsumeYanguanQingyiForAgenda",
         "_kjSpawnYanguanQingyi"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-reform-memorial.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-yanguan-attribution.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-reform-memorial.js",
-      "order": 251,
+      "order": 252,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjCheckReformMemorialTriggers",
         "_kjConsumeReformMemorialsForAgenda",
@@ -6455,19 +6477,19 @@
         "_kjSpawnReformMemorial"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-reform-evolution.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-yanguan-qingyi.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-reform-evolution.js",
-      "order": 252,
+      "order": 253,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_initKejuL8Hook",
@@ -6496,19 +6518,19 @@
         "_kjpMigrateReformChronicleV1"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-reform-presets-history.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-reform-memorial.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-reform-presets-history.js",
-      "order": 253,
+      "order": 254,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "ERA_LABEL_ZH",
         "L10_PRESETS",
@@ -6517,19 +6539,19 @@
         "_kjpL10FilterByEra"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-special-exams.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-reform-evolution.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-special-exams.js",
-      "order": 254,
+      "order": 255,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjCheckEnkeTriggers",
         "_kjCheckFanyiTriggers",
@@ -6541,19 +6563,19 @@
         "_kjSpawnSpecialExam"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-scandal.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-reform-presets-history.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-scandal.js",
-      "order": 255,
+      "order": 256,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjCheckScandalTriggers",
         "_kjConsumeScandalForAgenda",
@@ -6564,19 +6586,19 @@
         "resolveScandalExamContext"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-event-hooks.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-special-exams.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-event-hooks.js",
-      "order": 256,
+      "order": 257,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjEventCheckReignTransition",
         "_kjEventCheckWarStateRecovery",
@@ -6589,19 +6611,19 @@
         "_kjpHSchoolWenduiContext"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-enke-player-initiative.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-scandal.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-enke-player-initiative.js",
-      "order": 257,
+      "order": 258,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjG2DeriveLibuStanceFromChar",
         "_kjG2EnkeWenduiContext",
@@ -6619,19 +6641,19 @@
         "_kjG2ScanCtxInputEdictsForEnke"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-enke.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-event-hooks.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-enke.js",
-      "order": 258,
+      "order": 259,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjG2ApplyEnkeLifecycleCost",
         "_kjG2ApplyJinshiQualityDegradation",
@@ -6675,19 +6697,19 @@
         "_kjG2SpecialExamKeyiCallback"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-wuju.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-enke-player-initiative.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-wuju.js",
-      "order": 259,
+      "order": 260,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjG3ApplyWujuLifecycleCost",
         "_kjG3ApplyWuxiangshiRewards",
@@ -6742,19 +6764,19 @@
         "_kjG3WujuWenduiContext"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-tongzi.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-enke.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-tongzi.js",
-      "order": 260,
+      "order": 261,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_isG5Enabled",
         "_kjG5ApplyMinxinBoostOnSpawn",
@@ -6798,19 +6820,19 @@
         "_kjG5TongziHealthTick"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-school-network.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-wuju.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-school-network.js",
-      "order": 261,
+      "order": 262,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_isHEnabled",
         "_kjSchoolBanKeyiCallback",
@@ -6862,19 +6884,19 @@
         "_kjpSpawnShanzhang"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-reform-rollback.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-tongzi.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-reform-rollback.js",
-      "order": 262,
+      "order": 263,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_isL11Enabled",
@@ -6889,19 +6911,19 @@
         "_kjpL11SubmitRollback"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-reformer-bio.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-school-network.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-reformer-bio.js",
-      "order": 263,
+      "order": 264,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_isL12Enabled",
@@ -6923,19 +6945,19 @@
         "_kjpL12SubjectAliveInGame"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-reform-apply.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-reform-rollback.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-reform-apply.js",
-      "order": 264,
+      "order": 265,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjReformKeyiCallback",
         "_kjpL7AppendHistory",
@@ -6963,19 +6985,19 @@
         "_kjpL7WriteNpcReputationFromScore"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-allocation.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-reformer-bio.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-allocation.js",
-      "order": 265,
+      "order": 266,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjAllocateMingQing",
         "_kjAllocateSong",
@@ -6986,19 +7008,19 @@
         "_kjDispatchAllocationByDynasty"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-activation.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-reform-apply.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-activation.js",
-      "order": 266,
+      "order": 267,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_kjActivateOutcomeHandlers",
         "_kjActivateRun",
@@ -7006,19 +7028,19 @@
         "_kjApplyReformOutcome"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-indicators.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-allocation.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-indicators.js",
-      "order": 267,
+      "order": 268,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_kjCalcF1",
@@ -7029,19 +7051,19 @@
         "_kjUpdateIndicators"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-activation.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju.js",
-      "order": 268,
+      "order": 269,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "CY",
         "_adjustHuangquan",
@@ -7086,19 +7108,19 @@
         "startKejuReform"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-chaoyi.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-indicators.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-chaoyi.js",
-      "order": 269,
+      "order": 270,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_cc2_agendaDedupKey",
         "_cc2_agendaSourceToItem",
@@ -7135,36 +7157,36 @@
         "startChaoyiSession"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-official-scenario-seeder.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-official-scenario-seeder.js",
-      "order": 270,
+      "order": 271,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMOfficialScenarioSeeder"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-electron.js"
-      ],
-      "mustLoadAfter": [
-        "tm-chaoyi.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-electron.js",
-      "order": 271,
+      "order": 272,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "__tmElectronGlobalMouseDownInstalled",
         "_pendingRefText",
@@ -7190,19 +7212,19 @@
         "updateRegion"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-runtime.js"
-      ],
-      "mustLoadAfter": [
-        "tm-official-scenario-seeder.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-runtime.js",
-      "order": 272,
+      "order": 273,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_adjustHuangwei",
         "_finalizeStageAndAdvance",
@@ -7245,19 +7267,19 @@
         "startKejuExam"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-keju-runtime-keyi.js"
-      ],
-      "mustLoadAfter": [
-        "tm-electron.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-keju-runtime-keyi.js",
-      "order": 273,
+      "order": 274,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "KEYI_STATE",
         "_aiGenerateFullCharacter",
@@ -7313,19 +7335,19 @@
         "viewAnswer"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-chaoyi-tinyi.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-runtime.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-chaoyi-tinyi.js",
-      "order": 274,
+      "order": 275,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_cy_suggestBtnHtml",
         "_ty2_afterOverride",
@@ -7358,19 +7380,19 @@
         "_ty2_tagBubbleStance"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-chaoyi-yuqian.js"
-      ],
-      "mustLoadAfter": [
-        "tm-keju-runtime-keyi.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-chaoyi-yuqian.js",
-      "order": 275,
+      "order": 276,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_yq2_askAdvisor",
         "_yq2_decide",
@@ -7397,19 +7419,19 @@
         "_yq2_triggerExcludedFeelings"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-chaoyi-changchao-adapter.js"
-      ],
-      "mustLoadAfter": [
-        "tm-chaoyi-tinyi.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-chaoyi-changchao-adapter.js",
-      "order": 276,
+      "order": 277,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_cc3RuntimePlayer",
         "_cc3_aiEnabled",
@@ -7443,19 +7465,19 @@
         "_cc3_streamReactBubble"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-chaoyi-changchao.js"
-      ],
-      "mustLoadAfter": [
-        "tm-chaoyi-yuqian.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-chaoyi-changchao.js",
-      "order": 277,
+      "order": 278,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "$",
         "AGENDA",
@@ -7548,19 +7570,19 @@
         "updateTimeOfDay"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-chaoyi-changchao-flows.js"
-      ],
-      "mustLoadAfter": [
-        "tm-chaoyi-changchao-adapter.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-chaoyi-changchao-flows.js",
-      "order": 278,
+      "order": 279,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "NEUTRAL_AFTER_HOLD",
         "OPPOSER_AFTER_APPROVE",
@@ -7596,19 +7618,19 @@
         "showSummary"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-tinyi-v3-persona.js"
-      ],
-      "mustLoadAfter": [
-        "tm-chaoyi-changchao.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-tinyi-v3-persona.js",
-      "order": 279,
+      "order": 280,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "DYNASTY_POPULATION_CONFIDENCE_INIT",
         "EMPEROR_INTENT_BIAS",
@@ -7685,19 +7707,19 @@
         "_ty3_v15_pushClearOpinionEvent"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-tinyi-v3.js"
-      ],
-      "mustLoadAfter": [
-        "tm-chaoyi-changchao-flows.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-tinyi-v3.js",
-      "order": 280,
+      "order": 281,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TY3_HAREM_TITLE_RE",
         "_cy_pickMode",
@@ -7825,19 +7847,19 @@
         "_yq2_seedTopic"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-tinyi-v3-edict-personnel.js"
-      ],
-      "mustLoadAfter": [
-        "tm-tinyi-v3-persona.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-tinyi-v3-edict-personnel.js",
-      "order": 281,
+      "order": 282,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_ty2_enterDecide",
         "_ty3_advanceToSeal",
@@ -7891,19 +7913,19 @@
         "escAttr"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-tinyi-v3-parties.js"
-      ],
-      "mustLoadAfter": [
-        "tm-tinyi-v3.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-tinyi-v3-parties.js",
-      "order": 282,
+      "order": 283,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_TY3_REVIEW_DELAY",
         "_ty3_alreadyHasTopic",
@@ -7977,19 +7999,19 @@
         "terminateChronicleTrack"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-char-autogen.js"
-      ],
-      "mustLoadAfter": [
-        "tm-tinyi-v3-edict-personnel.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-char-autogen.js",
-      "order": 283,
+      "order": 284,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_resolveFactionForChar",
         "_tmClickPendingChar",
@@ -8007,19 +8029,19 @@
         "wrapPendingName"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-bgm-config.js"
-      ],
-      "mustLoadAfter": [
-        "tm-tinyi-v3-parties.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-bgm-config.js",
-      "order": 284,
+      "order": 285,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM_BGM_DEFAULT_LOOP",
         "TM_BGM_PLAYLIST_VERSION",
@@ -8027,19 +8049,19 @@
         "TM_MENU_BGM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-audio-theme.js"
-      ],
-      "mustLoadAfter": [
-        "tm-char-autogen.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-audio-theme.js",
-      "order": 285,
+      "order": 286,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "AudioSystem",
         "TM_playMenuBgm",
@@ -8058,19 +8080,19 @@
         "updateSfxVolume"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-save-lifecycle.js"
-      ],
-      "mustLoadAfter": [
-        "tm-bgm-config.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-save-lifecycle.js",
-      "order": 286,
+      "order": 287,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "GM",
         "P",
@@ -8182,38 +8204,38 @@
         "scriptData"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-save-close-flush.js"
-      ],
-      "mustLoadAfter": [
-        "tm-audio-theme.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-save-close-flush.js",
-      "order": 287,
+      "order": 288,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_tmAwaitDesktopAutoSaveForClose",
         "_tmFlushBackgroundAutosavesForClose",
         "_tmInstallDesktopCloseFlushBridge"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-office-editor.js"
-      ],
-      "mustLoadAfter": [
-        "tm-save-lifecycle.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-office-editor.js",
-      "order": 288,
+      "order": 289,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "SCENARIO_RESET_EDITOR_DRAFT_KEY",
         "_activeOfficePanWrap",
@@ -8283,19 +8305,19 @@
         "renderTechTab"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-topbar-vars.js"
-      ],
-      "mustLoadAfter": [
-        "tm-save-close-flush.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-topbar-vars.js",
-      "order": 289,
+      "order": 290,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TOP_BAR_VARS",
         "_VAR_RENDERERS",
@@ -8354,19 +8376,19 @@
         "renderTopBarVars"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-shell-extras.js"
-      ],
-      "mustLoadAfter": [
-        "tm-office-editor.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-shell-extras.js",
-      "order": 290,
+      "order": 291,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_renderShellExtrasLeft",
         "_renderShellExtrasRight",
@@ -8377,37 +8399,37 @@
         "_tmShellMarchPrompt"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-houguong.js"
-      ],
-      "mustLoadAfter": [
-        "tm-topbar-vars.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-houguong.js",
-      "order": 291,
+      "order": 292,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_launchPostTurnJobs"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-shizheng-panel.js"
-      ],
-      "mustLoadAfter": [
-        "tm-shell-extras.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-shizheng-panel.js",
-      "order": 292,
+      "order": 293,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_mzAddSystemLine",
         "_mzCaptureSelection",
@@ -8440,69 +8462,69 @@
         "openShizhengTasks"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-corruption-engine.js"
-      ],
-      "mustLoadAfter": [
-        "tm-houguong.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-corruption-engine.js",
-      "order": 293,
+      "order": 294,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "CorruptionEngine"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-corruption-cases.js"
-      ],
-      "mustLoadAfter": [
-        "tm-shizheng-panel.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-corruption-cases.js",
-      "order": 294,
+      "order": 295,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-corruption-extras.js"
-      ],
-      "mustLoadAfter": [
-        "tm-corruption-engine.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-corruption-extras.js",
-      "order": 295,
+      "order": 296,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_corrEditorSave",
         "renderPolygons"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-lizhi-panel.js"
-      ],
-      "mustLoadAfter": [
-        "tm-corruption-cases.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-lizhi-panel.js",
-      "order": 296,
+      "order": 297,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_calcOverCollectRate",
@@ -8541,36 +8563,36 @@
         "renderTaxThreeNumberBlock"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-guoku-engine.js"
-      ],
-      "mustLoadAfter": [
-        "tm-corruption-extras.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-guoku-engine.js",
-      "order": 297,
+      "order": 298,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "GuokuEngine"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-guoku-panel.js"
-      ],
-      "mustLoadAfter": [
-        "tm-lizhi-panel.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-guoku-panel.js",
-      "order": 298,
+      "order": 299,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_guokuActionBtn",
         "_guokuFmt",
@@ -8604,36 +8626,36 @@
         "renderGuokuPanel"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-neitang-engine.js"
-      ],
-      "mustLoadAfter": [
-        "tm-guoku-engine.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-neitang-engine.js",
-      "order": 299,
+      "order": 300,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "NeitangEngine"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-neitang-panel.js"
-      ],
-      "mustLoadAfter": [
-        "tm-guoku-panel.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-neitang-panel.js",
-      "order": 300,
+      "order": 301,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_neitangActionBtn",
         "_neitangFmt",
@@ -8649,36 +8671,36 @@
         "renderNeitangPanel"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-char-economy-engine.js"
-      ],
-      "mustLoadAfter": [
-        "tm-neitang-engine.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-char-economy-engine.js",
-      "order": 301,
+      "order": 302,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "CharEconEngine"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-char-historical-profiles.js"
-      ],
-      "mustLoadAfter": [
-        "tm-neitang-panel.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-char-historical-profiles.js",
-      "order": 302,
+      "order": 303,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "HISTORICAL_CHAR_PROFILES",
         "createCharFromProfile",
@@ -8687,294 +8709,294 @@
         "loadHistoricalCharsFromScenario"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-char-historical-wave-01.js"
-      ],
-      "mustLoadAfter": [
-        "tm-char-economy-engine.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-char-historical-wave-01.js",
-      "order": 303,
+      "order": 304,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "HISTORICAL_CHAR_PROFILES"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-char-historical-wave-02.js"
-      ],
-      "mustLoadAfter": [
-        "tm-char-historical-profiles.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-char-historical-wave-02.js",
-      "order": 304,
+      "order": 305,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "HISTORICAL_CHAR_PROFILES"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-char-historical-wave-03.js"
-      ],
-      "mustLoadAfter": [
-        "tm-char-historical-wave-01.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-char-historical-wave-03.js",
-      "order": 305,
+      "order": 306,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "HISTORICAL_CHAR_PROFILES"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-char-historical-wave-04.js"
-      ],
-      "mustLoadAfter": [
-        "tm-char-historical-wave-02.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-char-historical-wave-04.js",
-      "order": 306,
+      "order": 307,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "HISTORICAL_CHAR_PROFILES"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-char-historical-wave-05.js"
-      ],
-      "mustLoadAfter": [
-        "tm-char-historical-wave-03.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-char-historical-wave-05.js",
-      "order": 307,
+      "order": 308,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "HISTORICAL_CHAR_PROFILES"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-char-historical-wave-06.js"
-      ],
-      "mustLoadAfter": [
-        "tm-char-historical-wave-04.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-char-historical-wave-06.js",
-      "order": 308,
+      "order": 309,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "HISTORICAL_CHAR_PROFILES"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-char-historical-wave-07.js"
-      ],
-      "mustLoadAfter": [
-        "tm-char-historical-wave-05.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-char-historical-wave-07.js",
-      "order": 309,
+      "order": 310,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "HISTORICAL_CHAR_PROFILES"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-char-historical-wave-08.js"
-      ],
-      "mustLoadAfter": [
-        "tm-char-historical-wave-06.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-char-historical-wave-08.js",
-      "order": 310,
+      "order": 311,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "HISTORICAL_CHAR_PROFILES"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-char-historical-wave-09.js"
-      ],
-      "mustLoadAfter": [
-        "tm-char-historical-wave-07.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-char-historical-wave-09.js",
-      "order": 311,
+      "order": 312,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "HISTORICAL_CHAR_PROFILES"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-char-historical-wave-10.js"
-      ],
-      "mustLoadAfter": [
-        "tm-char-historical-wave-08.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-char-historical-wave-10.js",
-      "order": 312,
+      "order": 313,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "HISTORICAL_CHAR_PROFILES"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-char-historical-wave-11.js"
-      ],
-      "mustLoadAfter": [
-        "tm-char-historical-wave-09.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-char-historical-wave-11.js",
-      "order": 313,
+      "order": 314,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "HISTORICAL_CHAR_PROFILES"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-char-historical-wave-12.js"
-      ],
-      "mustLoadAfter": [
-        "tm-char-historical-wave-10.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-char-historical-wave-12.js",
-      "order": 314,
+      "order": 315,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "HISTORICAL_CHAR_PROFILES"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-ceming.js"
-      ],
-      "mustLoadAfter": [
-        "tm-char-historical-wave-11.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-ceming.js",
-      "order": 315,
+      "order": 316,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-char-economy-ui.js"
-      ],
-      "mustLoadAfter": [
-        "tm-char-historical-wave-12.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-char-economy-ui.js",
-      "order": 316,
+      "order": 317,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_charConfiscate",
         "_charInspect",
         "renderCharResourcesSection"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-char-full-schema.js"
-      ],
-      "mustLoadAfter": [
-        "tm-ceming.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-char-full-schema.js",
-      "order": 317,
+      "order": 318,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "CharFullSchema"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-economy-engine-currency.js"
-      ],
-      "mustLoadAfter": [
-        "tm-char-economy-ui.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-economy-engine-currency.js",
-      "order": 318,
+      "order": 319,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "CurrencyEngine",
         "CurrencyUnit"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-economy-engine.js"
-      ],
-      "mustLoadAfter": [
-        "tm-char-full-schema.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-economy-engine.js",
-      "order": 319,
+      "order": 320,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "EconomyCore",
         "EconomyEventBus",
@@ -8983,125 +9005,125 @@
         "EnvCapacityEngine"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-central-local-engine.js"
-      ],
-      "mustLoadAfter": [
-        "tm-economy-engine-currency.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-central-local-engine.js",
-      "order": 320,
+      "order": 321,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "CentralLocalEngine"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-huji-engine.js"
-      ],
-      "mustLoadAfter": [
-        "tm-economy-engine.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-huji-engine.js",
-      "order": 321,
+      "order": 322,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "HujiEngine"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-edict-parser.js"
-      ],
-      "mustLoadAfter": [
-        "tm-central-local-engine.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-edict-parser.js",
-      "order": 322,
+      "order": 323,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "EdictComplete",
         "EdictParser",
         "PhaseC"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-huji-deep-fill.js"
-      ],
-      "mustLoadAfter": [
-        "tm-huji-engine.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-huji-deep-fill.js",
-      "order": 323,
+      "order": 324,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "HujiDeepFill"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-huji-runtime-bridge.js"
-      ],
-      "mustLoadAfter": [
-        "tm-edict-parser.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-huji-runtime-bridge.js",
-      "order": 324,
+      "order": 325,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "HujiRuntimeBridge",
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-huji-governance-loop.js"
-      ],
-      "mustLoadAfter": [
-        "tm-huji-deep-fill.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-huji-governance-loop.js",
-      "order": 325,
+      "order": 326,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "HujiGovernanceLoop",
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-edict-complete.js"
-      ],
-      "mustLoadAfter": [
-        "tm-huji-runtime-bridge.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-edict-complete.js",
-      "order": 326,
+      "order": 327,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "EdictComplete",
         "_processAbduction",
@@ -9109,36 +9131,36 @@
         "openMemorialsPanel"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-env-recovery-fill.js"
-      ],
-      "mustLoadAfter": [
-        "tm-huji-governance-loop.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-env-recovery-fill.js",
-      "order": 327,
+      "order": 328,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "EnvRecoveryFill"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-authority-engines.js"
-      ],
-      "mustLoadAfter": [
-        "tm-edict-complete.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-authority-engines.js",
-      "order": 328,
+      "order": 329,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "AuthorityEngines",
         "PhaseF1",
@@ -9148,413 +9170,413 @@
         "filterQueryOptionsByPhase"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-building-works.js"
-      ],
-      "mustLoadAfter": [
-        "tm-env-recovery-fill.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-building-works.js",
-      "order": 329,
+      "order": 330,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-talent-cohorts.js"
-      ],
-      "mustLoadAfter": [
-        "tm-authority-engines.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-talent-cohorts.js",
-      "order": 330,
+      "order": 331,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-talent-bottlenecks.js"
-      ],
-      "mustLoadAfter": [
-        "tm-building-works.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-talent-bottlenecks.js",
-      "order": 331,
+      "order": 332,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-talent-building-bridge.js"
-      ],
-      "mustLoadAfter": [
-        "tm-talent-cohorts.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-talent-building-bridge.js",
-      "order": 332,
+      "order": 333,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-talent-backlash.js"
-      ],
-      "mustLoadAfter": [
-        "tm-talent-bottlenecks.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-talent-backlash.js",
-      "order": 333,
+      "order": 334,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-field-pipelines.js"
-      ],
-      "mustLoadAfter": [
-        "tm-talent-building-bridge.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-field-pipelines.js",
-      "order": 334,
+      "order": 335,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-region-status.js"
-      ],
-      "mustLoadAfter": [
-        "tm-talent-backlash.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-region-status.js",
-      "order": 335,
+      "order": 336,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-renli.js"
-      ],
-      "mustLoadAfter": [
-        "tm-field-pipelines.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-renli.js",
-      "order": 336,
+      "order": 337,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-reported-view.js"
-      ],
-      "mustLoadAfter": [
-        "tm-region-status.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-reported-view.js",
-      "order": 337,
+      "order": 338,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-social-foundation.js"
-      ],
-      "mustLoadAfter": [
-        "tm-renli.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-social-foundation.js",
-      "order": 338,
+      "order": 339,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-authority-complete.js"
-      ],
-      "mustLoadAfter": [
-        "tm-reported-view.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-authority-complete.js",
-      "order": 339,
+      "order": 340,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "AuthorityComplete"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-revolt-entity.js"
-      ],
-      "mustLoadAfter": [
-        "tm-social-foundation.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-revolt-entity.js",
-      "order": 340,
+      "order": 341,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-revolt-inference.js"
-      ],
-      "mustLoadAfter": [
-        "tm-authority-complete.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-revolt-inference.js",
-      "order": 341,
+      "order": 342,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-party-inference.js"
-      ],
-      "mustLoadAfter": [
-        "tm-revolt-entity.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-party-inference.js",
-      "order": 342,
+      "order": 343,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-captive-court.js"
-      ],
-      "mustLoadAfter": [
-        "tm-revolt-inference.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-captive-court.js",
-      "order": 343,
+      "order": 344,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-historical-presets.js"
-      ],
-      "mustLoadAfter": [
-        "tm-party-inference.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-historical-presets.js",
-      "order": 344,
+      "order": 345,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "HistoricalPresets"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-prophecy.js"
-      ],
-      "mustLoadAfter": [
-        "tm-captive-court.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-prophecy.js",
-      "order": 345,
+      "order": 346,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "PhaseD"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-region-enrich.js"
-      ],
-      "mustLoadAfter": [
-        "tm-historical-presets.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-region-enrich.js",
-      "order": 346,
+      "order": 347,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "PhaseB"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-audit.js"
-      ],
-      "mustLoadAfter": [
-        "tm-prophecy.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-audit.js",
-      "order": 347,
+      "order": 348,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "PhaseA"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-feedback-loops.js"
-      ],
-      "mustLoadAfter": [
-        "tm-region-enrich.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-feedback-loops.js",
-      "order": 348,
+      "order": 349,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "PhaseE",
         "openAnnualFuyiPanel"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-event-bus.js"
-      ],
-      "mustLoadAfter": [
-        "tm-audit.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-event-bus.js",
-      "order": 349,
+      "order": 350,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "EventBus",
         "PhaseF2",
         "buildUnifiedAIContext"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-class-mobility.js"
-      ],
-      "mustLoadAfter": [
-        "tm-feedback-loops.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-class-mobility.js",
-      "order": 350,
+      "order": 351,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "PhaseF3"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-authority-deep.js"
-      ],
-      "mustLoadAfter": [
-        "tm-event-bus.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-authority-deep.js",
-      "order": 351,
+      "order": 352,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "PhaseF4"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-player-tools.js"
-      ],
-      "mustLoadAfter": [
-        "tm-class-mobility.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-player-tools.js",
-      "order": 352,
+      "order": 353,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "PhaseF5",
         "openEdictReferenceBar",
@@ -9563,36 +9585,36 @@
         "openPlayerActionMenu"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-ledger-paper.js"
-      ],
-      "mustLoadAfter": [
-        "tm-authority-deep.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-ledger-paper.js",
-      "order": 353,
+      "order": 354,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "PhaseF6"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-authority-ui.js"
-      ],
-      "mustLoadAfter": [
-        "tm-player-tools.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-authority-ui.js",
-      "order": 354,
+      "order": 355,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "PhaseG1",
         "openLizhiInspection",
@@ -9602,92 +9624,92 @@
         "openTianweiInspection"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-ethnic-religion.js"
-      ],
-      "mustLoadAfter": [
-        "tm-ledger-paper.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-ethnic-religion.js",
-      "order": 355,
+      "order": 356,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "PhaseG2"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-edict-thresholds.js"
-      ],
-      "mustLoadAfter": [
-        "tm-authority-ui.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-edict-thresholds.js",
-      "order": 356,
+      "order": 357,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "PhaseG3",
         "TM_THRESHOLDS",
         "openFuyiSchemeComparison"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-fiscal-ui.js"
-      ],
-      "mustLoadAfter": [
-        "tm-ethnic-religion.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-fiscal-ui.js",
-      "order": 357,
+      "order": 358,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "PhaseG4",
         "openCarryingCapacityHeatmap",
         "openYearlyReport"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-integration-bridge.js"
-      ],
-      "mustLoadAfter": [
-        "tm-edict-thresholds.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-integration-bridge.js",
-      "order": 358,
+      "order": 359,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "IntegrationBridge",
         "aggregateRegionsToVariables"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-fiscal-engine.js"
-      ],
-      "mustLoadAfter": [
-        "tm-fiscal-ui.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-fiscal-engine.js",
-      "order": 359,
+      "order": 360,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "CascadeTax",
         "FiscalEngine",
@@ -9695,258 +9717,258 @@
         "PhaseH"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-invariants.js"
-      ],
-      "mustLoadAfter": [
-        "tm-integration-bridge.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-invariants.js",
-      "order": 360,
+      "order": 361,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-namespaces.js"
-      ],
-      "mustLoadAfter": [
-        "tm-fiscal-engine.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-namespaces.js",
-      "order": 361,
+      "order": 362,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-state.js"
-      ],
-      "mustLoadAfter": [
-        "tm-invariants.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-state.js",
-      "order": 362,
+      "order": 363,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-diff.js"
-      ],
-      "mustLoadAfter": [
-        "tm-namespaces.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-diff.js",
-      "order": 363,
+      "order": 364,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-hooks-tracker.js"
-      ],
-      "mustLoadAfter": [
-        "tm-state.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-hooks-tracker.js",
-      "order": 364,
+      "order": 365,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-diagnostics-panel.js"
-      ],
-      "mustLoadAfter": [
-        "tm-diff.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-diagnostics-panel.js",
-      "order": 365,
+      "order": 366,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_tmDiagHotkey"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-checklist.js"
-      ],
-      "mustLoadAfter": [
-        "tm-hooks-tracker.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-checklist.js",
-      "order": 366,
+      "order": 367,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-onboard-tools.js"
-      ],
-      "mustLoadAfter": [
-        "tm-diagnostics-panel.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-onboard-tools.js",
-      "order": 367,
+      "order": 368,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-ai-schema.js"
-      ],
-      "mustLoadAfter": [
-        "tm-checklist.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-ai-schema.js",
-      "order": 368,
+      "order": 369,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM_AI_SCHEMA"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-ai-output-validator.js"
-      ],
-      "mustLoadAfter": [
-        "tm-onboard-tools.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-ai-output-validator.js",
-      "order": 369,
+      "order": 370,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-data-access.js"
-      ],
-      "mustLoadAfter": [
-        "tm-ai-schema.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-data-access.js",
-      "order": 370,
+      "order": 371,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "DA"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-ai-change-pathutils.js"
-      ],
-      "mustLoadAfter": [
-        "tm-ai-output-validator.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-ai-change-pathutils.js",
-      "order": 371,
+      "order": 372,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-ai-change-army.js"
-      ],
-      "mustLoadAfter": [
-        "tm-data-access.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-ai-change-army.js",
-      "order": 372,
+      "order": 373,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-ai-change-narrative.js"
-      ],
-      "mustLoadAfter": [
-        "tm-ai-change-pathutils.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-ai-change-narrative.js",
-      "order": 373,
+      "order": 374,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-ai-change-applier.js"
-      ],
-      "mustLoadAfter": [
-        "tm-ai-change-army.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-ai-change-applier.js",
-      "order": 374,
+      "order": 375,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "AIChangeApplier",
         "_TM_IMPRISON_RE",
@@ -9966,34 +9988,34 @@
         "renderTurnReport"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-ai-change-applier-validators.js"
-      ],
-      "mustLoadAfter": [
-        "tm-ai-change-narrative.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-ai-change-applier-validators.js",
-      "order": 375,
+      "order": 376,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-ai-change-applier-reconcile.js"
-      ],
-      "mustLoadAfter": [
-        "tm-ai-change-applier.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-ai-change-applier-reconcile.js",
-      "order": 376,
+      "order": 377,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_applyBattleResult",
         "_applyDirectiveCompliance",
@@ -10011,38 +10033,38 @@
         "validateAIWriteBackBatch"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-ai-npc-memorials.js"
-      ],
-      "mustLoadAfter": [
-        "tm-ai-change-applier-validators.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-ai-npc-memorials.js",
-      "order": 377,
+      "order": 378,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "NpcMemorials",
         "buildEventReactionPrompt",
         "buildNpcSceneContext"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-var-drawers.js"
-      ],
-      "mustLoadAfter": [
-        "tm-ai-change-applier-reconcile.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-var-drawers.js",
-      "order": 378,
+      "order": 379,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "VarDrawersExt",
         "VarDrawersFinal",
@@ -10060,19 +10082,19 @@
         "renderMinxinPanel"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "editor-division-deep.js"
-      ],
-      "mustLoadAfter": [
-        "tm-ai-npc-memorials.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "editor-division-deep.js",
-      "order": 379,
+      "order": 380,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_dd_addDisasterRow",
         "_ensureDivisionDeepFields",
@@ -10081,36 +10103,36 @@
         "renderDivisionDeepFieldsHTML"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "editor-office-deep.js"
-      ],
-      "mustLoadAfter": [
-        "tm-var-drawers.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "editor-office-deep.js",
-      "order": 380,
+      "order": 381,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM_OfficeDeep"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "editor-presets.js"
-      ],
-      "mustLoadAfter": [
-        "editor-division-deep.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "editor-presets.js",
-      "order": 381,
+      "order": 382,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM_CustomPresets",
         "tmCpsAiGen",
@@ -10118,139 +10140,119 @@
         "tmCpsRender"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "bundled-scenarios/manifest.js"
-      ],
-      "mustLoadAfter": [
-        "editor-office-deep.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "bundled-scenarios/manifest.js",
-      "order": 382,
+      "order": 383,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-official-scenario-loader.js"
-      ],
-      "mustLoadAfter": [
-        "editor-presets.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-official-scenario-loader.js",
-      "order": 383,
+      "order": 384,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMOfficialScenarioLoader"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-test-harness.js"
-      ],
-      "mustLoadAfter": [
-        "bundled-scenarios/manifest.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
-    },
-    {
-      "script": "tm-test-harness.js",
-      "order": 384,
-      "phase": "world",
-      "provides": [
-        "P",
-        "TM",
-        "getTributeRatio",
-        "tm_guard_test_unique_xyz_123"
-      ],
-      "consumes": [],
-      "mustLoadBefore": [
-        "tm-changelog.js"
-      ],
-      "mustLoadAfter": [
-        "tm-official-scenario-loader.js"
-      ],
-      "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-changelog.js",
       "order": 385,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM_Changelog"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-online-client.js"
-      ],
-      "mustLoadAfter": [
-        "tm-test-harness.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-online-client.js",
       "order": 386,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-workshop-covers.js"
-      ],
-      "mustLoadAfter": [
-        "tm-changelog.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-workshop-covers.js",
       "order": 387,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMWorkshopCovers"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-zip-store.js"
-      ],
-      "mustLoadAfter": [
-        "tm-online-client.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-zip-store.js",
       "order": 388,
       "phase": "world",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMZipStore"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-content-manager.js"
-      ],
-      "mustLoadAfter": [
-        "tm-workshop-covers.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-content-manager.js",
       "order": 389,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "P",
         "TM",
@@ -10259,70 +10261,70 @@
         "showScnSelect"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-content-manager-community.js"
-      ],
-      "mustLoadAfter": [
-        "tm-zip-store.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-content-manager-community.js",
       "order": 390,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "preview/img/east-asia-basemap-data.js"
-      ],
-      "mustLoadAfter": [
-        "tm-content-manager.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "preview/img/east-asia-basemap-data.js",
       "order": 391,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "EAST_ASIA_BASEMAP"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "phase8-formal-bridge-styles.js"
-      ],
-      "mustLoadAfter": [
-        "tm-content-manager-community.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "phase8-formal-bridge-styles.js",
       "order": 392,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "phase8-formal-bridge.js"
-      ],
-      "mustLoadAfter": [
-        "preview/img/east-asia-basemap-data.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "phase8-formal-bridge.js",
       "order": 393,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMPhase8FormalBridge",
         "TM_PHASE8_FORMAL",
@@ -10338,115 +10340,81 @@
         "syncPhase8FormalEdictDrafts"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "phase8-formal-topbar.js"
-      ],
-      "mustLoadAfter": [
-        "phase8-formal-bridge-styles.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "phase8-formal-topbar.js",
       "order": 394,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-map-label-geo.js"
-      ],
-      "mustLoadAfter": [
-        "phase8-formal-bridge.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
-    },
-    {
-      "script": "tm-map-label-geo.js",
-      "order": 395,
-      "phase": "optional",
-      "provides": [
-        "TMMapLabelGeo"
-      ],
-      "consumes": [],
-      "mustLoadBefore": [
-        "tm-map-label-collide.js"
-      ],
-      "mustLoadAfter": [
-        "phase8-formal-topbar.js"
-      ],
-      "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
-    },
-    {
-      "script": "tm-map-label-collide.js",
-      "order": 396,
-      "phase": "optional",
-      "provides": [
-        "TMMapLabelCollide"
-      ],
-      "consumes": [],
-      "mustLoadBefore": [
-        "phase8-formal-map.js"
-      ],
-      "mustLoadAfter": [
-        "tm-map-label-geo.js"
-      ],
-      "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "phase8-formal-map.js",
-      "order": 397,
+      "order": 395,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "phase8-formal-map-dossier.js"
-      ],
-      "mustLoadAfter": [
-        "tm-map-label-collide.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "phase8-formal-map-dossier.js",
-      "order": 398,
+      "order": 396,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "phase8-formal-modules.js"
-      ],
-      "mustLoadAfter": [
-        "phase8-formal-map.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "phase8-formal-modules.js",
-      "order": 399,
+      "order": 397,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "renderRenwuModule"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "phase8-formal-drafts.js"
-      ],
-      "mustLoadAfter": [
-        "phase8-formal-map-dossier.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "phase8-formal-drafts.js",
-      "order": 400,
+      "order": 398,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "GM",
         "TM",
@@ -10460,52 +10428,52 @@
         "syncPhase8FormalEdictDrafts"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "phase8-formal-drafts-message-panels.js"
-      ],
-      "mustLoadAfter": [
-        "phase8-formal-modules.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "phase8-formal-drafts-message-panels.js",
-      "order": 401,
+      "order": 399,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "_tmLetterReadGo",
         "_tmLetterReadReply"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "phase8-formal-records.js"
-      ],
-      "mustLoadAfter": [
-        "phase8-formal-drafts.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "phase8-formal-records.js",
-      "order": 402,
+      "order": 400,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-renwu-tuzhi.js"
-      ],
-      "mustLoadAfter": [
-        "phase8-formal-drafts-message-panels.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-renwu-tuzhi.js",
-      "order": 403,
+      "order": 401,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMZhi",
         "TMZhiOpen",
@@ -10514,219 +10482,225 @@
         "openRenwuTuzhi"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "phase8-formal-rightrail.js"
-      ],
-      "mustLoadAfter": [
-        "phase8-formal-records.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "phase8-formal-rightrail.js",
-      "order": 404,
+      "order": 402,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "phase8-formal-rightrail-social.js"
-      ],
-      "mustLoadAfter": [
-        "tm-renwu-tuzhi.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "phase8-formal-rightrail-social.js",
-      "order": 405,
+      "order": 403,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "_tmLastPartyClassDebugCopy"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "preview/scenario-editor-sandbox-bridge.js"
-      ],
-      "mustLoadAfter": [
-        "phase8-formal-rightrail.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "preview/scenario-editor-sandbox-bridge.js",
-      "order": 406,
+      "order": 404,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM_SCENARIO_QUICKTEST"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-pause-fab.js"
-      ],
-      "mustLoadAfter": [
-        "phase8-formal-rightrail-social.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-pause-fab.js",
-      "order": 407,
+      "order": 405,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "renderGameState"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-capacitor-boot.js"
-      ],
-      "mustLoadAfter": [
-        "preview/scenario-editor-sandbox-bridge.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-capacitor-boot.js",
-      "order": 408,
+      "order": 406,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-update-card.js"
-      ],
-      "mustLoadAfter": [
-        "tm-pause-fab.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
-    },
-    {
-      "script": "tm-update-card.js",
-      "order": 409,
-      "phase": "optional",
-      "provides": [
-        "TMUpdateCard"
-      ],
-      "consumes": [],
-      "mustLoadBefore": [
-        "tm-desktop-update.js"
-      ],
-      "mustLoadAfter": [
-        "tm-capacitor-boot.js"
-      ],
-      "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
-    },
-    {
-      "script": "tm-desktop-update.js",
-      "order": 410,
-      "phase": "optional",
-      "provides": [
-        "TMDesktopUpdate"
-      ],
-      "consumes": [],
-      "mustLoadBefore": [
-        "tm-online-update.js"
-      ],
-      "mustLoadAfter": [
-        "tm-update-card.js"
-      ],
-      "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
-    },
-    {
-      "script": "tm-online-update.js",
-      "order": 411,
-      "phase": "optional",
-      "provides": [
-        "TM_OnlineUpdate"
-      ],
-      "consumes": [],
-      "mustLoadBefore": [
-        "tm-touch-gestures.js"
-      ],
-      "mustLoadAfter": [
-        "tm-desktop-update.js"
-      ],
-      "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-touch-gestures.js",
-      "order": 412,
+      "order": 407,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-pinch-pan.js"
-      ],
-      "mustLoadAfter": [
-        "tm-online-update.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-pinch-pan.js",
-      "order": 413,
+      "order": 408,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TM",
         "attachPinchPan"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-hover-fulltext.js"
-      ],
-      "mustLoadAfter": [
-        "tm-touch-gestures.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-hover-fulltext.js",
-      "order": 414,
+      "order": 409,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "__tmFulltipInstalled",
         "tmFulltip"
       ],
       "consumes": [],
-      "mustLoadBefore": [
-        "tm-startup-contract.js"
-      ],
-      "mustLoadAfter": [
-        "tm-pinch-pan.js"
-      ],
+      "dependsOn": [],
+      "mustLoadBefore": [],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
     },
     {
       "script": "tm-startup-contract.js",
-      "order": 415,
+      "order": 410,
       "phase": "optional",
+      "loadPolicy": "eager-ordered",
+      "platform": "any",
+      "sideEffects": "legacy-unknown",
       "provides": [
         "TMStartupContract",
         "__tmStartupContract"
       ],
       "consumes": [],
+      "dependsOn": [],
       "mustLoadBefore": [],
-      "mustLoadAfter": [
-        "tm-hover-fulltext.js"
-      ],
+      "mustLoadAfter": [],
       "lazySafe": false,
-      "reason": "Round 20 dependency audit retained the current classic-script order; no startup side-effect-free lazy boundary was proven for this provider."
+      "reason": "Legacy eager script: document order remains observable, but adjacency is not represented as a dependency. Explicit split contracts remain owned by lint-split-contracts.js."
+    }
+  ],
+  "features": [
+    {
+      "feature": "browserTestHarness",
+      "scripts": [
+        "tm-test-harness.js"
+      ],
+      "loadPolicy": "query-only",
+      "platform": "any",
+      "sideEffects": "test-provider",
+      "dependsOn": [],
+      "provides": [
+        "TM.test"
+      ]
+    },
+    {
+      "feature": "desktopUpdate",
+      "scripts": [
+        "tm-update-card.js",
+        "tm-desktop-update.js"
+      ],
+      "loadPolicy": "on-demand",
+      "platform": "desktop",
+      "sideEffects": "explicit-lifecycle",
+      "dependsOn": [],
+      "provides": [
+        "TMUpdateCard",
+        "TMDesktopUpdate"
+      ]
+    },
+    {
+      "feature": "formalMapLabels",
+      "scripts": [
+        "tm-map-label-geo.js",
+        "tm-map-label-collide.js"
+      ],
+      "loadPolicy": "first-formal-map-render",
+      "platform": "any",
+      "sideEffects": "none",
+      "dependsOn": [],
+      "provides": [
+        "TMMapLabelGeo",
+        "TMMapLabelCollide"
+      ]
+    },
+    {
+      "feature": "onlineUpdate",
+      "scripts": [
+        "tm-online-update.js"
+      ],
+      "loadPolicy": "idle-after-load",
+      "platform": "web",
+      "sideEffects": "explicit-lifecycle",
+      "dependsOn": [],
+      "provides": [
+        "TM_OnlineUpdate"
+      ]
     }
   ]
 }

--- a/web/tm-content-manager.js
+++ b/web/tm-content-manager.js
@@ -1234,6 +1234,19 @@
     return Promise.all(tasks);
   }
 
+  async function ensureDesktopUpdateFeature() {
+    if (!desktop()) return { ok: false, code: 'not-applicable' };
+    if (!window.TM || !TM.Features || typeof TM.Features.ensure !== 'function') {
+      return { ok: false, code: 'feature-loader-unavailable' };
+    }
+    try {
+      return await TM.Features.ensure('desktopUpdate');
+    } catch (error) {
+      if (window.console && typeof window.console.warn === 'function') window.console.warn('[TMContentManager] 桌面更新 feature 加载失败', error);
+      return { ok: false, code: error && error.code || 'feature-load-failed' };
+    }
+  }
+
   async function openContentManager() {
     state.feedUrl = loadFeedUrl();
     state.hotFeedUrl = loadHotFeedUrl();
@@ -1258,6 +1271,7 @@
       try { if (Array.isArray(state.webInstalled) && state.webInstalled.length) checkWorkshopUpdates(true); } catch (eU) {} // 批C·静默检查更新(有已装包才跑·不弹窗·结果缀真源条/更新中心)
       return;
     }
+    await ensureDesktopUpdateFeature();
     try {
       var status = await window.tianming.contentStatus();
       if (status && status.success) {

--- a/web/tm-content-manager.js
+++ b/web/tm-content-manager.js
@@ -1240,6 +1240,12 @@
       return { ok: false, code: 'feature-loader-unavailable' };
     }
     try {
+      if (typeof TM.Features.ensureRecoverable === 'function') {
+        return await TM.Features.ensureRecoverable('desktopUpdate', {
+          retryLoadError: true,
+          retryInitError: true
+        });
+      }
       return await TM.Features.ensure('desktopUpdate');
     } catch (error) {
       if (window.console && typeof window.console.warn === 'function') window.console.warn('[TMContentManager] 桌面更新 feature 加载失败', error);

--- a/web/tm-desktop-update.js
+++ b/web/tm-desktop-update.js
@@ -38,6 +38,8 @@
   var _verbose = false;
   var _fetchTotalBytes = 0;       // 增量计划总字节·算百分比/速度用
   var _samples = [];              // 速度采样（滚动 2.5s 窗·与安卓卡同算法）
+  var _initialized = false;
+  var _subscriptionDisposers = [];
 
   function card() { return window.TMUpdateCard || null; }
   function nowMs() {
@@ -182,8 +184,8 @@
 
   // electron-updater 事件 → 卡片进度（仅本模块发起的安装包下载会话）
   function wireInstallerEvents() {
-    if (typeof window.tianming.onUpdateStatus !== 'function') return;
-    window.tianming.onUpdateStatus(function (st) {
+    if (typeof window.tianming.onUpdateStatus !== 'function') return null;
+    return window.tianming.onUpdateStatus(function (st) {
       if (!_installerActive || !st || !st.kind) return;
       var c = card();
       if (!c) return;
@@ -205,8 +207,8 @@
 
   // ── 主进程事件 → 卡片进度 ────────────────────────────────────────────────
   function wireStatusEvents() {
-    if (typeof window.tianming.onHotUpdateStatus !== 'function') return;
-    window.tianming.onHotUpdateStatus(function (st) {
+    if (typeof window.tianming.onHotUpdateStatus !== 'function') return null;
+    return window.tianming.onHotUpdateStatus(function (st) {
       if (!_sessionActive || !st || !st.kind) return;
       var c = card();
       if (!c) return;
@@ -330,23 +332,65 @@
     runCheck(verbose);
   }
 
-  function arm() {
+  function init() {
+    if (_initialized) return { ok: true, reused: true, subscriptions: _subscriptionDisposers.length };
     // wireXxx 保留：手动 TMDesktopUpdate.check(true) 发起的安装会话仍需进度回显。
-    wireStatusEvents();
-    wireInstallerEvents();
+    var installed = [];
+    try {
+      var hotDispose = wireStatusEvents();
+      if (typeof hotDispose === 'function') installed.push(hotDispose);
+      var installerDispose = wireInstallerEvents();
+      if (typeof installerDispose === 'function') installed.push(installerDispose);
+    } catch (error) {
+      installed.forEach(function (disposeSubscription) {
+        try { disposeSubscription(); }
+        catch (disposeError) { if (window.console && typeof window.console.warn === 'function') window.console.warn('[tm-desktop-update] init rollback disposer failed', disposeError); }
+      });
+      throw error;
+    }
+    _subscriptionDisposers = installed;
+    _initialized = true;
     // ★2026-07-01·桌面端不再自动检查/自动弹热更卡（owner：桌面热更改到「创意工坊 / 更新中心」手动做）。
     //   原「启动 8s 首查 + 6h 周期复查」会自动 offerUpdate/installerFlow 弹 TMUpdateCard·已整段移除。
     //   → 桌面开局零更新卡；新版仍靠邸报(有未读 changelog 自动弹+红点)提示玩家去创意工坊更新。
     //   checkWhenClear / CHECK_DELAY_MS / RECHECK_INTERVAL_MS / AVOID_* 现仅供手动路径与历史参考。
+    return { ok: true, reused: false, subscriptions: _subscriptionDisposers.length };
   }
-  if (document.readyState === 'complete') arm();
-  else window.addEventListener('load', arm);
+
+  function dispose() {
+    if (!_initialized) return { ok: true, disposed: false, subscriptions: 0 };
+    var errors = [];
+    _subscriptionDisposers.splice(0).forEach(function (disposeSubscription) {
+      try { disposeSubscription(); }
+      catch (error) {
+        errors.push(error && error.message ? error.message : String(error));
+        if (window.console && typeof window.console.warn === 'function') window.console.warn('[tm-desktop-update] subscription disposer failed', error);
+      }
+    });
+    _initialized = false;
+    _sessionActive = false;
+    _installerActive = false;
+    _busy = false;
+    return { ok: errors.length === 0, disposed: true, errors: errors };
+  }
 
   // 手动入口（联网中枢/控制台/调试用）
   window.TMDesktopUpdate = {
-    check: function (verbose) { return runCheck(verbose !== false); },
+    init: init,
+    dispose: dispose,
+    check: function (verbose) {
+      init();
+      return runCheck(verbose !== false);
+    },
     state: function () {
-      return { busy: _busy, sessionActive: _sessionActive, installerActive: _installerActive, offeredVersion: _offeredVersion };
+      return {
+        busy: _busy,
+        sessionActive: _sessionActive,
+        installerActive: _installerActive,
+        offeredVersion: _offeredVersion,
+        initialized: _initialized,
+        subscriptions: _subscriptionDisposers.length
+      };
     }
   };
 })();

--- a/web/tm-feature-loader.js
+++ b/web/tm-feature-loader.js
@@ -1,0 +1,336 @@
+// tm-feature-loader.js — explicit, lifecycle-aware classic-script feature boundaries.
+(function (root) {
+  'use strict';
+  if (!root || !root.document) return;
+
+  root.TM = root.TM || {};
+
+  var MANIFEST_SRC = 'feature-manifest.js?v=20260825-feature-loader-v2';
+  var DEFAULT_TIMEOUT_MS = 15000;
+  var definitions = Object.create(null);
+  var runtime = Object.create(null);
+  var scriptLoads = Object.create(null);
+  var manifestPromise = null;
+
+  function featureError(code, message, details) {
+    var error = new Error(message || code);
+    error.code = code;
+    error.details = details || {};
+    return error;
+  }
+
+  function report(error, phase, feature) {
+    var payload = {
+      code: error && error.code ? error.code : 'feature-error',
+      phase: phase || 'unknown',
+      feature: feature || '',
+      message: error && error.message ? error.message : String(error || 'unknown feature error')
+    };
+    try {
+      if (root.TM && root.TM.Diagnostics && typeof root.TM.Diagnostics.capture === 'function') {
+        root.TM.Diagnostics.capture('feature-loader', payload);
+      } else if (root.console && typeof root.console.warn === 'function') {
+        root.console.warn('[TM.Features]', payload);
+      }
+    } catch (diagnosticError) {
+      if (root.console && typeof root.console.warn === 'function') {
+        root.console.warn('[TM.Features] diagnostic failed', diagnosticError);
+      }
+    }
+  }
+
+  function normalizeScripts(value) {
+    if (!Array.isArray(value) || !value.length) throw featureError('invalid-feature-definition', 'feature scripts must be a non-empty array');
+    return value.map(function (entry) {
+      if (typeof entry !== 'string' || !entry.trim()) throw featureError('invalid-feature-script', 'feature script path must be a non-empty string');
+      return entry.trim();
+    });
+  }
+
+  function normalizeDefinition(name, input) {
+    if (!name || typeof name !== 'string') throw featureError('invalid-feature-name', 'feature name must be a non-empty string');
+    input = input || {};
+    return {
+      name: name,
+      scripts: normalizeScripts(input.scripts),
+      dependsOn: Array.isArray(input.dependsOn) ? input.dependsOn.slice() : [],
+      platform: input.platform || 'any',
+      provides: Array.isArray(input.provides) ? input.provides.slice() : [],
+      loadPolicy: input.loadPolicy || 'on-demand',
+      sideEffects: input.sideEffects || 'legacy-unknown',
+      init: typeof input.init === 'function' ? input.init : null,
+      dispose: typeof input.dispose === 'function' ? input.dispose : null,
+      timeoutMs: Number.isFinite(Number(input.timeoutMs)) && Number(input.timeoutMs) > 0
+        ? Number(input.timeoutMs) : DEFAULT_TIMEOUT_MS
+    };
+  }
+
+  function stateFor(name) {
+    if (!runtime[name]) {
+      runtime[name] = {
+        state: definitions[name] ? 'defined' : 'unknown',
+        promise: null,
+        initialized: false,
+        retryCount: 0,
+        lastError: null
+      };
+    }
+    return runtime[name];
+  }
+
+  function define(name, input) {
+    if (definitions[name]) throw featureError('duplicate-feature-definition', 'feature is already defined: ' + name, { feature: name });
+    definitions[name] = normalizeDefinition(name, input);
+    stateFor(name).state = 'defined';
+    return definitions[name];
+  }
+
+  function registerManifest(manifest) {
+    if (!manifest || manifest.version !== 1 || !manifest.features || typeof manifest.features !== 'object') {
+      throw featureError('invalid-feature-manifest', 'feature manifest version 1 is required');
+    }
+    Object.keys(manifest.features).forEach(function (name) {
+      define(name, manifest.features[name]);
+    });
+    return Object.keys(manifest.features).length;
+  }
+
+  function platformKind() {
+    try {
+      if (root.TM && root.TM.platform && root.TM.platform.kind) return String(root.TM.platform.kind);
+      if (root.tianming) return 'electron';
+      if (root.Capacitor && typeof root.Capacitor.isNativePlatform === 'function' && root.Capacitor.isNativePlatform()) return 'capacitor';
+    } catch (error) {
+      report(error, 'platform-detection');
+    }
+    return 'web';
+  }
+
+  function applicable(expected, actual) {
+    if (!expected || expected === 'any') return true;
+    if (Array.isArray(expected)) return expected.indexOf(actual) >= 0;
+    if (expected === 'desktop') return actual === 'electron';
+    if (expected === 'touch') return actual === 'capacitor';
+    return expected === actual;
+  }
+
+  function resolvePath(pathText) {
+    var parts = String(pathText || '').split('.');
+    var value = root;
+    for (var i = 0; i < parts.length; i++) {
+      if (!parts[i] || value == null || !Object.prototype.hasOwnProperty.call(value, parts[i])) return undefined;
+      value = value[parts[i]];
+    }
+    return value;
+  }
+
+  function verifyProvides(definition) {
+    var missing = definition.provides.filter(function (pathText) { return typeof resolvePath(pathText) === 'undefined'; });
+    if (missing.length) {
+      throw featureError('feature-provider-missing', 'feature did not provide required globals: ' + missing.join(', '), {
+        feature: definition.name,
+        missing: missing
+      });
+    }
+  }
+
+  function loadScript(src, timeoutMs) {
+    if (scriptLoads[src]) return scriptLoads[src];
+    scriptLoads[src] = new Promise(function (resolve, reject) {
+      var script = root.document.createElement('script');
+      var settled = false;
+      var timer = root.setTimeout(function () {
+        if (settled) return;
+        settled = true;
+        delete scriptLoads[src];
+        script.onload = null;
+        script.onerror = null;
+        reject(featureError('feature-script-timeout', 'feature script timed out: ' + src, { script: src, timeoutMs: timeoutMs }));
+      }, timeoutMs);
+      script.async = false;
+      script.src = src;
+      script.dataset.tmFeatureScript = 'true';
+      script.onload = function () {
+        if (settled) return;
+        settled = true;
+        root.clearTimeout(timer);
+        script.onload = null;
+        script.onerror = null;
+        resolve({ ok: true, script: src });
+      };
+      script.onerror = function () {
+        if (settled) return;
+        settled = true;
+        root.clearTimeout(timer);
+        delete scriptLoads[src];
+        script.onload = null;
+        script.onerror = null;
+        reject(featureError('feature-script-load-failed', 'feature script failed to load: ' + src, { script: src }));
+      };
+      (root.document.head || root.document.documentElement).appendChild(script);
+    });
+    return scriptLoads[src];
+  }
+
+  function ensureManifest() {
+    if (manifestPromise) return manifestPromise;
+    manifestPromise = loadScript(MANIFEST_SRC, DEFAULT_TIMEOUT_MS).then(function () {
+      if (!Object.keys(definitions).length) throw featureError('feature-manifest-empty', 'feature manifest registered no features');
+      return true;
+    }).catch(function (error) {
+      manifestPromise = null;
+      throw error;
+    });
+    return manifestPromise;
+  }
+
+  function ensureDefined(name) {
+    if (definitions[name]) return Promise.resolve(definitions[name]);
+    return ensureManifest().then(function () {
+      if (!definitions[name]) throw featureError('unknown-feature', 'unknown feature: ' + name, { feature: name });
+      return definitions[name];
+    });
+  }
+
+  function loadFeature(name) {
+    return ensureDefined(name).then(function (definition) {
+      var state = stateFor(name);
+      var actualPlatform = platformKind();
+      if (!applicable(definition.platform, actualPlatform)) {
+        state.state = 'not-applicable';
+        return { ok: false, code: 'not-applicable', feature: name, platform: actualPlatform };
+      }
+      return definition.dependsOn.reduce(function (chain, dependency) {
+        return chain.then(function () {
+          return ensure(dependency).then(function (result) {
+            if (result && result.ok === false && result.code === 'not-applicable') {
+              throw featureError('feature-dependency-not-applicable', 'feature dependency is not applicable: ' + dependency, {
+                feature: name,
+                dependency: dependency
+              });
+            }
+          });
+        });
+      }, Promise.resolve()).then(function () {
+        return definition.scripts.reduce(function (chain, src) {
+          return chain.then(function () { return loadScript(src, definition.timeoutMs); });
+        }, Promise.resolve());
+      }).then(function () {
+        verifyProvides(definition);
+        if (!state.initialized && definition.init) {
+          return Promise.resolve(definition.init()).then(function () { state.initialized = true; });
+        }
+        state.initialized = true;
+      }).then(function () {
+        state.state = 'ready';
+        state.lastError = null;
+        return { ok: true, feature: name, state: 'ready' };
+      });
+    });
+  }
+
+  function ensure(name) {
+    var state = stateFor(name);
+    if (state.state === 'ready') return Promise.resolve({ ok: true, feature: name, state: 'ready', reused: true });
+    if (state.promise) return state.promise;
+    if (state.state === 'failed') {
+      return Promise.reject(featureError('feature-retry-required', 'feature failed previously; call retry(): ' + name, {
+        feature: name,
+        retryCount: state.retryCount
+      }));
+    }
+    state.state = 'loading';
+    state.promise = loadFeature(name).catch(function (error) {
+      state.state = 'failed';
+      state.lastError = error;
+      report(error, 'ensure', name);
+      throw error;
+    }).finally(function () {
+      state.promise = null;
+    });
+    return state.promise;
+  }
+
+  function retry(name) {
+    var state = stateFor(name);
+    if (state.state !== 'failed') return ensure(name);
+    if (state.retryCount >= 1) {
+      return Promise.reject(featureError('feature-retry-limit', 'feature retry limit reached: ' + name, { feature: name }));
+    }
+    state.retryCount += 1;
+    state.state = 'defined';
+    state.lastError = null;
+    return ensure(name);
+  }
+
+  function preload(name) {
+    return ensure(name);
+  }
+
+  function dispose(name) {
+    return ensureDefined(name).then(function (definition) {
+      var state = stateFor(name);
+      if (!state.initialized) {
+        state.state = state.state === 'unknown' ? 'defined' : state.state;
+        return { ok: true, feature: name, disposed: false };
+      }
+      return Promise.resolve(definition.dispose ? definition.dispose() : undefined).then(function () {
+        state.initialized = false;
+        state.state = 'disposed';
+        return { ok: true, feature: name, disposed: true };
+      });
+    });
+  }
+
+  function status(name) {
+    if (name) {
+      var one = stateFor(name);
+      return {
+        feature: name,
+        state: one.state,
+        initialized: one.initialized,
+        retryCount: one.retryCount,
+        errorCode: one.lastError && one.lastError.code || ''
+      };
+    }
+    return Object.keys(runtime).sort().map(function (key) { return status(key); });
+  }
+
+  function afterWindowLoad(callback) {
+    if (root.document.readyState === 'complete') root.setTimeout(callback, 0);
+    else root.addEventListener('load', callback, { once: true });
+  }
+
+  function bootOptionalFeatures() {
+    afterWindowLoad(function () {
+      var search = '';
+      try { search = String(root.location && root.location.search || ''); } catch (error) { report(error, 'query-detection'); }
+      if (/[?&](?:test|devHarness)=1(?:&|$)/.test(search)) {
+        ensure('browserTestHarness').catch(function (error) { report(error, 'browser-test-harness', 'browserTestHarness'); });
+      }
+      if (platformKind() === 'web') {
+        var idle = typeof root.requestIdleCallback === 'function'
+          ? root.requestIdleCallback
+          : function (fn) { return root.setTimeout(fn, 1200); };
+        idle(function () {
+          ensure('onlineUpdate').catch(function (error) { report(error, 'online-update', 'onlineUpdate'); });
+        });
+      }
+    });
+  }
+
+  root.TM.Features = {
+    define: define,
+    registerManifest: registerManifest,
+    ensure: ensure,
+    preload: preload,
+    dispose: dispose,
+    status: status,
+    retry: retry,
+    platformKind: platformKind,
+    _loadScript: loadScript,
+    _manifestSource: MANIFEST_SRC
+  };
+
+  bootOptionalFeatures();
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/web/tm-feature-loader.js
+++ b/web/tm-feature-loader.js
@@ -11,6 +11,7 @@
   var runtime = Object.create(null);
   var scriptLoads = Object.create(null);
   var manifestPromise = null;
+  var scriptAttemptId = 0;
 
   function featureError(code, message, details) {
     var error = new Error(message || code);
@@ -72,15 +73,67 @@
         promise: null,
         initialized: false,
         retryCount: 0,
-        lastError: null
+        lastError: null,
+        generation: 0,
+        disposeRequested: false
       };
     }
     return runtime[name];
   }
 
+  function dependencyCycle(graph) {
+    var visiting = Object.create(null);
+    var visited = Object.create(null);
+
+    function walk(name, trail) {
+      if (visiting[name]) {
+        var start = trail.indexOf(name);
+        return trail.slice(start >= 0 ? start : 0).concat(name);
+      }
+      if (visited[name] || !graph[name]) return null;
+      visiting[name] = true;
+      var nextTrail = trail.concat(name);
+      var dependencies = Array.isArray(graph[name].dependsOn) ? graph[name].dependsOn : [];
+      for (var i = 0; i < dependencies.length; i++) {
+        if (!graph[dependencies[i]]) continue;
+        var cycle = walk(dependencies[i], nextTrail);
+        if (cycle) return cycle;
+      }
+      visiting[name] = false;
+      visited[name] = true;
+      return null;
+    }
+
+    var names = Object.keys(graph);
+    for (var i = 0; i < names.length; i++) {
+      var cycle = walk(names[i], []);
+      if (cycle) return cycle;
+    }
+    return null;
+  }
+
+  function assertNoDependencyCycle(graph) {
+    var cycle = dependencyCycle(graph);
+    if (cycle) {
+      throw featureError('feature-dependency-cycle', 'feature dependency cycle: ' + cycle.join(' -> '), {
+        cycle: cycle
+      });
+    }
+  }
+
+  function graphWith(pending) {
+    var graph = Object.create(null);
+    Object.keys(definitions).forEach(function (name) { graph[name] = definitions[name]; });
+    Object.keys(pending || {}).forEach(function (name) { graph[name] = pending[name]; });
+    return graph;
+  }
+
   function define(name, input) {
     if (definitions[name]) throw featureError('duplicate-feature-definition', 'feature is already defined: ' + name, { feature: name });
-    definitions[name] = normalizeDefinition(name, input);
+    var pending = Object.create(null);
+    pending[name] = normalizeDefinition(name, input);
+    assertNoDependencyCycle(graphWith(pending));
+    definitions[name] = pending[name];
     stateFor(name).state = 'defined';
     return definitions[name];
   }
@@ -89,10 +142,18 @@
     if (!manifest || manifest.version !== 1 || !manifest.features || typeof manifest.features !== 'object') {
       throw featureError('invalid-feature-manifest', 'feature manifest version 1 is required');
     }
-    Object.keys(manifest.features).forEach(function (name) {
-      define(name, manifest.features[name]);
+    var names = Object.keys(manifest.features);
+    var pending = Object.create(null);
+    names.forEach(function (name) {
+      if (definitions[name]) throw featureError('duplicate-feature-definition', 'feature is already defined: ' + name, { feature: name });
+      pending[name] = normalizeDefinition(name, manifest.features[name]);
     });
-    return Object.keys(manifest.features).length;
+    assertNoDependencyCycle(graphWith(pending));
+    names.forEach(function (name) {
+      definitions[name] = pending[name];
+      stateFor(name).state = 'defined';
+    });
+    return names.length;
   }
 
   function platformKind() {
@@ -134,42 +195,122 @@
     }
   }
 
+  function scriptRequiresReload(record) {
+    return !!record && (record.state === 'timed-out' || record.state === 'loaded-late' || record.state === 'failed-after-timeout');
+  }
+
+  function removeScriptNode(node) {
+    if (!node) return;
+    try {
+      if (typeof node.remove === 'function') node.remove();
+      else if (node.parentNode && typeof node.parentNode.removeChild === 'function') node.parentNode.removeChild(node);
+    } catch (error) {
+      report(error, 'script-remove');
+    }
+  }
+
+  function reloadRequiredError(src, record) {
+    return featureError('feature-reload-required', 'feature script timed out; reload the page before trying again: ' + src, {
+      script: src,
+      scriptState: record && record.state || 'timed-out',
+      attemptId: record && record.attemptId || 0
+    });
+  }
+
   function loadScript(src, timeoutMs) {
-    if (scriptLoads[src]) return scriptLoads[src];
-    scriptLoads[src] = new Promise(function (resolve, reject) {
+    var existing = scriptLoads[src];
+    if (existing) {
+      if (scriptRequiresReload(existing)) return Promise.reject(reloadRequiredError(src, existing));
+      return existing.promise;
+    }
+
+    var record = {
+      state: 'loading',
+      node: null,
+      promise: null,
+      attemptId: ++scriptAttemptId,
+      error: null
+    };
+    scriptLoads[src] = record;
+    record.promise = new Promise(function (resolve, reject) {
       var script = root.document.createElement('script');
+      record.node = script;
       var settled = false;
       var timer = root.setTimeout(function () {
         if (settled) return;
         settled = true;
-        delete scriptLoads[src];
-        script.onload = null;
-        script.onerror = null;
-        reject(featureError('feature-script-timeout', 'feature script timed out: ' + src, { script: src, timeoutMs: timeoutMs }));
+        var timeoutError = featureError('feature-script-timeout', 'feature script timed out: ' + src, {
+          script: src,
+          timeoutMs: timeoutMs,
+          attemptId: record.attemptId
+        });
+        record.state = 'timed-out';
+        record.error = timeoutError;
+        removeScriptNode(script);
+        reject(timeoutError);
       }, timeoutMs);
       script.async = false;
       script.src = src;
       script.dataset.tmFeatureScript = 'true';
       script.onload = function () {
-        if (settled) return;
+        if (settled) {
+          if (record.state === 'timed-out') {
+            record.state = 'loaded-late';
+            report(featureError('feature-script-loaded-late', 'timed-out feature script executed after its deadline: ' + src, {
+              script: src,
+              attemptId: record.attemptId
+            }), 'script-loaded-late');
+          }
+          script.onload = null;
+          script.onerror = null;
+          return;
+        }
         settled = true;
+        record.state = 'loaded';
         root.clearTimeout(timer);
         script.onload = null;
         script.onerror = null;
-        resolve({ ok: true, script: src });
+        resolve({ ok: true, script: src, attemptId: record.attemptId });
       };
       script.onerror = function () {
+        if (settled) {
+          if (record.state === 'timed-out') record.state = 'failed-after-timeout';
+          script.onload = null;
+          script.onerror = null;
+          return;
+        }
+        settled = true;
+        root.clearTimeout(timer);
+        var loadError = featureError('feature-script-load-failed', 'feature script failed to load: ' + src, {
+          script: src,
+          attemptId: record.attemptId
+        });
+        record.state = 'failed';
+        record.error = loadError;
+        delete scriptLoads[src];
+        script.onload = null;
+        script.onerror = null;
+        reject(loadError);
+      };
+      try {
+        (root.document.head || root.document.documentElement).appendChild(script);
+      } catch (error) {
         if (settled) return;
         settled = true;
         root.clearTimeout(timer);
         delete scriptLoads[src];
+        record.state = 'failed';
+        record.error = error;
         script.onload = null;
         script.onerror = null;
-        reject(featureError('feature-script-load-failed', 'feature script failed to load: ' + src, { script: src }));
-      };
-      (root.document.head || root.document.documentElement).appendChild(script);
+        reject(featureError('feature-script-load-failed', 'feature script could not be inserted: ' + src, {
+          script: src,
+          attemptId: record.attemptId,
+          cause: error && error.message || String(error)
+        }));
+      }
     });
-    return scriptLoads[src];
+    return record.promise;
   }
 
   function ensureManifest() {
@@ -192,8 +333,75 @@
     });
   }
 
-  function loadFeature(name) {
+  function initFailure(error, definition) {
+    return featureError('feature-init-failed', 'feature init failed: ' + definition.name, {
+      feature: definition.name,
+      causeCode: error && error.code || '',
+      cause: error && error.message || String(error)
+    });
+  }
+
+  function initializeFeature(definition, state, generation) {
+    if (state.disposeRequested || generation !== state.generation) {
+      state.initialized = false;
+      state.state = 'disposed';
+      return Promise.resolve({ skippedInit: true });
+    }
+    if (!definition.init) {
+      state.initialized = true;
+      return Promise.resolve({ initialized: true });
+    }
+    return Promise.resolve().then(function () {
+      return definition.init();
+    }).then(function () {
+      state.initialized = true;
+      return { initialized: true };
+    }).catch(function (error) {
+      return Promise.resolve().then(function () {
+        return definition.dispose ? definition.dispose() : undefined;
+      }).then(function () {
+        state.initialized = false;
+        throw initFailure(error, definition);
+      }, function (rollbackError) {
+        state.initialized = false;
+        throw featureError('feature-init-rollback-failed', 'feature init rollback failed: ' + definition.name, {
+          feature: definition.name,
+          initError: error && error.message || String(error),
+          rollbackError: rollbackError && rollbackError.message || String(rollbackError)
+        });
+      });
+    });
+  }
+
+  function runDisposer(definition, state) {
+    if (!state.initialized) {
+      state.disposeRequested = false;
+      state.state = 'disposed';
+      return Promise.resolve({ ok: true, feature: definition.name, state: 'disposed', disposed: false });
+    }
+    return Promise.resolve().then(function () {
+      return definition.dispose ? definition.dispose() : undefined;
+    }).then(function () {
+      state.initialized = false;
+      state.disposeRequested = false;
+      state.state = 'disposed';
+      state.lastError = null;
+      return { ok: true, feature: definition.name, state: 'disposed', disposed: true };
+    }).catch(function (error) {
+      var disposeError = featureError('feature-dispose-failed', 'feature dispose failed: ' + definition.name, {
+        feature: definition.name,
+        cause: error && error.message || String(error)
+      });
+      state.disposeRequested = false;
+      state.state = 'failed';
+      state.lastError = disposeError;
+      throw disposeError;
+    });
+  }
+
+  function loadFeature(name, generation, trail) {
     return ensureDefined(name).then(function (definition) {
+      assertNoDependencyCycle(definitions);
       var state = stateFor(name);
       var actualPlatform = platformKind();
       if (!applicable(definition.platform, actualPlatform)) {
@@ -202,7 +410,7 @@
       }
       return definition.dependsOn.reduce(function (chain, dependency) {
         return chain.then(function () {
-          return ensure(dependency).then(function (result) {
+          return ensureInternal(dependency, trail).then(function (result) {
             if (result && result.ok === false && result.code === 'not-applicable') {
               throw featureError('feature-dependency-not-applicable', 'feature dependency is not applicable: ' + dependency, {
                 feature: name,
@@ -217,11 +425,16 @@
         }, Promise.resolve());
       }).then(function () {
         verifyProvides(definition);
-        if (!state.initialized && definition.init) {
-          return Promise.resolve(definition.init()).then(function () { state.initialized = true; });
+        return initializeFeature(definition, state, generation);
+      }).then(function (initResult) {
+        if (initResult && initResult.skippedInit) {
+          state.disposeRequested = false;
+          state.state = 'disposed';
+          return { ok: true, feature: name, state: 'disposed', skippedInit: true };
         }
-        state.initialized = true;
-      }).then(function () {
+        if (state.disposeRequested || generation !== state.generation) {
+          return runDisposer(definition, state);
+        }
         state.state = 'ready';
         state.lastError = null;
         return { ok: true, feature: name, state: 'ready' };
@@ -229,18 +442,29 @@
     });
   }
 
-  function ensure(name) {
+  function ensureInternal(name, trail) {
+    trail = Array.isArray(trail) ? trail : [];
+    if (trail.indexOf(name) >= 0) {
+      var cycle = trail.slice(trail.indexOf(name)).concat(name);
+      return Promise.reject(featureError('feature-dependency-cycle', 'feature dependency cycle: ' + cycle.join(' -> '), {
+        cycle: cycle
+      }));
+    }
     var state = stateFor(name);
     if (state.state === 'ready') return Promise.resolve({ ok: true, feature: name, state: 'ready', reused: true });
     if (state.promise) return state.promise;
     if (state.state === 'failed') {
       return Promise.reject(featureError('feature-retry-required', 'feature failed previously; call retry(): ' + name, {
         feature: name,
-        retryCount: state.retryCount
+        retryCount: state.retryCount,
+        lastErrorCode: state.lastError && state.lastError.code || ''
       }));
     }
+    state.disposeRequested = false;
+    state.generation += 1;
+    var generation = state.generation;
     state.state = 'loading';
-    state.promise = loadFeature(name).catch(function (error) {
+    state.promise = loadFeature(name, generation, trail.concat(name)).catch(function (error) {
       state.state = 'failed';
       state.lastError = error;
       report(error, 'ensure', name);
@@ -251,16 +475,55 @@
     return state.promise;
   }
 
+  function ensure(name) {
+    return ensureInternal(name, []);
+  }
+
+  function isRetryableFailure(error, options) {
+    var code = error && error.code || '';
+    if (code === 'feature-script-load-failed') return options.retryLoadError !== false;
+    if (code === 'feature-init-failed') return options.retryInitError !== false;
+    return false;
+  }
+
   function retry(name) {
-    var state = stateFor(name);
-    if (state.state !== 'failed') return ensure(name);
-    if (state.retryCount >= 1) {
-      return Promise.reject(featureError('feature-retry-limit', 'feature retry limit reached: ' + name, { feature: name }));
-    }
-    state.retryCount += 1;
-    state.state = 'defined';
-    state.lastError = null;
-    return ensure(name);
+    return ensureDefined(name).then(function (definition) {
+      var state = stateFor(name);
+      if (state.state !== 'failed') return ensure(name);
+      var prior = state.lastError;
+      var timedOut = definition.scripts.some(function (src) { return scriptRequiresReload(scriptLoads[src]); });
+      if (timedOut || prior && (prior.code === 'feature-script-timeout' || prior.code === 'feature-reload-required')) {
+        return Promise.reject(reloadRequiredError((prior && prior.details && prior.details.script) || definition.scripts[0],
+          scriptLoads[(prior && prior.details && prior.details.script) || definition.scripts[0]]));
+      }
+      if (!isRetryableFailure(prior, {})) {
+        return Promise.reject(featureError('feature-retry-not-allowed', 'feature failure is not safely retryable: ' + name, {
+          feature: name,
+          lastErrorCode: prior && prior.code || ''
+        }));
+      }
+      if (state.retryCount >= 1) {
+        return Promise.reject(featureError('feature-retry-limit', 'feature retry limit reached: ' + name, { feature: name }));
+      }
+      state.retryCount += 1;
+      state.state = 'defined';
+      state.lastError = null;
+      return ensure(name);
+    });
+  }
+
+  function ensureRecoverable(name, options) {
+    options = options || {};
+    return ensure(name).catch(function (error) {
+      var state = stateFor(name);
+      var prior = error && error.code === 'feature-retry-required' ? state.lastError : error;
+      if (prior && (prior.code === 'feature-script-timeout' || prior.code === 'feature-reload-required')) {
+        throw reloadRequiredError((prior.details && prior.details.script) || name,
+          scriptLoads[prior.details && prior.details.script]);
+      }
+      if (!isRetryableFailure(prior, options)) throw error;
+      return retry(name);
+    });
   }
 
   function preload(name) {
@@ -270,15 +533,23 @@
   function dispose(name) {
     return ensureDefined(name).then(function (definition) {
       var state = stateFor(name);
-      if (!state.initialized) {
-        state.state = state.state === 'unknown' ? 'defined' : state.state;
-        return { ok: true, feature: name, disposed: false };
+      state.disposeRequested = true;
+      if (state.promise) {
+        var active = state.promise;
+        return active.then(function () {
+          if (!state.initialized) {
+            state.disposeRequested = false;
+            state.state = 'disposed';
+            return { ok: true, feature: name, state: 'disposed', disposed: true, skippedInit: true };
+          }
+          return runDisposer(definition, state);
+        }, function (error) {
+          state.disposeRequested = false;
+          if (error && error.code === 'feature-dispose-failed') throw error;
+          return { ok: true, feature: name, state: state.state, disposed: false, loadFailed: true };
+        });
       }
-      return Promise.resolve(definition.dispose ? definition.dispose() : undefined).then(function () {
-        state.initialized = false;
-        state.state = 'disposed';
-        return { ok: true, feature: name, disposed: true };
-      });
+      return runDisposer(definition, state);
     });
   }
 
@@ -290,6 +561,7 @@
         state: one.state,
         initialized: one.initialized,
         retryCount: one.retryCount,
+        disposeRequested: one.disposeRequested,
         errorCode: one.lastError && one.lastError.code || ''
       };
     }
@@ -306,14 +578,14 @@
       var search = '';
       try { search = String(root.location && root.location.search || ''); } catch (error) { report(error, 'query-detection'); }
       if (/[?&](?:test|devHarness)=1(?:&|$)/.test(search)) {
-        ensure('browserTestHarness').catch(function (error) { report(error, 'browser-test-harness', 'browserTestHarness'); });
+        ensureRecoverable('browserTestHarness').catch(function (error) { report(error, 'browser-test-harness', 'browserTestHarness'); });
       }
       if (platformKind() === 'web') {
         var idle = typeof root.requestIdleCallback === 'function'
           ? root.requestIdleCallback
           : function (fn) { return root.setTimeout(fn, 1200); };
         idle(function () {
-          ensure('onlineUpdate').catch(function (error) { report(error, 'online-update', 'onlineUpdate'); });
+          ensureRecoverable('onlineUpdate').catch(function (error) { report(error, 'online-update', 'onlineUpdate'); });
         });
       }
     });
@@ -323,6 +595,7 @@
     define: define,
     registerManifest: registerManifest,
     ensure: ensure,
+    ensureRecoverable: ensureRecoverable,
     preload: preload,
     dispose: dispose,
     status: status,

--- a/web/tm-online-update.js
+++ b/web/tm-online-update.js
@@ -1,9 +1,8 @@
 // ============================================================
-//  tm-online-update.js — 在线版更新提示 + 三端 footer 版本号同步
+//  tm-online-update.js — 在线版更新提示（由 TM.Features 显式管理生命周期）
 //  2026-06-11·更新功能全面升级 S6
 //
-//  ① footer 版本号（#tm-foot-ver）三端统一从 <meta name="tm-version"> 读·
-//     meta 与代码同包同发·天然就是「正在运行的版本」·从此告别手改 footer。
+//  ① footer 版本号同步已迁入 tm-startup-contract.js，避免三端为一行文本加载本模块。
 //  ② 仅在线版（github.io·非桌面非安卓）跑检查循环：同源拉 version.json?t=时间戳
 //     （query 进缓存键·穿透浏览器缓存与 Pages 边缘缓存）·远端版本更高 → 弹横幅
 //     「线上新版已颁·刷新页面即可启用」·绝不自动刷新（玩家可能在局中）。
@@ -34,6 +33,10 @@
 
     var _lastCheckAt = 0;
     var _state = { localVersion: '', remoteVersion: '', shown: false, lastResult: '' };
+    var _initialized = false;
+    var _firstCheckTimer = null;
+    var _recheckInterval = null;
+    var _visibilityHandler = null;
 
     function compareVersions(a, b) {
       var aa = String(a || '0').split(/[.+-]/).map(function (n) { var v = parseInt(n, 10); return isFinite(v) ? v : 0; });
@@ -59,16 +62,6 @@
         if (m) return m[0];
       } catch (_) {}
       return '';
-    }
-
-    // ── footer 版本号同步（三端都跑·meta = 正在运行的包版本） ────────────────
-    function syncFooter() {
-      try {
-        var v = getLocalVersion();
-        if (!v) return;
-        var span = document.getElementById('tm-foot-ver');
-        if (span && span.textContent !== v) span.textContent = v;
-      } catch (_) {}
     }
 
     // ── 横幅 ─────────────────────────────────────────────────────────────────
@@ -195,31 +188,65 @@
         });
     }
 
-    function arm() {
-      syncFooter();
-      if (!isWeb) return; // 桌面/安卓只同步 footer·各有自己的更新通道
+    function init() {
+      if (_initialized) return { ok: true, reused: true, isWeb: isWeb };
+      _initialized = true;
+      if (!isWeb) return { ok: false, code: 'not-applicable', isWeb: false };
       var testMode = false;
       try { testMode = /[?&]tmOluTest=1/.test(String(window.location.search || '')); } catch (_) {}
-      setTimeout(function () { check(false); }, testMode ? 500 : FIRST_CHECK_MS);
-      setInterval(function () {
+      _firstCheckTimer = setTimeout(function () {
+        _firstCheckTimer = null;
+        check(false);
+      }, testMode ? 500 : FIRST_CHECK_MS);
+      _recheckInterval = setInterval(function () {
         try { if (!document.hidden && !_state.shown) check(false); } catch (_) {}
       }, RECHECK_MS);
-      try {
-        document.addEventListener('visibilitychange', function () {
-          try {
-            if (document.hidden || _state.shown) return;
-            if (Date.now() - _lastCheckAt >= VISIBLE_RECHECK_MIN_GAP_MS) check(false);
-          } catch (_) {}
-        });
-      } catch (_) {}
+      _visibilityHandler = function () {
+        try {
+          if (document.hidden || _state.shown) return;
+          if (Date.now() - _lastCheckAt >= VISIBLE_RECHECK_MIN_GAP_MS) check(false);
+        } catch (_) {}
+      };
+      document.addEventListener('visibilitychange', _visibilityHandler);
+      return { ok: true, reused: false, isWeb: true };
     }
 
-    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', arm);
-    else arm();
+    function dispose() {
+      if (!_initialized) return { ok: true, disposed: false };
+      if (_firstCheckTimer != null) {
+        clearTimeout(_firstCheckTimer);
+        _firstCheckTimer = null;
+      }
+      if (_recheckInterval != null) {
+        clearInterval(_recheckInterval);
+        _recheckInterval = null;
+      }
+      if (_visibilityHandler) {
+        document.removeEventListener('visibilitychange', _visibilityHandler);
+        _visibilityHandler = null;
+      }
+      removeBanner();
+      _initialized = false;
+      return { ok: true, disposed: true };
+    }
 
     window.TM_OnlineUpdate = {
+      init: init,
+      dispose: dispose,
       check: function (force) { return check(force !== false); },
-      getState: function () { return { localVersion: getLocalVersion(), remoteVersion: _state.remoteVersion, shown: _state.shown, lastResult: _state.lastResult, isWeb: isWeb }; },
+      getState: function () {
+        return {
+          localVersion: getLocalVersion(),
+          remoteVersion: _state.remoteVersion,
+          shown: _state.shown,
+          lastResult: _state.lastResult,
+          isWeb: isWeb,
+          initialized: _initialized,
+          firstCheckScheduled: _firstCheckTimer != null,
+          recheckScheduled: _recheckInterval != null,
+          visibilityBound: !!_visibilityHandler
+        };
+      },
       dismiss: dismiss,
       refresh: doRefresh
     };

--- a/web/tm-startup-contract.js
+++ b/web/tm-startup-contract.js
@@ -19,6 +19,18 @@
     ['TimeUtils', function (world) { return !!world.TimeUtils; }]
   ];
 
+  function syncFooterVersion(doc) {
+    doc = doc || (root && root.document);
+    if (!doc || typeof doc.querySelector !== 'function') return '';
+    var meta = doc.querySelector('meta[name="tm-version"]');
+    var version = meta && typeof meta.getAttribute === 'function'
+      ? String(meta.getAttribute('content') || '').trim() : '';
+    if (!/^\d+(?:\.\d+){1,3}$/.test(version)) return '';
+    var footer = typeof doc.getElementById === 'function' ? doc.getElementById('tm-foot-ver') : null;
+    if (footer && footer.textContent !== version) footer.textContent = version;
+    return version;
+  }
+
   function validate(world) {
     world = world || root;
     var missing = REQUIRED.filter(function (entry) {
@@ -44,8 +56,14 @@
     return true;
   }
 
-  var api = { validate: validate, renderFailure: renderFailure, required: REQUIRED.map(function (entry) { return entry[0]; }) };
+  var api = {
+    validate: validate,
+    renderFailure: renderFailure,
+    syncFooterVersion: syncFooterVersion,
+    required: REQUIRED.map(function (entry) { return entry[0]; })
+  };
   root.TMStartupContract = api;
+  syncFooterVersion();
   var result = validate(root);
   root.__tmStartupContract = result;
   if (!result.ok) {


### PR DESCRIPTION
Feature Loader V2 stacked on PR #59. Removes six optional scripts from eager startup, adds a manifest-driven single-flight classic-script loader with lifecycle disposal and platform routing, upgrades startup observability to V2, and makes formal map labels late-bind safely. Validation: lint-arch-all PASS (12/12); ci-smokes PASS (892 discovered, 2 established missing-asset waivers); release-contract PASS (166); official scenario parity PASS (27); hot builder gates PASS (27); npm audit 0 vulnerabilities; canonical hot baseline PASS (1091 files with asset overlay). No release, installer, deployment, or main mutation performed.