### PR TITLE
fix: route edict finances through canonical ledgers

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-25T20:10:12.571Z",
+  "generatedAt": "2026-08-27T17:34:37.160Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -2171,8 +2171,8 @@
     },
     {
       "path": "index.html",
-      "sha256": "b59fefd20a499d5d63c33df2445a8e4c7990ff4bc2012c7c0606951169236a05",
-      "size": 69148
+      "sha256": "9281f386efd220be924dff284509c11e9f85e3969a8ce4de2da19402bbc807de",
+      "size": 69163
     },
     {
       "path": "INDEX.md",
@@ -3856,8 +3856,8 @@
     },
     {
       "path": "tm-economy-engine.js",
-      "sha256": "3c69b648b92181e6c84efad8756aa8dc4bbecdb4b85fa5c1e7f9726c0b1c811d",
-      "size": 138561
+      "sha256": "7687b091bcb80c02fb3af7435664af072fe66f63db71f33cba3a013b91db6ee6",
+      "size": 139069
     },
     {
       "path": "tm-economy.js",
@@ -3881,8 +3881,8 @@
     },
     {
       "path": "tm-edict-parser.js",
-      "sha256": "6fac2321555a9f6e00990cb907e7f27f03f44fe773e0c6d21c183845c116df56",
-      "size": 114270
+      "sha256": "8643bb4a23cb25358b620dfcac2c038a9c87cd373632d2879ccec8e2e3292be4",
+      "size": 115345
     },
     {
       "path": "tm-edict-thresholds.js",
@@ -4251,8 +4251,8 @@
     },
     {
       "path": "tm-fiscal-engine.js",
-      "sha256": "1d6bc470b9af356ccd605f221c3ce30c18b5417f8080873f6e8be3d9e7d50643",
-      "size": 109093
+      "sha256": "24783e9d6b3817f5b8722f1a31d1807d4a3c08bafdf573002aaf1a771df991a4",
+      "size": 116253
     },
     {
       "path": "tm-fiscal-ui.js",

--- a/web/index.html
+++ b/web/index.html
@@ -882,11 +882,11 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-ceming.js?v=2026042817"></script>
 <script src="tm-char-economy-ui.js?v=2026042714"></script>
 <script src="tm-char-full-schema.js?v=2026042714"></script>
-<script src="tm-economy-engine-currency.js?v=20260824-auditfix19"></script><!-- 立项拆分：§A CurrencyUnit+§B CurrencyEngine 两整IIFE·紧挨 economy-engine 之前保序·勿动位置 -->
-<script src="tm-economy-engine.js?v=20260824-auditfix19"></script>
+<script src="tm-economy-engine-currency.js?v=20260828-edictledger"></script><!-- 立项拆分：§A CurrencyUnit+§B CurrencyEngine 两整IIFE·紧挨 economy-engine 之前保序·勿动位置 -->
+<script src="tm-economy-engine.js?v=20260828-edictledger"></script>
 <script src="tm-central-local-engine.js?v=20260709"></script>
 <script src="tm-huji-engine.js?v=20260822-auditfix16"></script>
-<script src="tm-edict-parser.js?v=20260709"></script>
+<script src="tm-edict-parser.js?v=20260828-edictledger"></script>
 <script src="tm-huji-deep-fill.js?v=20260822-auditfix14"></script>
 <script src="tm-huji-runtime-bridge.js?v=20260822-auditfix17"></script>
 <script src="tm-huji-governance-loop.js?v=20260602-huji-governance-loop"></script>
@@ -923,7 +923,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-edict-thresholds.js?v=2026042714"></script>
 <script src="tm-fiscal-ui.js?v=2026042714"></script>
 <script src="tm-integration-bridge.js?v=20260822-auditfix17"></script>
-<script src="tm-fiscal-engine.js?v=20260824-auditfix19"></script>
+<script src="tm-fiscal-engine.js?v=20260828-edictledger"></script>
 <script src="tm-invariants.js?v=2026042714"></script>
 <script src="tm-namespaces.js?v=2026042714"></script>
 <script src="tm-state.js?v=2026042714"></script>

--- a/web/scripts/smoke-edict-fiscal-ledger-integrity.js
+++ b/web/scripts/smoke-edict-fiscal-ledger-integrity.js
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// Edict fiscal writes must preserve the canonical guoku ledger and atomic region transfers.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const ROOT = path.resolve(__dirname, '..');
+
+let passed = 0;
+function assert(value, message) {
+  if (!value) throw new Error('[smoke-edict-fiscal-ledger-integrity] ' + message);
+  passed += 1;
+}
+function same(actual, expected, message) {
+  assert(JSON.stringify(actual) === JSON.stringify(expected), message);
+}
+
+function makeGame(money, regionMoney) {
+  return {
+    turn: 12,
+    month: 1,
+    guoku: { balance: money, money: money, grain: 0, cloth: 0 },
+    huangquan: { index: 50 },
+    chars: [],
+    regions: [{ id: 'r1', name: '河东', unrest: 20, disasterLevel: 0 }],
+    fiscal: {
+      regions: {
+        r1: {
+          regionId: 'r1',
+          ledgers: { money: regionMoney, grain: 0, cloth: 0 },
+          compliance: 0.8,
+          autonomyLevel: 0.2,
+          annualReport: { collected: 0, remitted: 0, skimmed: 0 },
+          expenditures: { fixed: [], discretionary: [], imperial: [], illicit: [], downstream: [] },
+          history: []
+        }
+      }
+    }
+  };
+}
+
+function makeContext(game) {
+  const context = {
+    console,
+    Date,
+    JSON,
+    Math,
+    Object,
+    Array,
+    Number,
+    String,
+    Boolean,
+    RegExp,
+    Error,
+    Map,
+    Set,
+    WeakMap,
+    WeakSet,
+    isFinite,
+    isNaN,
+    parseInt,
+    parseFloat,
+    GM: game,
+    P: { conf: {} },
+    scriptData: game,
+    addEB() {},
+    toast() {},
+    _adjAuthority() {},
+    isYearBoundary() { return true; },
+    EconomyEventBus: { emit() {} },
+    TM: { errors: { capture(error) { throw error; } } }
+  };
+  context.window = context;
+  context.global = context;
+  context.globalThis = context;
+  vm.createContext(context);
+  ['tm-fiscal-engine.js', 'tm-economy-engine.js', 'tm-edict-parser.js'].forEach(function(file) {
+    vm.runInContext(fs.readFileSync(path.join(ROOT, file), 'utf8'), context, { filename: file });
+  });
+  return context;
+}
+
+function assertTrinity(game, label) {
+  const stock = game.guoku.ledgers && game.guoku.ledgers.money && game.guoku.ledgers.money.stock;
+  assert(game.guoku.balance === game.guoku.money, label + ': balance must equal money');
+  assert(game.guoku.money === stock, label + ': money must equal ledger stock');
+}
+
+// Region → guoku transfer is source-limited, conserved, and audited on both sides.
+{
+  const ctx = makeContext(makeGame(100000, 60000));
+  const beforeTotal = ctx.GM.guoku.money + ctx.GM.fiscal.regions.r1.ledgers.money;
+  const result = ctx.EconomyGapFill.forceLevy('r1', 100000, '军饷');
+  assert(result.ok === true, 'force levy should succeed through the canonical fiscal engine');
+  assert(result.actualAmount === 60000 && result.limitedBySource === true,
+    'force levy should transfer only funds actually held by the region');
+  assert(ctx.GM.guoku.money + ctx.GM.fiscal.regions.r1.ledgers.money === beforeTotal,
+    'force levy must conserve central plus regional money');
+  assertTrinity(ctx.GM, 'force levy');
+  assert(ctx.GM.guoku.ledgers.money.sources['诏令·地方强征'] === 60000,
+    'central ledger should record the force-levy source');
+  assert(ctx.GM.fiscal.regions.r1.ledgerAudit.money.sinks['诏令·地方强征'] === 60000,
+    'regional audit ledger should record the force-levy sink');
+}
+
+// Faults after either side has changed roll back both worlds of the transfer.
+{
+  const ctx = makeContext(makeGame(80000, 45000));
+  ctx.FiscalEngine.addToGuoku({ money: 0 }, 'init');
+  const guokuBefore = JSON.parse(JSON.stringify(ctx.GM.guoku));
+  const regionBefore = JSON.parse(JSON.stringify(ctx.GM.fiscal.regions.r1));
+  const result = ctx.FiscalEngine.transferRegionToGuokuAtomic({
+    regionId: 'r1',
+    amount: 20000,
+    sourceTag: '故障注入',
+    gameRef: ctx.GM,
+    _faultInjector(stage) {
+      if (stage === 'after-guoku-credit') throw new Error('injected transfer failure');
+    }
+  });
+  assert(result.ok === false && result.code === 'region-guoku-transfer-failed',
+    'fault injection should fail the whole transfer');
+  same(ctx.GM.guoku, guokuBefore, 'guoku must roll back byte-for-structure after transfer failure');
+  same(ctx.GM.fiscal.regions.r1, regionBefore, 'regional fiscal state must roll back after transfer failure');
+}
+
+// Full-amount spending never partially deducts.
+{
+  const ctx = makeContext(makeGame(3200, 0));
+  const result = ctx.FiscalEngine.trySpendFromGuoku({
+    amounts: { money: 5000 },
+    sinkTag: '诏令·御史核查',
+    gameRef: ctx.GM,
+    requireFullAmount: true
+  });
+  assert(result.ok === false && result.code === 'insufficient-guoku-money',
+    'full spending should return a structured insufficient-funds result');
+  assert(ctx.GM.guoku.money === 3200 && ctx.GM.guoku.balance === 3200,
+    'insufficient full spending must not deduct the available remainder');
+  assert(!ctx.GM.guoku.ledgers, 'failed full spending must restore the pre-call guoku shape');
+}
+
+// Investigation is created only after its fixed cost commits.
+{
+  const ctx = makeContext(makeGame(3200, 0));
+  ctx.GM._pendingMemorials = [{ id: 'memo-low', status: 'drafted', drafter: '御史甲', typeName: '核查' }];
+  const denied = ctx.EdictComplete.processImperialAssentExtended('memo-low', 'investigate', {});
+  assert(denied.ok === false && denied.code === 'insufficient-guoku-money',
+    'underfunded investigation should fail before world mutation');
+  assert(!ctx.GM._investigations, 'underfunded investigation must not create an investigation record');
+  assert(ctx.GM._pendingMemorials[0].status === 'drafted', 'underfunded investigation must not change memorial status');
+
+  ctx.GM.guoku.balance = 10000;
+  ctx.GM.guoku.money = 10000;
+  const approved = ctx.EdictComplete.processImperialAssentExtended('memo-low', 'investigate', {});
+  assert(approved.ok === true && ctx.GM._investigations.length === 1,
+    'funded investigation should create exactly one record');
+  assertTrinity(ctx.GM, 'investigation');
+  assert(ctx.GM.guoku.money === 5000, 'funded investigation should deduct its exact fixed cost');
+  assert(ctx.GM.guoku.ledgers.money.sinks['诏令·御史核查'] === 5000,
+    'investigation cost should be named in the central sink ledger');
+}
+
+// Initial institution funding uses all-or-nothing spending.
+{
+  const ctx = makeContext(makeGame(3000, 0));
+  const institution = ctx.EdictParser.registerDynamicInstitution({ name: '水利司', annualBudget: 5000 });
+  assert(institution.stage === 'underfunded', 'new institution should be marked underfunded when full budget is unavailable');
+  assert(ctx.GM.guoku.money === 3000, 'new institution must not partially consume an insufficient treasury');
+}
+
+// Yearly institution funding uses a fresh canonical world and never partially deducts.
+{
+  const ctx = makeContext(makeGame(3000, 0));
+  ctx.FiscalEngine.addToGuoku({ money: 0 }, 'fixture-init');
+  ctx.GM.dynamicInstitutions = [{
+    id: 'inst-yearly', name: '漕运司', stage: 'running', annualBudget: 5000,
+    effectiveness: 1, corruption: 10, history: []
+  }];
+  ctx.PhaseC.tick({ turn: ctx.GM.turn, monthRatio: 1 });
+  assert(ctx.GM.dynamicInstitutions[0].stage === 'underfunded',
+    'yearly institution funding failure should mark the institution underfunded');
+  assert(ctx.GM.guoku.money === 3000, 'yearly funding failure must not partially deduct funds');
+  assertTrinity(ctx.GM, 'underfunded institution');
+}
+
+console.log('[smoke-edict-fiscal-ledger-integrity] PASS assertions=' + passed);

--- a/web/scripts/smoke-edict-office-reform-dynamic-lifecycle.js
+++ b/web/scripts/smoke-edict-office-reform-dynamic-lifecycle.js
@@ -47,9 +47,12 @@ ctx.globalThis = ctx;
 vm.createContext(ctx);
 
 (function main() {
+  load(ctx, 'tm-fiscal-engine.js');
   load(ctx, 'tm-edict-parser.js');
 
   assert(ctx.EdictParser && typeof ctx.EdictParser.tryExecute === 'function', 'EdictParser.tryExecute should load');
+  assert(ctx.FiscalEngine && typeof ctx.FiscalEngine.trySpendFromGuoku === 'function',
+    'office reform smoke uses the same canonical fiscal provider as production');
 
   const result = ctx.EdictParser.tryExecute('诏令：设文书司，正五品，掌诏令档案，司典籍校雠。', {}, {});
   assert(result && result.ok, 'direct office reform edict should execute');

--- a/web/scripts/smoke-edict-parser-layered.js
+++ b/web/scripts/smoke-edict-parser-layered.js
@@ -54,7 +54,8 @@ function load(file) {
   vm.runInContext(src, ctx, { filename: file });
 }
 
-// R12b 后·tm-phase-c-patches.js 已 inline 入 tm-edict-parser.js·只 load v1
+// R12b 后·tm-phase-c-patches.js 已 inline 入 tm-edict-parser.js；机构拨款走 production FiscalEngine。
+load('tm-fiscal-engine.js');
 load('tm-edict-parser.js');
 
 // PhaseC.init() 现在是 no-op (OVERRIDEs 已 inline 入 v1)·调用兼容性保持

--- a/web/tm-economy-engine.js
+++ b/web/tm-economy-engine.js
@@ -2555,9 +2555,21 @@
     var rf = G.fiscal.regions[regionId];
     if (!rf) return { ok: false };
     var region = _getRegionsArray(G).find(function(r) { return r.id === regionId; });
-    var realAmount = Math.min(amount, (rf.ledgers.money || 0) + amount * 0.5); // 最多搜刮到本地留存 + 强拿 50%
-    rf.ledgers.money = Math.max(0, rf.ledgers.money - realAmount);
-    if (G.guoku) G.guoku.money = (G.guoku.money || 0) + realAmount * 0.8; // 20% 损耗
+    var fiscal = global.FiscalEngine;
+    if (!fiscal || typeof fiscal.transferRegionToGuokuAtomic !== 'function') {
+      return { ok: false, code: 'fiscal-engine-unavailable' };
+    }
+    var transfer = fiscal.transferRegionToGuokuAtomic({
+      regionId: regionId,
+      amount: amount,
+      sourceTag: '诏令·地方强征',
+      gameRef: G
+    });
+    if (!transfer || transfer.ok !== true) return transfer || { ok: false, code: 'force-levy-transfer-failed' };
+    var realAmount = Number(transfer.actualAmount || 0);
+    if (!(realAmount > 0)) {
+      return { ok: false, code: 'insufficient-region-funds', requested: Number(amount || 0), available: 0 };
+    }
     // 合规率重挫
     rf.compliance = Math.max(0.05, rf.compliance - 0.2);
     // 连续强征计数
@@ -2577,7 +2589,13 @@
     if (global.EconomyEventBus && typeof global.EconomyEventBus.emit === 'function') {
       global.EconomyEventBus.emit('central_local.force_levy', { regionId: regionId, amount: realAmount, newCompliance: rf.compliance });
     }
-    return { ok: true, actualAmount: realAmount, newCompliance: rf.compliance };
+    return {
+      ok: true,
+      actualAmount: realAmount,
+      requestedAmount: transfer.requested,
+      limitedBySource: !!transfer.limitedBySource,
+      newCompliance: rf.compliance
+    };
   }
 
   /** 每年重置 recent force levy 计数 */

--- a/web/tm-edict-parser.js
+++ b/web/tm-edict-parser.js
@@ -621,13 +621,15 @@
       if (!params.regionId || !params.amount) return { ok: false, reason: '缺少强征区域或金额' };
       if (global.EconomyGapFill && typeof global.EconomyGapFill.forceLevy === 'function') {
         result = global.EconomyGapFill.forceLevy(params.regionId, params.amount, params.reason || 'edict');
-      } else if (G.fiscal && G.fiscal.regions && G.fiscal.regions[params.regionId]) {
-        var rf = G.fiscal.regions[params.regionId];
-        var actual = Math.min(params.amount, (rf.ledgers && rf.ledgers.money) || params.amount);
-        if (rf.ledgers) rf.ledgers.money = Math.max(0, (rf.ledgers.money || 0) - actual);
-        if (G.guoku) G.guoku.balance = (G.guoku.balance || 0) + actual;
-        rf.compliance = Math.max(0.05, (rf.compliance || 0.8) - 0.2);
-        result = { ok: true, actualAmount: actual, fallback: true };
+      } else if (global.FiscalEngine && typeof global.FiscalEngine.transferRegionToGuokuAtomic === 'function') {
+        result = global.FiscalEngine.transferRegionToGuokuAtomic({
+          regionId: params.regionId,
+          amount: params.amount,
+          sourceTag: '诏令·地方强征',
+          gameRef: G
+        });
+      } else {
+        result = { ok: false, code: 'fiscal-engine-unavailable' };
       }
     } else if (action === 'dispatch_censor') {
       if (!params.regionId) return { ok: false, reason: '缺少监察区域' };
@@ -1696,6 +1698,19 @@
       return { ok: true, status: 'redraft_pending' };
     }
     if (action === 'investigate') {
+      var fiscal = global.FiscalEngine;
+      if (!fiscal || typeof fiscal.trySpendFromGuoku !== 'function') {
+        return { ok: false, code: 'fiscal-engine-unavailable', reason: '财政账本未就绪' };
+      }
+      var payment = fiscal.trySpendFromGuoku({
+        amounts: { money: 5000 },
+        sinkTag: '诏令·御史核查',
+        gameRef: G,
+        requireFullAmount: true
+      });
+      if (!payment || payment.ok !== true) {
+        return Object.assign({ ok: false, reason: '国库不足，无法派御史核查' }, payment || {});
+      }
       if (!G._investigations) G._investigations = [];
       G._investigations.push({
         id: 'invest_' + (G.turn||0) + '_' + Math.floor(Math.random()*10000),
@@ -1705,7 +1720,6 @@
         expectedReturnTurn: (G.turn || 0) + 2,
         cost: 5000
       });
-      if (G.guoku) G.guoku.money = Math.max(0, G.guoku.money - 5000);
       memo.status = 'under_investigation';
       if (global.addEB) global.addEB('监察', '派御史核查 ' + memo.drafter + ' 奏疏');
       return { ok: true, status: 'investigating' };
@@ -1921,9 +1935,16 @@
         G.huangquan.index = Math.max(0, G.huangquan.index - 5);
       }
     }
-    if (G.guoku && G.guoku.money >= inst.annualBudget) {
-      G.guoku.money -= inst.annualBudget;
-    } else {
+    var fiscal = global.FiscalEngine;
+    var initialPayment = fiscal && typeof fiscal.trySpendFromGuoku === 'function'
+      ? fiscal.trySpendFromGuoku({
+          amounts: { money: inst.annualBudget },
+          sinkTag: '诏令·新设机构·' + inst.name,
+          gameRef: G,
+          requireFullAmount: true
+        })
+      : { ok: false, code: 'fiscal-engine-unavailable' };
+    if (!initialPayment || initialPayment.ok !== true) {
       inst.stage = 'underfunded';
       inst.effectiveness *= 0.5;
     }
@@ -1940,9 +1961,17 @@
     G.dynamicInstitutions.forEach(function(inst) {
       if (inst.stage === 'abolished') return;
       if (inst._migratedToTree) return;   // 批四·已归官制树→岁支旧账停走(俸给改循官制 calcSalary·flag 关时无此标记=零回归)
-      if (isFiscalYear && G.guoku) {
-        if (G.guoku.money >= inst.annualBudget) {
-          G.guoku.money -= inst.annualBudget;
+      if (isFiscalYear) {
+        var fiscal = global.FiscalEngine;
+        var annualPayment = fiscal && typeof fiscal.trySpendFromGuoku === 'function'
+          ? fiscal.trySpendFromGuoku({
+              amounts: { money: inst.annualBudget },
+              sinkTag: '诏令·机构年度拨款·' + inst.name,
+              gameRef: G,
+              requireFullAmount: true
+            })
+          : { ok: false, code: 'fiscal-engine-unavailable' };
+        if (annualPayment && annualPayment.ok === true) {
           inst.stage = 'running';
         } else {
           inst.stage = 'underfunded';

--- a/web/tm-fiscal-engine.js
+++ b/web/tm-fiscal-engine.js
@@ -2082,9 +2082,176 @@
     return { ok: true, deducted: out };
   }
 
+  function _readFiniteNonNegativeAmount(value, field) {
+    if (value == null || value === '') return { ok: true, value: 0 };
+    var parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      return { ok: false, code: 'invalid-fiscal-amount', field: field, value: value };
+    }
+    return { ok: true, value: parsed };
+  }
+
+  // 固定支出入口：先验证全部资源和余额，再一次性落账。资金不足时不发生“有多少扣多少”。
+  function trySpendFromGuoku(spec) {
+    spec = spec || {};
+    var G = getGame(spec.gameRef);
+    if (!G) return { ok: false, code: 'no-game-state' };
+    var requested = spec.amounts || {};
+    var normalized = {};
+    var kinds = ['money', 'grain', 'cloth'];
+    for (var i = 0; i < kinds.length; i++) {
+      var parsed = _readFiniteNonNegativeAmount(requested[kinds[i]], 'amounts.' + kinds[i]);
+      if (!parsed.ok) return parsed;
+      normalized[kinds[i]] = parsed.value;
+    }
+
+    var snapshot = _captureFiscalTransaction(G, ['guoku']);
+    try {
+      var L = ensureGuoku(G);
+      reconcileLedgerScalar(L.money, G.guoku.money, G.guoku.balance);
+      reconcileLedgerScalar(L.grain, G.guoku.grain, null);
+      reconcileLedgerScalar(L.cloth, G.guoku.cloth, null);
+      var available = {
+        money: safeNumber(L.money.stock, 0),
+        grain: safeNumber(L.grain.stock, 0),
+        cloth: safeNumber(L.cloth.stock, 0)
+      };
+      if (spec.requireFullAmount !== false) {
+        for (var a = 0; a < kinds.length; a++) {
+          var kind = kinds[a];
+          if (available[kind] < normalized[kind]) {
+            _restoreFiscalTransaction(G, snapshot);
+            return {
+              ok: false,
+              code: 'insufficient-guoku-' + kind,
+              resource: kind,
+              required: normalized[kind],
+              available: available[kind]
+            };
+          }
+        }
+      }
+
+      var deducted = {};
+      var deficits = {};
+      for (var d = 0; d < kinds.length; d++) {
+        var resource = kinds[d];
+        var result = normalized[resource] > 0
+          ? deductFromLedger(L[resource], normalized[resource], spec.sinkTag || '支出')
+          : { deducted: 0, deficit: 0 };
+        deducted[resource] = result.deducted;
+        deficits[resource] = result.deficit;
+      }
+      if (typeof spec._faultInjector === 'function') spec._faultInjector('after-deduct', G, deducted);
+      syncAccountScalars(G.guoku, L);
+      if (typeof spec._faultInjector === 'function') spec._faultInjector('after-sync', G, deducted);
+      return { ok: true, deducted: deducted, deficits: deficits };
+    } catch (error) {
+      _restoreFiscalTransaction(G, snapshot);
+      return {
+        ok: false,
+        code: 'guoku-spend-transaction-failed',
+        error: error && error.message ? error.message : String(error)
+      };
+    }
+  }
+
+  function _ensureRegionTransferAudit(regionFiscal) {
+    if (!regionFiscal.ledgerAudit || typeof regionFiscal.ledgerAudit !== 'object') regionFiscal.ledgerAudit = {};
+    if (!regionFiscal.ledgerAudit.money || typeof regionFiscal.ledgerAudit.money !== 'object') {
+      regionFiscal.ledgerAudit.money = { thisTurnIn: 0, thisTurnOut: 0, sources: {}, sinks: {}, history: [] };
+    }
+    var audit = regionFiscal.ledgerAudit.money;
+    if (!Number.isFinite(Number(audit.thisTurnIn))) audit.thisTurnIn = 0;
+    if (!Number.isFinite(Number(audit.thisTurnOut))) audit.thisTurnOut = 0;
+    if (!audit.sources || typeof audit.sources !== 'object') audit.sources = {};
+    if (!audit.sinks || typeof audit.sinks !== 'object') audit.sinks = {};
+    if (!Array.isArray(audit.history)) audit.history = [];
+    return audit;
+  }
+
+  function _restoreObjectInPlace(target, snapshot) {
+    Object.keys(target || {}).forEach(function(key) {
+      if (!Object.prototype.hasOwnProperty.call(snapshot || {}, key)) delete target[key];
+    });
+    Object.keys(snapshot || {}).forEach(function(key) {
+      target[key] = snapshot[key];
+    });
+  }
+
+  // 地方留存 → 中央国库原子转账。地方仍保留旧式 numeric ledger，审计明细另存 ledgerAudit。
+  function transferRegionToGuokuAtomic(spec) {
+    spec = spec || {};
+    var G = getGame(spec.gameRef);
+    if (!G) return { ok: false, code: 'no-game-state' };
+    var regionId = String(spec.regionId || '').trim();
+    if (!regionId) return { ok: false, code: 'region-id-required' };
+    var amountResult = _readFiniteNonNegativeAmount(spec.amount, 'amount');
+    if (!amountResult.ok) return amountResult;
+    if (!G.fiscal || !G.fiscal.regions || !G.fiscal.regions[regionId]) {
+      return { ok: false, code: 'region-fiscal-not-found', regionId: regionId };
+    }
+    var rf = G.fiscal.regions[regionId];
+    if (!rf.ledgers || typeof rf.ledgers !== 'object') {
+      return { ok: false, code: 'region-ledger-missing', regionId: regionId };
+    }
+    var availableResult = _readFiniteNonNegativeAmount(rf.ledgers.money, 'region.' + regionId + '.ledgers.money');
+    if (!availableResult.ok) return availableResult;
+
+    var requested = amountResult.value;
+    var actual = Math.min(requested, availableResult.value);
+    if (requested === 0) {
+      return { ok: true, changed: false, requested: 0, actual: 0, actualAmount: 0, limitedBySource: false };
+    }
+
+    var guokuSnapshot = _captureFiscalTransaction(G, ['guoku']);
+    var regionSnapshot = clone(rf);
+    var sourceTag = spec.sourceTag || '地方上解';
+    try {
+      rf.ledgers.money = availableResult.value - actual;
+      var audit = _ensureRegionTransferAudit(rf);
+      audit.thisTurnOut = safeNumber(audit.thisTurnOut, 0) + actual;
+      audit.sinks[sourceTag] = safeNumber(audit.sinks[sourceTag], 0) + actual;
+      audit.history.push({
+        turn: Number(G.turn || 0),
+        direction: 'to-guoku',
+        amount: actual,
+        tag: sourceTag
+      });
+      if (audit.history.length > 60) audit.history.splice(0, audit.history.length - 60);
+      if (rf.annualReport && typeof rf.annualReport === 'object') {
+        rf.annualReport.remitted = safeNumber(rf.annualReport.remitted, 0) + actual;
+      }
+      if (typeof spec._faultInjector === 'function') spec._faultInjector('after-region-deduct', G, rf);
+
+      var credit = addToGuoku({ money: actual }, sourceTag, G);
+      if (!credit || credit.ok !== true) throw new Error('guoku credit failed');
+      if (typeof spec._faultInjector === 'function') spec._faultInjector('after-guoku-credit', G, rf);
+      return {
+        ok: true,
+        changed: actual > 0,
+        requested: requested,
+        actual: actual,
+        actualAmount: actual,
+        limitedBySource: actual < requested,
+        deducted: { money: actual },
+        credited: { money: actual }
+      };
+    } catch (error) {
+      _restoreFiscalTransaction(G, guokuSnapshot);
+      _restoreObjectInPlace(rf, regionSnapshot);
+      return {
+        ok: false,
+        code: 'region-guoku-transfer-failed',
+        regionId: regionId,
+        error: error && error.message ? error.message : String(error)
+      };
+    }
+  }
+
   // 入账（#25·外交收贡/赔款/互市之利等 → 国库）·镜像 spendFromGuoku·走 ledger.stock + thisTurnIn + sources + 同步 balance/money
-  function addToGuoku(amounts, sourceTag) {
-    var G = getGame();
+  function addToGuoku(amounts, sourceTag, gameRef) {
+    var G = getGame(gameRef);
     if (!G) return { ok: false, reason: 'no GM' };
     amounts = amounts || {};
     var L = ensureGuoku(G);
@@ -2214,7 +2381,9 @@
     adjustPlayerDivisionCorruption: adjustPlayerDivisionCorruption,
     triggerPlayerSurvey: triggerPlayerSurvey,
     spendFromGuoku: spendFromGuoku,
+    trySpendFromGuoku: trySpendFromGuoku,
     addToGuoku: addToGuoku,
+    transferRegionToGuokuAtomic: transferRegionToGuokuAtomic,
     spendFromNeitang: spendFromNeitang,
     addToNeitang: addToNeitang,
     applyPlayerTaxReform: applyPlayerTaxReform,


### PR DESCRIPTION
## Scope
- add full-amount treasury spending and atomic region-to-guoku transfer APIs
- route levy, investigation, institution creation, and annual funding through FiscalEngine
- preserve balance === money === ledgers.money.stock and source/sink audit trails
- keep insufficient funds and fault injection all-or-nothing

## Gameplay contract
This PR intentionally adopts the auditable levy rule:
- a forced levy can transfer only money actually present in the regional ledger
- the actual transferred amount is credited in full to the central treasury
- requests above the regional balance are source-limited and report limitedBySource
- no implicit 20% loss, corruption, or transport sink is applied

This is a fiscal consistency fix plus an explicit replacement of the previous implicit levy-loss behavior.

## Verification
- smoke-edict-fiscal-ledger-integrity.js: 27 assertions
- relevant ledger/policy regressions passed
- architecture guards passed locally and on PR CI

No package, release, or deployment was executed.