### PR TITLE
fix: harden editor write failures and bookmark lifecycles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,8 @@
 
 ```bash
 git clone <本仓>
+cd tianming
+npm ci --ignore-scripts                  # 安装锁定依赖；AST 架构守卫需要 devDependency acorn
 git config core.hooksPath hooks        # 安装 pre-push 守卫（~12s 的 8 项架构 lint）
 ```
 

--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-25T10:48:28.203Z",
+  "generatedAt": "2026-08-25T20:10:12.571Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -2036,13 +2036,13 @@
     },
     {
       "path": "editor-authoring-agent-ui.js",
-      "sha256": "18c9e5f52b037ef44c898b8716feca5065834b1e41916c9db966cfb81cf48ec0",
-      "size": 200836
+      "sha256": "289ba1798611103a6c0bcd7640686c2e6386857973d5b1bbe3088275a211ebac",
+      "size": 204308
     },
     {
       "path": "editor-authoring-agent.js",
-      "sha256": "570dbb8c9ae7ddd8617adcd3dea22f3b268b71894965051b1b98a42849c067a9",
-      "size": 276669
+      "sha256": "8a9e2f2825191a4fd44ac9eed5cae13c26824783cb74022959e90d15bc4dc42c",
+      "size": 277776
     },
     {
       "path": "editor-core.js",
@@ -2221,8 +2221,8 @@
     },
     {
       "path": "map-editor-bookmarks.js",
-      "sha256": "8be6daec643941e9f7735763b891a9876356fea0bc0c0d103ac7a2419cbfe1e1",
-      "size": 8187
+      "sha256": "c97d4147dc42297e32e4af56ea7148619c21736f6f05d01883be338b56ba3712",
+      "size": 9760
     },
     {
       "path": "map-editor-borders.js",
@@ -2266,8 +2266,8 @@
     },
     {
       "path": "map-editor-core.js",
-      "sha256": "660e2b68007329021a007b414f66d4e980545e5b46117110caa4bcf2ae47c2ad",
-      "size": 60882
+      "sha256": "90940ee59ac7ca5b10d0b495cd61d9189bf502964c8389e83ca2b8a87dab5098",
+      "size": 61506
     },
     {
       "path": "map-editor-cross-time.js",

--- a/web/editor-authoring-agent-ui.js
+++ b/web/editor-authoring-agent-ui.js
@@ -1142,6 +1142,44 @@
 
   function setStatus(t) { if (ui.els) ui.els.status.textContent = t || ''; }
 
+  // 用户主动写操作必须先确认底层持久化成功，再更新按钮或显示成功。
+  function _reportUserWriteFailure(error, operation, target) {
+    var err = error && typeof error === 'object' ? error : new Error(String(error || '未知错误'));
+    var reported = false;
+    try {
+      if (global.TM && global.TM.errors && typeof global.TM.errors.capture === 'function') {
+        global.TM.errors.capture(err, 'authoring-agent.user-write', { operation: operation || 'unknown', target: target || '' });
+        reported = true;
+      }
+    } catch (captureError) {
+      if (global.console && typeof global.console.error === 'function') global.console.error('[authoring-agent] 写失败诊断记录异常', captureError);
+    }
+    if (!reported && global.console && typeof global.console.error === 'function') {
+      global.console.error('[authoring-agent] 用户写操作失败', operation || 'unknown', target || '', err);
+    }
+    return err;
+  }
+  function _commitUserWrite(opts) {
+    opts = opts || {};
+    var result;
+    try {
+      if (typeof opts.run !== 'function') throw new Error('缺少写操作处理器');
+      result = opts.run();
+      if (!(result === true || (result && result.ok === true))) {
+        var rejected = new Error(String((result && (result.error || result.reason || result.code)) || '操作未完成'));
+        rejected.code = (result && result.code) || 'authoring-user-write-failed';
+        throw rejected;
+      }
+    } catch (error) {
+      var err = _reportUserWriteFailure(error, opts.operation, opts.target);
+      setStatus((opts.failureLabel || '操作') + '失败：' + String((err && err.message) || err));
+      return false;
+    }
+    if (typeof opts.onSuccess === 'function') opts.onSuccess(result);
+    if (opts.successMessage) setStatus(typeof opts.successMessage === 'function' ? opts.successMessage(result) : opts.successMessage);
+    return true;
+  }
+
   // 方向I · 可观测性：运行中实时 token / 耗时 / 轮次计量条。
   function _fmtTok(n) { n = n || 0; return n >= 1000 ? (Math.round(n / 100) / 10) + 'k' : String(n); }
   function _renderMeter(done) {
@@ -1482,7 +1520,12 @@
     var cur = _loadScenConv(), lines = cur ? cur.split('\n') : [];
     if (lines.indexOf(conv) >= 0) return true;
     lines.push(conv);
-    return _saveScenConv(lines.join('\n'));
+    return _commitUserWrite({
+      operation: 'convention-save',
+      target: _fileKey(),
+      failureLabel: '记住本剧本约定',
+      run: function () { return _saveScenConv(lines.join('\n')); }
+    });
   }
   // S11 · 审阅报告尾追加「发现的约定」记住签（复用本剧本层落点）
   function _renderConvSuggest(sug) {
@@ -1553,7 +1596,16 @@
         + (s ? '<button type="button" class="tm-aa-conv-clear">清空本剧本约定</button>' : '') + '</div>';
       ui.els.summary.style.display = '';
       var cb = ui.els.summary.querySelector('.tm-aa-conv-clear');
-      if (cb) cb.addEventListener('click', function () { _saveScenConv(''); cb.textContent = '已清空 ✓'; cb.disabled = true; setStatus('本剧本约定已清空'); });
+      if (cb) cb.addEventListener('click', function () {
+        _commitUserWrite({
+          operation: 'convention-clear',
+          target: _fileKey(),
+          failureLabel: '清空本剧本约定',
+          run: function () { return _saveScenConv(''); },
+          onSuccess: function () { cb.textContent = '已清空 ✓'; cb.disabled = true; },
+          successMessage: '本剧本约定已清空'
+        });
+      });
     }
     _freezeLastReply();
     setStatus('约定两层：全局' + (g ? ' ' + g.split('\n').filter(Boolean).length + ' 条' : '空') + ' · 本剧本' + (s ? ' ' + s.split('\n').filter(Boolean).length + ' 条' : '空'));
@@ -1583,7 +1635,15 @@
       : '<div style="color:var(--tx3)">（空 · 国师在共事中了解到推导不出的背景时会自动存；也可让它「把XX记住」）</div>';
     var host = _mgmtCard('记忆册（跨会话背景 · 按需求召回注入 · 存 ' + ms.length + ' 条）', body, '记忆 ' + ms.length + ' 条');
     if (host) host.querySelectorAll('[data-mem-del]').forEach(function (b) {
-      b.addEventListener('click', function () { try { AA.memories.remove(b.getAttribute('data-mem-del')); } catch (e) {} b.closest('div').style.opacity = '.35'; b.textContent = '已删 ✓'; b.disabled = true; });
+      b.addEventListener('click', function () {
+        var name = b.getAttribute('data-mem-del');
+        _commitUserWrite({
+          operation: 'memory-remove', target: name, failureLabel: '删除记忆',
+          run: function () { return AA.memories.remove(name); },
+          onSuccess: function () { b.closest('div').style.opacity = '.35'; b.textContent = '已删 ✓'; b.disabled = true; },
+          successMessage: '已删除记忆「' + name + '」'
+        });
+      });
     });
   }
   function showSkillsUI() {   // /技能册 · ≈CC Skill 目录
@@ -1600,7 +1660,15 @@
       : '<div style="color:var(--tx3)">（空）</div>';
     var host = _mgmtCard('技能册（打磨过的操作指令包 · 国师做对应事时自动展开照做 · ' + sk.length + ' 项）', body, '技能 ' + sk.length + ' 项');
     if (host) host.querySelectorAll('[data-skill-del]').forEach(function (b) {
-      b.addEventListener('click', function () { try { AA.skills.remove(b.getAttribute('data-skill-del')); } catch (e) {} b.closest('div').style.opacity = '.35'; b.textContent = '已删 ✓'; b.disabled = true; });
+      b.addEventListener('click', function () {
+        var name = b.getAttribute('data-skill-del');
+        _commitUserWrite({
+          operation: 'skill-remove', target: name, failureLabel: '删除技能',
+          run: function () { return AA.skills.remove(name); },
+          onSuccess: function () { b.closest('div').style.opacity = '.35'; b.textContent = '已删 ✓'; b.disabled = true; },
+          successMessage: '已删除技能「' + name + '」'
+        });
+      });
     });
   }
   function showPacksUI() {   // /能力包 · ≈CC /plugin（启停/导入/导出）
@@ -1617,8 +1685,12 @@
     host.querySelectorAll('[data-pack-tg]').forEach(function (b) {
       b.addEventListener('click', function () {
         var n = b.getAttribute('data-pack-tg'), now = b.textContent === '停用' ? false : true;
-        try { AA.packs.setEnabled(n, now); } catch (e) {}
-        b.textContent = now ? '停用' : '启用'; setStatus('「' + n + '」已' + (now ? '启用' : '停用') + '（下轮生效）');
+        _commitUserWrite({
+          operation: 'pack-set-enabled', target: n, failureLabel: now ? '启用能力包' : '停用能力包',
+          run: function () { return AA.packs.setEnabled(n, now); },
+          onSuccess: function () { b.textContent = now ? '停用' : '启用'; },
+          successMessage: '「' + n + '」已' + (now ? '启用' : '停用') + '（下轮生效）'
+        });
       });
     });
     host.querySelectorAll('[data-pack-exp]').forEach(function (b) {
@@ -1629,15 +1701,26 @@
       });
     });
     host.querySelectorAll('[data-pack-rm]').forEach(function (b) {
-      b.addEventListener('click', function () { try { AA.packs.remove(b.getAttribute('data-pack-rm')); } catch (e) {} b.closest('div').style.opacity = '.35'; b.textContent = '已卸 ✓'; b.disabled = true; });
+      b.addEventListener('click', function () {
+        var name = b.getAttribute('data-pack-rm');
+        _commitUserWrite({
+          operation: 'pack-remove', target: name, failureLabel: '卸载能力包',
+          run: function () { return AA.packs.remove(name); },
+          onSuccess: function () { b.closest('div').style.opacity = '.35'; b.textContent = '已卸 ✓'; b.disabled = true; },
+          successMessage: '已卸载能力包「' + name + '」（下轮生效）'
+        });
+      });
     });
     var ib = host.querySelector('[data-pack-imp]');
     if (ib) ib.addEventListener('click', function () {
       var j = window.prompt('粘贴能力包 JSON：', '');
       if (!j) return;
-      var r = null; try { r = AA.packs.importJSON(j); } catch (e) { r = { ok: false, error: String(e && e.message || e) }; }
-      setStatus(r && r.ok ? '已导入「' + r.imported + '」（' + r.skills + ' 技能·下轮生效）' : '导入失败：' + ((r && r.error) || '未知'));
-      if (r && r.ok) showPacksUI();
+      _commitUserWrite({
+        operation: 'pack-import', target: 'clipboard-json', failureLabel: '导入能力包',
+        run: function () { return AA.packs.importJSON(j); },
+        onSuccess: function () { showPacksUI(); },
+        successMessage: function (r) { return '已导入「' + r.imported + '」（' + r.skills + ' 技能·下轮生效）'; }
+      });
     });
   }
   function showUsageUI() {   // /用量·上下文 · CC /context+/cost 对照（本地 codex-token-usage / claude-hud 思路）
@@ -2882,6 +2965,6 @@
   else init();
 
   // 暴露给测试/调试
-  global.TM_AuthoringAgentUI = { init: init, _ui: ui, undo: undoLastApply, stop: onStop, review: runReview, orchestrate: runOrchestratedUI, preflight: runPreflightUI, qa: runQaUI, explain: runExplainUI, autoMode: _armAutoMode, checkpoint: manualCheckpoint, checkpoints: listCheckpoints, restore: restoreCheckpoint, history: listHistory, clearHistory: clearHistory, changelog: buildChangelog, runChangelog: runChangelogUI, macros: listMacros, saveMacro: saveMacro, deleteMacro: deleteMacro, applyMacro: applyMacro, exportBundle: exportBundle, importBundle: importBundle, detectModels: _detectModels, saveApiCfg: _saveApiCfg, permMode: function (m) { if (m && _PM_LABEL[m]) { var p = _loadPerm(); p.mode = m; _applyPerm(p); } return _loadPerm().mode; }, attachIngest: _ingestFiles, showMemories: showMemoriesUI, showSkills: showSkillsUI, showPacks: showPacksUI, showUsage: showUsageUI,
+  global.TM_AuthoringAgentUI = { init: init, _ui: ui, _commitUserWrite: _commitUserWrite, undo: undoLastApply, stop: onStop, review: runReview, orchestrate: runOrchestratedUI, preflight: runPreflightUI, qa: runQaUI, explain: runExplainUI, autoMode: _armAutoMode, checkpoint: manualCheckpoint, checkpoints: listCheckpoints, restore: restoreCheckpoint, history: listHistory, clearHistory: clearHistory, changelog: buildChangelog, runChangelog: runChangelogUI, macros: listMacros, saveMacro: saveMacro, deleteMacro: deleteMacro, applyMacro: applyMacro, exportBundle: exportBundle, importBundle: importBundle, detectModels: _detectModels, saveApiCfg: _saveApiCfg, permMode: function (m) { if (m && _PM_LABEL[m]) { var p = _loadPerm(); p.mode = m; _applyPerm(p); } return _loadPerm().mode; }, attachIngest: _ingestFiles, showMemories: showMemoriesUI, showSkills: showSkillsUI, showPacks: showPacksUI, showUsage: showUsageUI,
     listSessions: listSessions, switchSession: switchSession, deleteSession: deleteSession, renameSession: renameSession, forkSession: forkSession, rememberConvention: rememberConvention };
 })(typeof window !== 'undefined' ? window : this);

--- a/web/editor-authoring-agent.js
+++ b/web/editor-authoring-agent.js
@@ -892,7 +892,11 @@
     catch (e) { return []; }
   }
   function _saveMemoriesArr(arr) {
-    try { global.localStorage && global.localStorage.setItem(MEMDIR_KEY, JSON.stringify(arr.slice(0, 60))); return true; }
+    try {
+      if (!global.localStorage || typeof global.localStorage.setItem !== 'function') return false;
+      global.localStorage.setItem(MEMDIR_KEY, JSON.stringify(arr.slice(0, 60)));
+      return true;
+    }
     catch (e) { return false; }
   }
   function _prepareMemoryEntry(m) {
@@ -918,8 +922,9 @@
   function deleteMemory(idOrName) {
     var arr = _loadMemories(), n = arr.length;
     arr = arr.filter(function (x) { return x && x.id !== idOrName && x.name !== idOrName; });
-    _saveMemoriesArr(arr);
-    return { ok: arr.length < n, removed: n - arr.length };
+    if (arr.length === n) return { ok: false, removed: 0, error: '记忆不存在或已删除' };
+    if (!_saveMemoriesArr(arr)) return { ok: false, removed: 0, error: '记忆删除未能持久化' };
+    return { ok: true, removed: n - arr.length };
   }
   var _RECALL_TOOL = [{
     name: 'selectMemories',
@@ -991,7 +996,11 @@
     catch (e) { return []; }
   }
   function _saveUserSkills(arr) {
-    try { global.localStorage && global.localStorage.setItem(SKILLS_KEY, JSON.stringify(arr.slice(0, 40))); return true; }
+    try {
+      if (!global.localStorage || typeof global.localStorage.setItem !== 'function') return false;
+      global.localStorage.setItem(SKILLS_KEY, JSON.stringify(arr.slice(0, 40)));
+      return true;
+    }
     catch (e) { return false; }
   }
   function _prepareSkillEntry(s) {
@@ -1050,8 +1059,9 @@
   function deleteSkill(name) {
     var arr = _loadUserSkills(), n = arr.length;
     arr = arr.filter(function (x) { return x && x.name !== name; });
-    _saveUserSkills(arr);
-    return { ok: arr.length < n };
+    if (arr.length === n) return { ok: false, error: '技能不存在或已删除' };
+    if (!_saveUserSkills(arr)) return { ok: false, error: '技能删除未能持久化' };
+    return { ok: true };
   }
   function listAllSkills() {
     var seen = {}, out = [];
@@ -1128,9 +1138,23 @@
       return { name: p.name, version: p.version || '', description: p.description || '', builtin: !!p.builtin, enabled: _packEnabled(p.name), skills: (p.skills || []).length };
     });
   }
+  function _savePackState(state) {
+    try {
+      if (!global.localStorage || typeof global.localStorage.setItem !== 'function') return false;
+      global.localStorage.setItem(PACKS_STATE_KEY, JSON.stringify(state));
+      return true;
+    } catch (e) { return false; }
+  }
+  function _saveUserPacks(packs) {
+    try {
+      if (!global.localStorage || typeof global.localStorage.setItem !== 'function') return false;
+      global.localStorage.setItem(PACKS_KEY, JSON.stringify(packs.slice(0, 20)));
+      return true;
+    } catch (e) { return false; }
+  }
   function setPackEnabled(name, on) {
     var st = _packsState(); st[name] = !!on;
-    try { global.localStorage && global.localStorage.setItem(PACKS_STATE_KEY, JSON.stringify(st)); } catch (e) {}
+    if (!_savePackState(st)) return { ok: false, name: name, enabled: _packEnabled(name), error: '能力包启停状态未能持久化' };
     return { ok: true, name: name, enabled: !!on };
   }
   function _enabledPacks() {
@@ -1154,7 +1178,7 @@
       var arr = _loadUserPacks();
       var i = arr.findIndex(function (x) { return x && x.name === clean.name; });
       if (i >= 0) arr[i] = clean; else arr.unshift(clean);
-      try { global.localStorage && global.localStorage.setItem(PACKS_KEY, JSON.stringify(arr.slice(0, 20))); } catch (e2) {}
+      if (!_saveUserPacks(arr)) return { ok: false, error: '能力包导入未能持久化' };
       return { ok: true, imported: clean.name, skills: clean.skills.length };
     } catch (e) { return { ok: false, error: String(e && e.message || e) }; }
   }
@@ -1166,8 +1190,9 @@
   function removePack(name) {
     var arr = _loadUserPacks(), n = arr.length;
     arr = arr.filter(function (x) { return x && x.name !== name; });
-    try { global.localStorage && global.localStorage.setItem(PACKS_KEY, JSON.stringify(arr)); } catch (e) {}
-    return { ok: arr.length < n };
+    if (arr.length === n) return { ok: false, error: '能力包不存在或已卸载' };
+    if (!_saveUserPacks(arr)) return { ok: false, error: '能力包卸载未能持久化' };
+    return { ok: true };
   }
 
   // ═══════════════════════════════════════════════════════════════════

--- a/web/map-editor-bookmarks.js
+++ b/web/map-editor-bookmarks.js
@@ -17,6 +17,10 @@
   var SLOTS = 4;
   var _bookmarks = null;     // { dynasty: [ {x,y,zoom,label} | null, ... ] }
   var _column = null;
+  var _initialized = false;
+  var _cameraTimer = null;
+  var _keydownHandler = null;
+  var _offMapLoaded = null;
 
   // ─── persist ───────────────────────────────────────────
 
@@ -141,6 +145,7 @@
   }
 
   function renderColumn(){
+    if (!_initialized) return;
     var col = ensureColumn();
     var slots = getSlots();
     var cur = currentSlot();
@@ -195,7 +200,8 @@
   // ─── 键盘 ──────────────────────────────────────────────
 
   function bindKeys(){
-    document.addEventListener('keydown', function(e){
+    if (_keydownHandler) return;
+    _keydownHandler = function(e){
       if (e.target && (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT')) return;
       var m = /^F([1-4])$/.exec(e.key);
       if (!m) return;
@@ -204,25 +210,63 @@
       if (e.shiftKey) setBookmark(idx);
       else if (e.altKey) clearBookmark(idx);
       else jumpBookmark(idx);
-    });
+    };
+    document.addEventListener('keydown', _keydownHandler);
   }
 
   // ─── init ──────────────────────────────────────────────
 
   function init(){
-    ensureColumn();
-    renderColumn();
-    bindKeys();
-    // camera 变·重 render column·indicator 跟随
-    var lastCam = { x: NaN, y: NaN, zoom: NaN };
-    setInterval(function(){
-      var c = ME.EDITOR.camera;
-      if (c.x !== lastCam.x || c.y !== lastCam.y || c.zoom !== lastCam.zoom){
-        lastCam.x = c.x; lastCam.y = c.y; lastCam.zoom = c.zoom;
-        renderColumn();
+    if (_initialized) return false;
+    _initialized = true;
+    try {
+      ensureColumn();
+      renderColumn();
+      bindKeys();
+      // camera 变·重 render column·indicator 跟随
+      var lastCam = { x: NaN, y: NaN, zoom: NaN };
+      _cameraTimer = setInterval(function(){
+        var c = ME.EDITOR.camera;
+        if (c.x !== lastCam.x || c.y !== lastCam.y || c.zoom !== lastCam.zoom){
+          lastCam.x = c.x; lastCam.y = c.y; lastCam.zoom = c.zoom;
+          renderColumn();
+        }
+      }, 500);
+      _offMapLoaded = ME.on('map-loaded', renderColumn);
+      if (typeof _offMapLoaded !== 'function' && typeof ME.off === 'function') {
+        _offMapLoaded = function(){ return ME.off('map-loaded', renderColumn); };
       }
-    }, 500);
-    ME.on('map-loaded', renderColumn);
+      return true;
+    } catch (error) {
+      dispose();
+      throw error;
+    }
+  }
+
+  function dispose(){
+    var hadResources = _initialized || _cameraTimer !== null || !!_keydownHandler || !!_offMapLoaded || !!_column;
+    var cleanupError = null;
+    _initialized = false;
+    if (_cameraTimer !== null){
+      clearInterval(_cameraTimer);
+      _cameraTimer = null;
+    }
+    if (_keydownHandler){
+      document.removeEventListener('keydown', _keydownHandler);
+      _keydownHandler = null;
+    }
+    if (typeof _offMapLoaded === 'function'){
+      try { _offMapLoaded(); }
+      catch (error) { cleanupError = error; }
+    }
+    _offMapLoaded = null;
+    if (_column && _column.parentNode) _column.parentNode.removeChild(_column);
+    _column = null;
+    if (cleanupError && global.console && typeof global.console.error === 'function') {
+      global.console.error('[bookmarks] map-loaded 退订失败', cleanupError);
+      return false;
+    }
+    return hadResources;
   }
 
   // ─── expose ────────────────────────────────────────────
@@ -231,6 +275,8 @@
   global.TM.MapEditor = global.TM.MapEditor || {};
   global.TM.MapEditor.bookmarks = {
     init: init,
+    dispose: dispose,
+    isInitialized: function(){ return _initialized; },
     set: setBookmark,
     jump: jumpBookmark,
     clear: clearBookmark,

--- a/web/map-editor-core.js
+++ b/web/map-editor-core.js
@@ -1254,12 +1254,32 @@
 
   var _handlers = {};
   function on(evt, fn){
+    if (typeof fn !== 'function') throw new TypeError('map-editor event handler must be a function');
     if (!_handlers[evt]) _handlers[evt] = [];
     _handlers[evt].push(fn);
+    var active = true;
+    return function unsubscribe(){
+      if (!active) return false;
+      active = false;
+      return off(evt, fn);
+    };
+  }
+  function off(evt, fn){
+    var arr = _handlers[evt];
+    if (!arr || typeof fn !== 'function') return false;
+    var removed = false;
+    for (var i = arr.length - 1; i >= 0; i--){
+      if (arr[i] !== fn) continue;
+      arr.splice(i, 1);
+      removed = true;
+    }
+    if (!arr.length) delete _handlers[evt];
+    return removed;
   }
   function fire(evt, payload){
     var arr = _handlers[evt];
     if (!arr) return;
+    arr = arr.slice();
     for (var i = 0; i < arr.length; i++){
       try { arr[i](payload); } catch(e){ console.error('[map-editor]', evt, e); }
     }
@@ -1597,6 +1617,7 @@
 
     // events
     on: on,
+    off: off,
     fire: fire
   });
 

--- a/web/scripts/README.md
+++ b/web/scripts/README.md
@@ -1,6 +1,12 @@
-# scripts/ · 零依赖测试 + 重构工具基础设施
+# scripts/ · 低依赖测试 + 重构工具基础设施
 
-此目录下的工具**严格遵守项目 `_no_dependencies` 原则**——仅使用 Node.js 内置模块 (`fs`, `path`, `vm`, `child_process`)，不引入任何 npm 包。
+大部分工具只使用 Node.js 内置模块 (`fs`, `path`, `vm`, `child_process`)；AST 架构守卫使用根目录 `devDependencies` 中的 `acorn`。全新 clone 后先在仓库根目录运行：
+
+```bash
+npm ci --ignore-scripts
+```
+
+不安装依赖直接运行 AST 守卫时会得到明确的安装提示；正式 CI 也始终先执行上述命令。
 
 ## 一键检查（最常用）
 

--- a/web/scripts/lint-global-providers.js
+++ b/web/scripts/lint-global-providers.js
@@ -8,7 +8,16 @@
 
 const fs = require('fs');
 const path = require('path');
-const acorn = require('acorn');
+let acorn;
+try {
+  acorn = require('acorn');
+} catch (error) {
+  if (error && error.code === 'MODULE_NOT_FOUND' && /["']acorn["']/.test(String(error.message || ''))) {
+    console.error('[lint-global-providers] 缺少开发依赖 acorn。\n请先在仓库根目录运行：npm ci --ignore-scripts');
+    process.exit(2);
+  }
+  throw error;
+}
 const lib = require('./lib-arch-guard');
 
 const INDEX_FILE = path.join(lib.WEB_ROOT, 'index.html');

--- a/web/scripts/lint-renderer-writeback-boundaries.js
+++ b/web/scripts/lint-renderer-writeback-boundaries.js
@@ -155,6 +155,48 @@ if (targetedRepair) {
   check(/_repairPreservesSemantics/.test(repairSource) && /repair-changed-business-semantics/.test(repairSource), 'targeted repairs must reject non-identity semantic changes in code');
 }
 
+const authoringUiParsed = parse('editor-authoring-agent-ui.js');
+const authoringUiFunctions = functionsByName(authoringUiParsed);
+['_commitUserWrite', 'rememberConvention', 'showConventionsUI', 'showMemoriesUI', 'showSkillsUI', 'showPacksUI'].forEach((name) => {
+  const fn = authoringUiFunctions.get(name);
+  check(!!fn, 'missing guarded authoring write function ' + name);
+  if (!fn || name === '_commitUserWrite') return;
+  const fnSource = authoringUiParsed.source.slice(fn.start, fn.end);
+  check(/_commitUserWrite\s*\(/.test(fnSource), name + ' must route user-visible writes through the confirmed commit boundary');
+});
+const authoringUiSource = authoringUiParsed.source;
+check(!/try\s*\{[^{}]*AA\.(?:memories\.remove|skills\.remove|packs\.(?:setEnabled|remove|importJSON))\s*\([^{}]*\)\s*;?\s*\}\s*catch\s*\([^)]*\)\s*\{\s*\}/.test(authoringUiSource),
+  'authoring user writes must not return to empty-catch false-success handling');
+
+const mapCoreParsed = parse('map-editor-core.js');
+const mapCoreFunctions = functionsByName(mapCoreParsed);
+const mapOn = mapCoreFunctions.get('on');
+const mapOff = mapCoreFunctions.get('off');
+const mapFire = mapCoreFunctions.get('fire');
+check(!!mapOn && !!mapOff && !!mapFire, 'map editor event hub must expose on/off/fire lifecycle functions');
+if (mapOn) check(/return function unsubscribe/.test(mapCoreParsed.source.slice(mapOn.start, mapOn.end)), 'map editor on() must return an unsubscribe disposer');
+if (mapFire) check(/\.slice\s*\(\s*\)/.test(mapCoreParsed.source.slice(mapFire.start, mapFire.end)), 'map editor fire() must dispatch over a stable listener snapshot');
+check(/\bon\s*:\s*on\s*,[\s\S]{0,80}\boff\s*:\s*off\s*,[\s\S]{0,80}\bfire\s*:\s*fire/.test(mapCoreParsed.source), 'map editor public event hub must publish off() alongside on()/fire()');
+
+const bookmarksParsed = parse('map-editor-bookmarks.js');
+const bookmarkFunctions = functionsByName(bookmarksParsed);
+const bookmarkInit = bookmarkFunctions.get('init');
+const bookmarkDispose = bookmarkFunctions.get('dispose');
+const bookmarkBindKeys = bookmarkFunctions.get('bindKeys');
+check(!!bookmarkInit && !!bookmarkDispose && !!bookmarkBindKeys, 'bookmark feature must expose explicit init/dispose/key binding boundaries');
+if (bookmarkInit) {
+  const source = bookmarksParsed.source.slice(bookmarkInit.start, bookmarkInit.end);
+  check(/if\s*\(\s*_initialized\s*\)\s*return false/.test(source), 'bookmark init must be idempotent');
+  check(/_cameraTimer\s*=\s*setInterval/.test(source) && /_offMapLoaded\s*=\s*ME\.on/.test(source), 'bookmark init must retain timer and map subscription handles');
+}
+if (bookmarkDispose) {
+  const source = bookmarksParsed.source.slice(bookmarkDispose.start, bookmarkDispose.end);
+  check(/clearInterval\s*\(\s*_cameraTimer\s*\)/.test(source), 'bookmark dispose must clear its camera timer');
+  check(/removeEventListener\s*\(\s*['"]keydown['"]\s*,\s*_keydownHandler\s*\)/.test(source), 'bookmark dispose must remove its key listener');
+  check(/_offMapLoaded\s*\(\s*\)/.test(source), 'bookmark dispose must unsubscribe from map-loaded');
+}
+check(/dispose\s*:\s*dispose/.test(bookmarksParsed.source) && /isInitialized\s*:/.test(bookmarksParsed.source), 'bookmark public API must expose lifecycle controls');
+
 const runtimeFiles = fs.readdirSync(WEB).filter((name) => name.endsWith('.js'));
 runtimeFiles.forEach((file) => {
   const parsed = parse(file);

--- a/web/scripts/smoke-authoring-user-write-failures.js
+++ b/web/scripts/smoke-authoring-user-write-failures.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let passed = 0;
+let failed = 0;
+function ok(condition, message) {
+  if (condition) {
+    passed++;
+    console.log('  ✓ ' + message);
+  } else {
+    failed++;
+    console.error('  ✗ ' + message);
+  }
+}
+
+function createStorage() {
+  const data = Object.create(null);
+  let failWrites = false;
+  return {
+    getItem(key) { return Object.prototype.hasOwnProperty.call(data, key) ? data[key] : null; },
+    setItem(key, value) {
+      if (failWrites) throw new Error('injected-storage-write-failure');
+      data[key] = String(value);
+    },
+    removeItem(key) {
+      if (failWrites) throw new Error('injected-storage-write-failure');
+      delete data[key];
+    },
+    setFailWrites(value) { failWrites = !!value; }
+  };
+}
+
+console.log('smoke-authoring-user-write-failures');
+
+const storage = createStorage();
+global.window = global;
+global.localStorage = storage;
+delete global.TM;
+require('../editor-authoring-agent.js');
+const AA = global.TM.AuthoringAgent;
+
+ok(AA.memories.save({ name: '持久记忆', type: 'user', description: '测试', body: '不得在失败时消失' }).ok, 'seed memory');
+ok(AA.skills.save({ name: '持久技能', body: '不得在失败时消失' }).ok, 'seed skill');
+ok(AA.packs.importJSON({ name: '持久能力包', version: '1.0', skills: [{ name: '包内技能', body: '测试' }] }).ok, 'seed user pack');
+
+storage.setFailWrites(true);
+const memoryDelete = AA.memories.remove('持久记忆');
+ok(memoryDelete.ok === false && AA.memories.list().some((entry) => entry.name === '持久记忆'), 'memory deletion reports persistence failure and preserves stored row');
+const skillDelete = AA.skills.remove('持久技能');
+ok(skillDelete.ok === false && AA.skills.list().some((entry) => entry.name === '持久技能'), 'skill deletion reports persistence failure and preserves stored row');
+const packToggle = AA.packs.setEnabled('立绘工坊', false);
+ok(packToggle.ok === false && AA.packs.list().find((pack) => pack.name === '立绘工坊').enabled === true, 'pack toggle reports persistence failure without changing effective state');
+const packImport = AA.packs.importJSON({ name: '失败导入包', skills: [{ name: '不会落盘', body: '测试' }] });
+ok(packImport.ok === false && !AA.packs.list().some((pack) => pack.name === '失败导入包'), 'pack import never reports success when storage rejects it');
+const packRemove = AA.packs.remove('持久能力包');
+ok(packRemove.ok === false && AA.packs.list().some((pack) => pack.name === '持久能力包'), 'pack removal reports persistence failure and preserves stored pack');
+
+const captured = [];
+const documentListeners = Object.create(null);
+const uiContext = {
+  console,
+  Promise,
+  Date,
+  Error,
+  JSON,
+  Math,
+  setTimeout,
+  clearTimeout,
+  localStorage: createStorage(),
+  document: {
+    readyState: 'loading',
+    currentScript: null,
+    addEventListener(type, handler) { documentListeners[type] = handler; }
+  },
+  TM: {
+    AuthoringAgent: {},
+    errors: {
+      capture(error, context, metadata) { captured.push({ error, context, metadata }); }
+    }
+  }
+};
+uiContext.window = uiContext;
+vm.createContext(uiContext);
+const uiSource = fs.readFileSync(path.resolve(__dirname, '..', 'editor-authoring-agent-ui.js'), 'utf8');
+vm.runInContext(uiSource, uiContext, { filename: 'editor-authoring-agent-ui.js' });
+const UI = uiContext.TM_AuthoringAgentUI;
+UI._ui.els = { status: { textContent: '' } };
+
+let successMutations = 0;
+const rejected = UI._commitUserWrite({
+  operation: 'test.rejected',
+  target: '写目标',
+  failureLabel: '测试写入',
+  run() { return { ok: false, error: '底层拒绝' }; },
+  onSuccess() { successMutations++; },
+  successMessage: '不应显示'
+});
+ok(rejected === false && successMutations === 0, 'structured write failure stops success-side UI mutation');
+ok(/测试写入失败：底层拒绝/.test(UI._ui.els.status.textContent), 'structured write failure is visible to the user');
+
+const thrown = UI._commitUserWrite({
+  operation: 'test.throw',
+  target: '抛错目标',
+  failureLabel: '抛错写入',
+  run() { throw new Error('注入异常'); },
+  onSuccess() { successMutations++; }
+});
+ok(thrown === false && successMutations === 0, 'thrown write failure also stops success-side UI mutation');
+ok(captured.length === 2 && captured.every((entry) => entry.context === 'authoring-agent.user-write'), 'write failures enter the structured diagnostic channel');
+
+const committed = UI._commitUserWrite({
+  operation: 'test.success',
+  target: '成功目标',
+  run() { return { ok: true }; },
+  onSuccess() { successMutations++; },
+  successMessage: '写入成功'
+});
+ok(committed === true && successMutations === 1 && UI._ui.els.status.textContent === '写入成功', 'success UI updates only after a confirmed commit');
+
+console.log('\nsmoke-authoring-user-write-failures ' + (failed ? 'FAIL' : 'PASS') + ' ' + passed + '/' + (passed + failed));
+process.exit(failed ? 1 : 0);

--- a/web/scripts/smoke-global-provider-guard.js
+++ b/web/scripts/smoke-global-provider-guard.js
@@ -11,4 +11,20 @@ if (result.status !== 0 || !String(result.stdout).includes('SELF-TEST PASS')) {
   console.error(result.stderr || '');
   process.exit(1);
 }
-console.log('[smoke-global-provider-guard] PASS — AST providers, root alias scope, and immediate dependency guards');
+
+const missingAcornProbe = [
+  "const Module = require('module');",
+  'const originalLoad = Module._load;',
+  "Module._load = function(request) { if (request === 'acorn') { const error = new Error(\"Cannot find module 'acorn'\"); error.code = 'MODULE_NOT_FOUND'; throw error; } return originalLoad.apply(this, arguments); };",
+  'process.argv = [' + JSON.stringify(process.execPath) + ', ' + JSON.stringify(guard) + ', "--self-test"];',
+  'require(' + JSON.stringify(guard) + ');'
+].join('\n');
+const missing = cp.spawnSync(process.execPath, ['-e', missingAcornProbe], { encoding: 'utf8', windowsHide: true });
+const missingOutput = String(missing.stdout || '') + String(missing.stderr || '');
+if (missing.status !== 2 || !/acorn/.test(missingOutput) || !/npm ci --ignore-scripts/.test(missingOutput)) {
+  console.error('[smoke-global-provider-guard] missing-acorn diagnosis did not expose the required recovery command');
+  console.error(missingOutput);
+  process.exit(1);
+}
+
+console.log('[smoke-global-provider-guard] PASS — AST providers, root alias scope, dependency guards, and missing-acorn diagnosis');

--- a/web/scripts/smoke-map-editor-bookmarks-lifecycle.js
+++ b/web/scripts/smoke-map-editor-bookmarks-lifecycle.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let passed = 0;
+let failed = 0;
+function ok(condition, message) {
+  if (condition) {
+    passed++;
+    console.log('  ✓ ' + message);
+  } else {
+    failed++;
+    console.error('  ✗ ' + message);
+  }
+}
+
+function FakeElement(tagName) {
+  this.tagName = String(tagName || 'div').toUpperCase();
+  this.children = [];
+  this.parentNode = null;
+  this.style = {};
+  this.listeners = Object.create(null);
+  this.innerHTML = '';
+  this.id = '';
+  this.title = '';
+}
+FakeElement.prototype.appendChild = function appendChild(child) {
+  child.parentNode = this;
+  this.children.push(child);
+  return child;
+};
+FakeElement.prototype.removeChild = function removeChild(child) {
+  const index = this.children.indexOf(child);
+  if (index >= 0) this.children.splice(index, 1);
+  child.parentNode = null;
+  return child;
+};
+FakeElement.prototype.addEventListener = function addEventListener(type, handler) {
+  if (!this.listeners[type]) this.listeners[type] = [];
+  this.listeners[type].push(handler);
+};
+FakeElement.prototype.removeEventListener = function removeEventListener(type, handler) {
+  const list = this.listeners[type] || [];
+  const index = list.indexOf(handler);
+  if (index >= 0) list.splice(index, 1);
+};
+
+const body = new FakeElement('body');
+const stage = new FakeElement('div');
+const documentListeners = Object.create(null);
+const intervals = new Map();
+let intervalSequence = 0;
+const storage = Object.create(null);
+const context = {
+  console,
+  Date,
+  Math,
+  JSON,
+  Object,
+  Array,
+  Number,
+  String,
+  Error,
+  TypeError,
+  requestAnimationFrame() { return 1; },
+  cancelAnimationFrame() {},
+  setInterval(handler, delay) {
+    const id = ++intervalSequence;
+    intervals.set(id, { handler, delay });
+    return id;
+  },
+  clearInterval(id) { intervals.delete(id); },
+  localStorage: {
+    getItem(key) { return Object.prototype.hasOwnProperty.call(storage, key) ? storage[key] : null; },
+    setItem(key, value) { storage[key] = String(value); }
+  },
+  document: {
+    body,
+    createElement(tag) { return new FakeElement(tag); },
+    querySelector(selector) { return selector === '.me-stage' ? stage : null; },
+    getElementById() { return null; },
+    addEventListener(type, handler) {
+      if (!documentListeners[type]) documentListeners[type] = [];
+      documentListeners[type].push(handler);
+    },
+    removeEventListener(type, handler) {
+      const list = documentListeners[type] || [];
+      const index = list.indexOf(handler);
+      if (index >= 0) list.splice(index, 1);
+    }
+  },
+  TM: {}
+};
+context.window = context;
+vm.createContext(context);
+
+function load(file) {
+  const source = fs.readFileSync(path.resolve(__dirname, '..', file), 'utf8');
+  vm.runInContext(source, context, { filename: file });
+}
+
+console.log('smoke-map-editor-bookmarks-lifecycle');
+load('map-editor-dynasty.js');
+load('map-editor-undo.js');
+load('map-editor-core.js');
+const ME = context.TM.MapEditor;
+ME.EDITOR.camera = { x: 0, y: 0, zoom: 1 };
+ME.EDITOR.map = { dynasty: 'smoke', divisions: [] };
+ME.EDITOR.canvas = null;
+
+let probeCalls = 0;
+const offProbe = ME.on('probe', function () { probeCalls++; });
+ME.fire('probe');
+const firstOff = offProbe();
+const secondOff = offProbe();
+ME.fire('probe');
+ok(probeCalls === 1 && firstOff === true && secondOff === false, 'event hub returns an idempotent disposer');
+
+const originalOn = ME.on;
+let mapLoadedSubscriptions = 0;
+let mapLoadedUnsubscriptions = 0;
+ME.on = function trackedOn(eventName, handler) {
+  const disposer = originalOn(eventName, handler);
+  if (eventName === 'map-loaded') mapLoadedSubscriptions++;
+  let active = true;
+  return function trackedDisposer() {
+    const result = disposer();
+    if (active && result && eventName === 'map-loaded') mapLoadedUnsubscriptions++;
+    active = false;
+    return result;
+  };
+};
+
+load('map-editor-bookmarks.js');
+const bookmarks = ME.bookmarks;
+ok(bookmarks.init() === true && bookmarks.isInitialized(), 'first init installs the bookmark feature');
+ok(intervals.size === 1 && (documentListeners.keydown || []).length === 1 && mapLoadedSubscriptions === 1, 'init installs exactly one timer, key listener, and map subscription');
+ok(bookmarks.init() === false && intervals.size === 1 && (documentListeners.keydown || []).length === 1 && mapLoadedSubscriptions === 1, 'repeated init is idempotent');
+ok(stage.children.length === 1 && stage.children[0].id === 'me-bookmarks', 'bookmark column is installed once');
+
+ME.fire('map-loaded');
+ok(bookmarks.dispose() === true && !bookmarks.isInitialized(), 'dispose releases an initialized feature');
+ok(intervals.size === 0 && (documentListeners.keydown || []).length === 0 && mapLoadedUnsubscriptions === 1, 'dispose clears timer, key listener, and map subscription');
+ok(stage.children.length === 0, 'dispose removes the bookmark column');
+ok(bookmarks.dispose() === false && mapLoadedUnsubscriptions === 1, 'repeated dispose is idempotent');
+
+ok(bookmarks.init() === true && intervals.size === 1 && (documentListeners.keydown || []).length === 1, 'feature can be initialized again after disposal');
+ok(bookmarks.dispose() === true && intervals.size === 0 && mapLoadedSubscriptions === 2 && mapLoadedUnsubscriptions === 2, 'second lifecycle leaves no accumulated resources');
+
+console.log('\nsmoke-map-editor-bookmarks-lifecycle ' + (failed ? 'FAIL' : 'PASS') + ' ' + passed + '/' + (passed + failed));
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## 摘要

- 让国师记忆、技能、能力包和剧本约定写操作只在真实持久化成功后更新成功 UI，并把失败送入结构化诊断
- 为地图编辑器事件总线增加退订契约，为书签模块补齐幂等 init/dispose、interval、keydown 和 map-loaded 清理
- 为缺少 acorn 的裸环境提供明确安装提示，并修正文档中的零依赖声明
- 增加写失败、书签生命周期和依赖诊断专项 Smoke，以及范围明确的架构守卫

## 验证

- node web/scripts/lint-arch-all.js
- node web/scripts/ci-smokes.js（895 total；893 直接通过，2 个既有缺资产白名单）
- npm run verify:release-contract（166/166）
- node web/scripts/verify-official-scenario-parity.js（27/27）
- node web/scripts/verify-hot-builder-gates.js（27/27）
- npm audit --omit=dev --audit-level=high（0 vulnerabilities）
- 完整资产 canonical hot baseline check（1096 files）
- git diff --check

未执行 release、安装包、部署或热更新发布。