### PR TITLE
fix: enforce population schema and transfer invariants

### DIFF
--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -3391,8 +3391,8 @@
     },
     {
       "path": "startup-script-phases.json",
-      "sha256": "b717430904971dd1f8d1599192ec98c81e01386b1e36cff637526aab794fa1ee",
-      "size": 345220
+      "sha256": "2589a6825ab4fe8c9bd184bd121c2129548efb65a5f60c070c205093f835a876",
+      "size": 345234
     },
     {
       "path": "styles.css",

--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-08-27T17:34:37.160Z",
+  "generatedAt": "2026-08-27T17:37:26.415Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -2171,8 +2171,8 @@
     },
     {
       "path": "index.html",
-      "sha256": "9281f386efd220be924dff284509c11e9f85e3969a8ce4de2da19402bbc807de",
-      "size": 69163
+      "sha256": "af2ddaeff8eb6c22e0b5fc65532b5fa514836c7cbb29bb47e1bbc2b1979bfea9",
+      "size": 69181
     },
     {
       "path": "INDEX.md",
@@ -3496,8 +3496,8 @@
     },
     {
       "path": "tm-authority-complete.js",
-      "sha256": "a951e0b9a1f2e5a857776920554c765f8ccc2bfce97d5662ce7bf829bb029444",
-      "size": 83358
+      "sha256": "ed612b8754e1eefbbc5c3c5be19b92babb9bff6219b436cd6080b465a51e3ff4",
+      "size": 84477
     },
     {
       "path": "tm-authority-deep.js",
@@ -3881,8 +3881,8 @@
     },
     {
       "path": "tm-edict-parser.js",
-      "sha256": "8643bb4a23cb25358b620dfcac2c038a9c87cd373632d2879ccec8e2e3292be4",
-      "size": 115345
+      "sha256": "1b1571d659729ac58511bd14b85f000be55d9b00c7305d24d4a6f523a09cd4c8",
+      "size": 115977
     },
     {
       "path": "tm-edict-thresholds.js",
@@ -4361,8 +4361,8 @@
     },
     {
       "path": "tm-huji-engine.js",
-      "sha256": "000d8801f493d0caaa386c670b8ae91baaccf106f40a72758990b29e34fd1a80",
-      "size": 128544
+      "sha256": "f5211b9f57f8620e1bde980b5c7e41fcd4043fe725037c97c6e1e3731e28a0f8",
+      "size": 143047
     },
     {
       "path": "tm-huji-governance-loop.js",
@@ -5151,8 +5151,8 @@
     },
     {
       "path": "tm-save-lifecycle.js",
-      "sha256": "31a685c4b88815843c6e9d99ed51ba10eef34e9a382c7e51008f17bec62dc5f3",
-      "size": 166122
+      "sha256": "29cf86690f09ec924c62a2be53590374849eb9bb5cf0fab825dee98211cfc657",
+      "size": 166630
     },
     {
       "path": "tm-save-manager.js",

--- a/web/index.html
+++ b/web/index.html
@@ -847,7 +847,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-bgm-config.js?v=2026051201"></script>
 <!-- R131 (2026-04-25) tm-audio-theme.js 拆分 → audio-theme + save-lifecycle + office-editor -->
 <script src="tm-audio-theme.js?v=20260710-fontscale"></script>
-<script src="tm-save-lifecycle.js?v=20260823-auditfix18-autosave"></script>
+<script src="tm-save-lifecycle.js?v=20260828-population-schema"></script>
 <script src="tm-save-close-flush.js?v=20260825-close-drain"></script><!-- 必须紧随 save-lifecycle：应用退出前排空 canonical + 桌面镜像 -->
 <script src="tm-office-editor.js?v=20260707-nestflat2"></script>
 <script src="tm-topbar-vars.js?v=20260514-phase8-vars-2"></script>
@@ -885,8 +885,8 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-economy-engine-currency.js?v=20260828-edictledger"></script><!-- 立项拆分：§A CurrencyUnit+§B CurrencyEngine 两整IIFE·紧挨 economy-engine 之前保序·勿动位置 -->
 <script src="tm-economy-engine.js?v=20260828-edictledger"></script>
 <script src="tm-central-local-engine.js?v=20260709"></script>
-<script src="tm-huji-engine.js?v=20260822-auditfix16"></script>
-<script src="tm-edict-parser.js?v=20260828-edictledger"></script>
+<script src="tm-huji-engine.js?v=20260828-population-schema"></script>
+<script src="tm-edict-parser.js?v=20260828-population-schema"></script>
 <script src="tm-huji-deep-fill.js?v=20260822-auditfix14"></script>
 <script src="tm-huji-runtime-bridge.js?v=20260822-auditfix17"></script>
 <script src="tm-huji-governance-loop.js?v=20260602-huji-governance-loop"></script>
@@ -903,7 +903,7 @@ console.log('天命游戏脚本开始加载...');
 <script src="tm-renli.js?v=20260616"></script>
 <script src="tm-reported-view.js?v=20260711"></script><!-- 奏报失真层核心引擎(S1·真值vs据奏·纯推导不落库·严格史实+开关双gate·docs/design-reported-view-2026-07.md) -->
 <script src="tm-social-foundation.js?v=20260612"></script>
-<script src="tm-authority-complete.js?v=20260623-ledgerflow"></script>
+<script src="tm-authority-complete.js?v=20260828-population-schema"></script>
 <script src="tm-revolt-entity.js?v=20260721"></script><!-- R2民变实体镜像·flag revoltEntityEnabled 默认OFF·爬梯level≥3具象化势力/渠帅/军队三件套 -->
 <script src="tm-revolt-inference.js?v=20260721b"></script><!-- 批三·民变演绎层(AI主导)·起号立领袖subcall+逐回合行为subcall(打/占/分合/建国/招抚谈判)·宪法闸落账·AI缺席模板兜底 -->
 <script src="tm-party-inference.js?v=20260722"></script><!-- 批乙·党派/阶层演绎层(AI主导)·forgeIdentity立身份+tickInference逐回合党派行动(联名/清议/杯葛/结盟交恶/议程转向/倒阁/煽动阶层)·宪法闸落账·flag partyInferenceEnabled默认ON·AI缺席模板兜底 -->

--- a/web/scripts/smoke-population-transfer-invariants.js
+++ b/web/scripts/smoke-population-transfer-invariants.js
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.resolve(__dirname, '..');
+const lifecycleSource = fs.readFileSync(path.join(ROOT, 'tm-save-lifecycle.js'), 'utf8');
+const edictSource = fs.readFileSync(path.join(ROOT, 'tm-edict-parser.js'), 'utf8');
+const authoritySource = fs.readFileSync(path.join(ROOT, 'tm-authority-complete.js'), 'utf8');
+
+let passed = 0;
+function assert(condition, message) {
+  if (!condition) throw new Error('[smoke-population-transfer-invariants] ' + message);
+  passed++;
+}
+
+const hujiSource = fs.readFileSync(path.join(ROOT, 'tm-huji-engine.js'), 'utf8');
+const schemaStart = hujiSource.indexOf('function _populationSchemaFailure');
+const schemaEnd = hujiSource.indexOf('\n  // ═══════════════════════════════════════════════════════════════════\n  //  朝代默认参数', schemaStart);
+assert(schemaStart >= 0 && schemaEnd > schemaStart, 'population schema owner is locatable in huji engine');
+
+const context = {
+  console,
+  Number,
+  Math,
+  Date,
+  Array,
+  Object,
+  String,
+  Error,
+  JSON,
+  RegExp,
+  Promise,
+  setTimeout,
+  clearTimeout,
+  TM: {}
+};
+context.window = context;
+context.global = context;
+vm.createContext(context);
+vm.runInContext(hujiSource.slice(schemaStart, schemaEnd), context, {
+  filename: 'tm-huji-population-schema.js'
+});
+
+const schema = context.TM.PopulationSchema;
+assert(schema && typeof schema.normalize === 'function' && typeof schema.transferCategory === 'function', 'central population schema API is installed');
+
+const unchanged = {
+  turn: 2,
+  population: {
+    national: { mouths: 300, households: 60 },
+    hiddenCount: 4,
+    fugitives: 5,
+    byCategory: { bianhu: { mouths: 200 }, junhu: { mouths: 100 } }
+  }
+};
+schema.normalize(unchanged, { source: 'smoke', allowLegacyNumericStrings: true });
+assert(unchanged.population.national.mouths === 300 && unchanged.population.national.households === 60, 'normal save population values remain unchanged');
+
+const missing = { turn: 3 };
+schema.normalize(missing, {
+  source: 'smoke-missing',
+  allowLegacyNumericStrings: true,
+  defaults: { nationalMouths: 5200, nationalHouseholds: 1000, hiddenPopulation: 12, nationalFugitives: 7 }
+});
+assert(missing.population.national.mouths === 5200 && missing.population.national.households === 1000, 'missing population receives scenario-backed national defaults');
+assert(missing.population.hiddenCount === 12 && missing.population.fugitives === 7, 'missing hidden and fugitive counters receive explicit defaults');
+assert(Array.isArray(missing._schemaNormalizationDiagnostics) && missing._schemaNormalizationDiagnostics.length > 0, 'safe population repairs remain diagnosable');
+
+const missingNational = {
+  population: {
+    hiddenCount: 0,
+    fugitives: 0,
+    byCategory: { a: { mouths: 70, households: 14 }, b: { mouths: 30, households: 6 } }
+  }
+};
+schema.normalize(missingNational, { source: 'smoke-derived', allowLegacyNumericStrings: true });
+assert(missingNational.population.national.mouths === 100 && missingNational.population.national.households === 20, 'missing national summary is safely derived from category rows');
+
+const legacyStrings = {
+  population: {
+    national: { mouths: '100000', households: '20000' },
+    hiddenCount: '300',
+    fugitives: '400',
+    byCategory: { bianhu: { mouths: '90000' }, junhu: { mouths: '10000' } }
+  }
+};
+schema.normalize(legacyStrings, { source: 'smoke-legacy', allowLegacyNumericStrings: true });
+assert(legacyStrings.population.national.mouths === 100000 && legacyStrings.population.byCategory.junhu.mouths === 10000, 'legacy numeric strings migrate to finite numbers');
+
+const legacyCategoryHouseholds = {
+  population: {
+    national: { mouths: 100, households: 20 },
+    hiddenCount: 0,
+    fugitives: 0,
+    byCategory: { bianhu: { mouths: '100', households: '20.9' } }
+  }
+};
+schema.normalize(legacyCategoryHouseholds, {
+  source: 'smoke-category-households',
+  allowLegacyNumericStrings: true
+});
+assert(legacyCategoryHouseholds.population.byCategory.bianhu.households === 20, 'category household numeric strings normalize in place under the integer population contract');
+assert(legacyCategoryHouseholds._schemaNormalizationDiagnostics.some(function(row) {
+  return row.field === 'population.byCategory.bianhu.households' && row.action === 'normalize-number';
+}), 'category household normalization remains diagnosable');
+assert(schema.validate(legacyCategoryHouseholds).ok === true, 'normalized category household values pass strict runtime validation');
+
+for (const [label, value] of [
+  ['NaN category households', NaN],
+  ['negative category households', -1],
+  ['invalid category household string', 'bad']
+]) {
+  const invalidHouseholds = {
+    population: {
+      national: { mouths: 100, households: 20 },
+      hiddenCount: 0,
+      fugitives: 0,
+      byCategory: { bianhu: { mouths: 100, households: value } }
+    }
+  };
+  assert(schema.validate(invalidHouseholds, { allowLegacyNumericStrings: true }).ok === false, label + ' fail validation');
+  let normalizeFailed = false;
+  try {
+    schema.normalize(invalidHouseholds, { source: 'smoke-invalid-households', allowLegacyNumericStrings: true });
+  } catch (error) {
+    normalizeFailed = error && error.code === 'invalid-population-value';
+  }
+  assert(normalizeFailed, label + ' are rejected at the normalization boundary');
+}
+
+for (const [label, value] of [
+  ['undefined', undefined],
+  ['NaN', NaN],
+  ['nonnumeric string', 'not-a-number'],
+  ['negative', -1]
+]) {
+  const result = schema.finiteNonNegative(value, 'count', { allowLegacyNumericStrings: true });
+  assert(result.ok === false && result.code === 'invalid-population-value', label + ' is rejected instead of becoming zero or NaN');
+}
+
+let transferWorld = {
+  national: { mouths: 150, households: 30 },
+  hiddenCount: 0,
+  fugitives: 0,
+  byCategory: { source: { mouths: 100 }, target: { mouths: 50 } }
+};
+const beforeTotal = transferWorld.byCategory.source.mouths + transferWorld.byCategory.target.mouths;
+const limited = schema.transferCategory(transferWorld, {
+  from: 'source', to: 'target', count: 1000, allowLegacyNumericStrings: true
+});
+assert(limited.ok && limited.actual === 100 && limited.requested === 1000 && limited.limitedBySource === true, 'over-large transfer is source-limited with a structured result');
+assert(transferWorld.byCategory.source.mouths === 0 && transferWorld.byCategory.target.mouths === 150, 'source-limited transfer moves only available people');
+assert(transferWorld.byCategory.source.mouths + transferWorld.byCategory.target.mouths === beforeTotal, 'category transfer conserves total population exactly');
+
+const sameRow = { byCategory: { source: { mouths: 100 } } };
+const same = schema.transferCategory(sameRow, {
+  from: 'source', to: 'source', count: 50, allowLegacyNumericStrings: true
+});
+assert(same.ok && same.changed === false && same.actual === 0 && sameRow.byCategory.source.mouths === 100, 'same-category transfer is an explicit no-op');
+
+const numericStrings = { byCategory: { source: { mouths: '20' }, target: { mouths: '5' } } };
+const migratedTransfer = schema.transferCategory(numericStrings, {
+  from: 'source', to: 'target', count: '7', allowLegacyNumericStrings: true
+});
+assert(migratedTransfer.ok && migratedTransfer.actual === 7 && numericStrings.byCategory.source.mouths === 13 && numericStrings.byCategory.target.mouths === 12, 'legacy numeric-string transfer is normalized and conserved');
+
+for (const [label, sourceValue, targetValue, count] of [
+  ['undefined source', undefined, 10, 1],
+  ['NaN target', 10, NaN, 1],
+  ['invalid request string', 10, 10, 'bad'],
+  ['negative request', 10, 10, -2]
+]) {
+  const population = { byCategory: { source: { mouths: sourceValue }, target: { mouths: targetValue } } };
+  const sourceBefore = population.byCategory.source.mouths;
+  const targetBefore = population.byCategory.target.mouths;
+  const result = schema.transferCategory(population, {
+    from: 'source', to: 'target', count, allowLegacyNumericStrings: true
+  });
+  assert(result.ok === false && result.code === 'invalid-category-transfer-data', label + ' returns a structured failure');
+  assert(Object.is(population.byCategory.source.mouths, sourceBefore) && Object.is(population.byCategory.target.mouths, targetBefore), label + ' does not partially mutate either category');
+}
+
+context.addEB = function() {};
+context.GM = {
+  population: {
+    national: { mouths: 100, households: 20 },
+    hiddenCount: 0,
+    fugitives: 0,
+    byCategory: { bianhu: { mouths: 80 }, junhu: { mouths: 20 } },
+    meta: {}
+  }
+};
+vm.runInContext(edictSource, context, { filename: 'tm-edict-parser.js' });
+const edictTransfer = context.EdictParser.EDICT_TYPES.huji_reform.aiEntry({
+  action: 'change_category', fromCategory: 'bianhu', toCategory: 'junhu', count: 1000
+});
+assert(edictTransfer.ok && edictTransfer.actual === 80 && edictTransfer.limitedBySource, 'edict category change returns the canonical structured transfer result');
+assert(context.GM.population.byCategory.bianhu.mouths + context.GM.population.byCategory.junhu.mouths === 100, 'edict category change preserves the category total');
+
+const linkageStart = authoritySource.indexOf('function _linkageFiscalFlow');
+const linkageEnd = authoritySource.indexOf('\n  // ═══════════════════════════════════════════════════════════════════\n  //  P2-16', linkageStart);
+assert(linkageStart >= 0 && linkageEnd > linkageStart, 'authority population linkage is locatable');
+context._corrIndex = function() { return 30; };
+context._addCorrIndex = function() {};
+context._allowPassiveAuthorityLinkage = function() { return false; };
+let capturedSchemaErrors = 0;
+context.TM.errors = { capture() { capturedSchemaErrors++; } };
+vm.runInContext(authoritySource.slice(linkageStart, linkageEnd), context, {
+  filename: 'tm-authority-population-linkage.js'
+});
+
+context.GM = {
+  turn: 4,
+  neitang: { money: 4000000, balance: 4000000, ledgers: { money: { stock: 4000000, sources: {}, sinks: {}, thisTurnIn: 0, thisTurnOut: 0 } } },
+  population: { national: { mouths: NaN, households: 20 }, hiddenCount: 0, fugitives: 0, byCategory: {} },
+  huangquan: { index: 30 }
+};
+const purseBeforeInvalid = context.GM.neitang.money;
+context._tickFullLinkage({}, 1);
+assert(context.GM.neitang.money === purseBeforeInvalid && Number.isNaN(context.GM.population.national.mouths), 'invalid mouths skip grain-gift fiscal and population writes instead of propagating NaN');
+assert(context.GM._populationSchemaDiagnostics.length === 1 && capturedSchemaErrors === 1, 'runtime population corruption emits bounded diagnostics');
+
+context.GM = {
+  turn: 5,
+  neitang: { money: 4000000, balance: 4000000, ledgers: { money: { stock: 4000000, sources: {}, sinks: {}, thisTurnIn: 0, thisTurnOut: 0 } } },
+  population: { hiddenCount: 7, fugitives: 0, byCategory: {} },
+  huangquan: { index: 30 }
+};
+context._tickFullLinkage({}, 1);
+assert(context.GM.population.hiddenCount === 7, 'missing national object does not crash or update weak-authority population linkage');
+
+context.GM = {
+  turn: 6,
+  neitang: { money: 4000000, balance: 4000000, ledgers: { money: { stock: 4000000, sources: {}, sinks: {}, thisTurnIn: 0, thisTurnOut: 0 } } },
+  population: { national: { mouths: 100000, households: 20000 }, hiddenCount: 0, fugitives: 0, byCategory: {} },
+  huangquan: { index: 30 }
+};
+context._tickFullLinkage({}, 1);
+assert(Number.isFinite(context.GM.population.national.mouths) && context.GM.population.national.mouths > 100000, 'valid grain gift adds a finite population amount');
+assert(context.GM.neitang.money < 4000000 && context.GM.population.hiddenCount > 0, 'valid linkage updates both grain-gift spending and weak-authority hidden population');
+
+assert(/populationSchema\.normalize\(GM,/.test(lifecycleSource), 'load/save default boundary invokes population normalization');
+assert(/_normalizePopulationBoundary\(G, 'huji-new-game'/.test(hujiSource), 'new-game huji initialization invokes the same population schema');
+
+console.log('[smoke-population-transfer-invariants] pass assertions=' + passed);

--- a/web/scripts/smoke-save-integrity-audit.js
+++ b/web/scripts/smoke-save-integrity-audit.js
@@ -11,6 +11,7 @@ const vm = require('vm');
 const ROOT = path.resolve(__dirname, '..', '..');
 const main = fs.readFileSync(path.join(ROOT, 'main-impl.js'), 'utf8');
 const lifecycle = fs.readFileSync(path.join(ROOT, 'web', 'tm-save-lifecycle.js'), 'utf8');
+const huji = fs.readFileSync(path.join(ROOT, 'web', 'tm-huji-engine.js'), 'utf8');
 const storage = fs.readFileSync(path.join(ROOT, 'web', 'tm-storage.js'), 'utf8');
 let pass = 0;
 function ok(cond, msg) { if (!cond) throw new Error('FAIL: ' + msg); pass++; console.log('  ok - ' + msg); }
@@ -108,7 +109,13 @@ console.log('=== save integrity audit ===');
   const gmBefore = JSON.stringify(ctx.GM);
   const pBefore = JSON.stringify(ctx.P);
   vm.createContext(ctx);
-  vm.runInContext(stableIdHelpers + '\n' + lifecycle.slice(blockStart, blockEnd) + '\n' + snapshot + '\n' + builder
+  const populationSchemaStart = huji.indexOf('function _populationSchemaFailure(');
+  const populationSchemaEnd = huji.indexOf('// ═══════════════════════════════════════════════════════════════════', populationSchemaStart);
+  ok(populationSchemaStart >= 0 && populationSchemaEnd > populationSchemaStart,
+    '存档审计加载 production PopulationSchema provider');
+  const populationSchema = '(function(global){"use strict";\n'
+    + huji.slice(populationSchemaStart, populationSchemaEnd) + '\n})(window);';
+  vm.runInContext(populationSchema + '\n' + stableIdHelpers + '\n' + lifecycle.slice(blockStart, blockEnd) + '\n' + snapshot + '\n' + builder
     + '\nthis.OUT=_buildSaveState({format:"idb"});', ctx);
   ok(JSON.stringify(ctx.GM) === gmBefore && JSON.stringify(ctx.P) === pBefore, '完整存档准备不修改 live GM/P');
   ok(!('_postTurnJobs' in ctx.OUT.GM) && ctx.GM._postTurnJobs.pending === true, '临时任务只从快照删除');

--- a/web/startup-script-phases.json
+++ b/web/startup-script-phases.json
@@ -9036,7 +9036,8 @@
       "platform": "any",
       "sideEffects": "legacy-unknown",
       "provides": [
-        "HujiEngine"
+        "HujiEngine",
+        "TM"
       ],
       "consumes": [],
       "dependsOn": [],

--- a/web/tm-authority-complete.js
+++ b/web/tm-authority-complete.js
@@ -1392,14 +1392,46 @@
     return applied;
   }
 
+  function _populationForFullLinkage(G) {
+    var schema = global.TM && global.TM.PopulationSchema;
+    var validation;
+    if (schema && typeof schema.validate === 'function') {
+      validation = schema.validate(G);
+    } else {
+      var population = G && G.population;
+      var national = population && population.national;
+      var fields = [
+        population && population.hiddenCount,
+        population && population.fugitives,
+        national && national.mouths,
+        national && national.households
+      ];
+      var ok = !!(population && typeof population === 'object' && national && typeof national === 'object' &&
+        population.byCategory && typeof population.byCategory === 'object' &&
+        fields.every(function(value) { return typeof value === 'number' && Number.isFinite(value) && value >= 0; }));
+      validation = ok ? { ok: true, population: population, failures: [] } : {
+        ok: false,
+        failures: [{ code: 'population-schema-invalid', field: 'population.national' }]
+      };
+    }
+    if (!validation.ok) {
+      if (schema && typeof schema.reportRuntimeFailure === 'function') {
+        schema.reportRuntimeFailure(G, 'authority-linkage', validation);
+      }
+      return null;
+    }
+    return validation.population;
+  }
+
   function _tickFullLinkage(ctx, mr) {
     var G = global.GM;
+    var population = _populationForFullLinkage(G);
 
     // 内帑 → 户口（内帑充盈可赐廪，户增）
-    if (G.neitang && G.neitang.money > 3000000 && G.population && G.population.national) {
+    if (G.neitang && G.neitang.money > 3000000 && population) {
       var benefit = G.neitang.money * 0.001 * mr / 12;
       _linkageFiscalFlow(G.neitang, -benefit, '赐廪养民');
-      G.population.national.mouths = Math.min(500000000, G.population.national.mouths + benefit * 0.1);
+      population.national.mouths = Math.min(500000000, Math.floor(population.national.mouths + benefit * 0.1));
     }
     // 内帑 → 皇权（丰厚时内帑支持宦官）
     if (G.neitang && G.neitang.money > 5000000 && G.huangquan) {
@@ -1411,17 +1443,17 @@
     }
 
     // 户口 → 内帑（皇庄进项）
-    if (G.population && G.population.byCategory && G.population.byCategory.huangzhuang && G.neitang) {
-      var huangzhuangMouths = G.population.byCategory.huangzhuang.mouths || 0;
+    if (population && population.byCategory.huangzhuang && G.neitang) {
+      var huangzhuangMouths = population.byCategory.huangzhuang.mouths;
       _linkageFiscalFlow(G.neitang, huangzhuangMouths * 0.3 * mr / 12, '皇庄进项');
     }
     // 户口 → 腐败（冗员多则腐败增）
-    if (G.population && G.population.byCategory && G.population.byCategory.ruhu && G.corruption && typeof G.corruption === 'object') {
-      var ruhu = G.population.byCategory.ruhu.mouths || 0;
+    if (population && population.byCategory.ruhu && G.corruption && typeof G.corruption === 'object') {
+      var ruhu = population.byCategory.ruhu.mouths;
       if (ruhu > 1000000) _addCorrIndex(G, 0.03 * mr);
     }
     // 户口 → 皇权（大人口需强管制）
-    if (G.population && G.population.national && G.population.national.mouths > 200000000) {
+    if (population && population.national.mouths > 200000000) {
       if (typeof global.AuthorityEngines !== 'undefined') global.AuthorityEngines.adjustHuangquan('idleGovern', -0.05 * mr, '人口繁巨');
     }
 
@@ -1432,8 +1464,8 @@
     }
 
     // 民心 → 户口（高民心 → 户口繁盛）
-    if (G.minxin && G.minxin.trueIndex > 70 && G.population && G.population.national) {
-      G.population.national.households = Math.round(G.population.national.households * (1 + 0.0003 * mr / 12));
+    if (G.minxin && G.minxin.trueIndex > 70 && population) {
+      population.national.households = Math.round(population.national.households * (1 + 0.0003 * mr / 12));
     }
     // 民心 → 腐败（高民心 → 举报多 → 腐败曝光）
     if (G.minxin && G.minxin.trueIndex > 80 && G.corruption && typeof G.corruption === 'object') {
@@ -1449,8 +1481,8 @@
       _linkageFiscalFlow(G.neitang, Math.max(0, (G.huangquan.index - 70)) * 50 * mr / 12, '皇权·内帑充实');
     }
     // 皇权 → 户口（弱皇权 → 户口失控）
-    if (G.huangquan && G.huangquan.index < 40 && G.population) {
-      G.population.hiddenCount = (G.population.hiddenCount || 0) + Math.round(G.population.national.households * 0.0002 * mr);
+    if (G.huangquan && G.huangquan.index < 40 && population) {
+      population.hiddenCount += Math.round(population.national.households * 0.0002 * mr);
     }
 
     // 皇威 → 帑廪（威远 → 朝贡增）
@@ -1462,8 +1494,8 @@
       _linkageFiscalFlow(G.neitang, -(10000 * mr), '暴君挥霍');
     }
     // 皇威 → 户口（威严 → 民附）
-    if (G.huangwei && G.huangwei.index > 80 && G.population) {
-      G.population.fugitives = Math.max(0, (G.population.fugitives || 0) - Math.round(G.population.national.mouths * 0.00002 * mr));
+    if (G.huangwei && G.huangwei.index > 80 && population) {
+      population.fugitives = Math.max(0, population.fugitives - Math.round(population.national.mouths * 0.00002 * mr));
     }
     // 皇威 → 腐败（失威段 → 腐败公开化）
     if (G.huangwei && G.huangwei.phase === 'lost' && G.corruption && typeof G.corruption === 'object') {

--- a/web/tm-edict-parser.js
+++ b/web/tm-edict-parser.js
@@ -963,13 +963,24 @@
         if (action === 'change_category' || action === '转色目') {
           var from = params.fromCategory || 'bianhu';
           var to = params.toCategory;
-          var count = params.count || 10000;
-          if (P.byCategory[from] && P.byCategory[to]) {
-            P.byCategory[from].mouths = Math.max(0, P.byCategory[from].mouths - count);
-            P.byCategory[to].mouths += count;
-            if (global.addEB) global.addEB('户籍', count + ' 口由 ' + from + ' 转 ' + to);
-            return true;
+          var count = params.count === undefined || params.count === null ? 10000 : params.count;
+          var populationSchema = global.TM && global.TM.PopulationSchema;
+          if (!populationSchema || typeof populationSchema.transferCategory !== 'function') {
+            return { ok: false, code: 'population-schema-unavailable' };
           }
+          var transfer = populationSchema.transferCategory(P, {
+            from: from,
+            to: to,
+            count: count,
+            allowLegacyNumericStrings: true
+          });
+          if (transfer.ok) {
+            if (global.addEB && transfer.changed) {
+              global.addEB('户籍', transfer.actual + ' 口由 ' + from + ' 转 ' + to);
+            }
+            return transfer;
+          }
+          return transfer;
         }
         // 清查隐户
         if (action === 'purge_hidden' || action === '清查隐户') {
@@ -1338,12 +1349,15 @@
     var type = EDICT_TYPES[cls.typeKey];
     if (!type || !type.aiEntry) return { ok: false, reason: '类型无执行入口' };
     var exec = false;
+    var execOk = false;
     try {
       var execParams = Object.assign({ _edictText: text, _edictContext: ctx || {}, _classification: cls }, params || {});
       exec = type.aiEntry(execParams);
-      if (exec && cls.typeKey === 'huji_reform') _recordEdictPolicyAction('huji', execParams.action || cls.typeKey, exec, text);
-    } catch(e) { console.error('[edict] exec', e); exec = false; }
-    return { ok: exec, pathway: 'direct', classification: cls };
+      execOk = exec && typeof exec === 'object' && Object.prototype.hasOwnProperty.call(exec, 'ok')
+        ? exec.ok === true : !!exec;
+      if (execOk && cls.typeKey === 'huji_reform') _recordEdictPolicyAction('huji', execParams.action || cls.typeKey, exec, text);
+    } catch(e) { console.error('[edict] exec', e); exec = false; execOk = false; }
+    return { ok: execOk, pathway: 'direct', classification: cls, executionResult: exec };
   }
 
   /** 将意图明确但细节不足的诏书转奏疏（二阶段） */

--- a/web/tm-huji-engine.js
+++ b/web/tm-huji-engine.js
@@ -23,6 +23,270 @@
 (function(global) {
   'use strict';
 
+  function _populationSchemaFailure(code, field, value) {
+    return { ok:false, code:code || 'invalid-population-value', field:field || '', value:value };
+  }
+
+  function _finiteNonNegativePopulation(value, field, options) {
+    options = options || {};
+    var candidate = value;
+    if (typeof candidate === 'string') {
+      if (options.allowLegacyNumericStrings !== true || candidate.trim() === '') {
+        return _populationSchemaFailure('invalid-population-value', field, value);
+      }
+      candidate = Number(candidate);
+    }
+    if (typeof candidate !== 'number' || !Number.isFinite(candidate) || candidate < 0) {
+      return _populationSchemaFailure('invalid-population-value', field, value);
+    }
+    return { ok:true, value:Math.floor(candidate), changed:candidate !== value };
+  }
+
+  function _populationSchemaError(failure, source) {
+    var error = new Error('人口 schema 无法安全迁移：' + failure.field);
+    error.code = failure.code || 'population-schema-invalid';
+    error.field = failure.field;
+    error.value = failure.value;
+    error.source = source || '';
+    return error;
+  }
+
+  function _populationInitialDefaults(gm, p) {
+    var config = p && p.populationConfig;
+    if (!config && p && p.scenario && p.scenario.populationConfig) config = p.scenario.populationConfig;
+    if (!config && typeof global.findScenarioById === 'function' && gm && gm.sid) {
+      try {
+        var scenario = global.findScenarioById(gm.sid);
+        config = scenario && scenario.populationConfig;
+      } catch (_) {}
+    }
+    return (config && config.initial && typeof config.initial === 'object') ? config.initial : {};
+  }
+
+  function _recordPopulationSchemaDiagnostics(gm, diagnostics) {
+    if (!gm || !diagnostics || !diagnostics.length) return;
+    if (!Array.isArray(gm._schemaNormalizationDiagnostics)) gm._schemaNormalizationDiagnostics = [];
+    Array.prototype.push.apply(gm._schemaNormalizationDiagnostics, diagnostics.map(function(row) {
+      return {
+        turn:Number(gm.turn) || 0,
+        field:row.field,
+        action:row.action,
+        source:row.source || 'population-schema'
+      };
+    }));
+    if (gm._schemaNormalizationDiagnostics.length > 50) {
+      gm._schemaNormalizationDiagnostics = gm._schemaNormalizationDiagnostics.slice(-50);
+    }
+  }
+
+  function _normalizePopulationSchema(gm, options) {
+    options = options || {};
+    if (!gm || typeof gm !== 'object' || Array.isArray(gm)) {
+      throw _populationSchemaError(_populationSchemaFailure('population-schema-invalid', 'GM', gm), options.source);
+    }
+    var diagnostics = [];
+    var defaults = options.defaults || _populationInitialDefaults(gm, options.p);
+    var population = gm.population;
+    if (population === undefined || population === null) {
+      population = gm.population = {};
+      diagnostics.push({ field:'population', action:'default-object', source:options.source });
+    } else if (typeof population !== 'object' || Array.isArray(population)) {
+      throw _populationSchemaError(_populationSchemaFailure('population-schema-invalid', 'population', population), options.source);
+    }
+
+    var byCategory = population.byCategory;
+    if (byCategory === undefined || byCategory === null) {
+      byCategory = population.byCategory = {};
+      diagnostics.push({ field:'population.byCategory', action:'default-object', source:options.source });
+    } else if (typeof byCategory !== 'object' || Array.isArray(byCategory)) {
+      throw _populationSchemaError(_populationSchemaFailure('population-schema-invalid', 'population.byCategory', byCategory), options.source);
+    }
+
+    var categoryMouths = 0;
+    var categoryHouseholds = 0;
+    var categoryKeys = Object.keys(byCategory);
+    categoryKeys.forEach(function(key) {
+      var row = byCategory[key];
+      var baseField = 'population.byCategory.' + key;
+      if (!row || typeof row !== 'object' || Array.isArray(row)) {
+        throw _populationSchemaError(_populationSchemaFailure('population-schema-invalid', baseField, row), options.source);
+      }
+      if (row.mouths === undefined || row.mouths === null) {
+        row.mouths = 0;
+        diagnostics.push({ field:baseField + '.mouths', action:'default-zero', source:options.source });
+      } else {
+        var mouthsResult = _finiteNonNegativePopulation(row.mouths, baseField + '.mouths', options);
+        if (!mouthsResult.ok) throw _populationSchemaError(mouthsResult, options.source);
+        if (row.mouths !== mouthsResult.value) {
+          row.mouths = mouthsResult.value;
+          diagnostics.push({ field:baseField + '.mouths', action:'normalize-number', source:options.source });
+        }
+      }
+      categoryMouths += row.mouths;
+      if (row.households !== undefined && row.households !== null) {
+        var householdsResult = _finiteNonNegativePopulation(row.households, baseField + '.households', options);
+        if (!householdsResult.ok) throw _populationSchemaError(householdsResult, options.source);
+        if (row.households !== householdsResult.value) {
+          row.households = householdsResult.value;
+          diagnostics.push({ field:baseField + '.households', action:'normalize-number', source:options.source });
+        }
+        categoryHouseholds += row.households;
+      }
+    });
+
+    var national = population.national;
+    if (national === undefined || national === null) {
+      national = population.national = {};
+      diagnostics.push({ field:'population.national', action:'default-object', source:options.source });
+    } else if (typeof national !== 'object' || Array.isArray(national)) {
+      throw _populationSchemaError(_populationSchemaFailure('population-schema-invalid', 'population.national', national), options.source);
+    }
+
+    function normalizeRequired(target, key, field, fallback) {
+      if (target[key] === undefined || target[key] === null) {
+        var fallbackResult = _finiteNonNegativePopulation(fallback, field, { allowLegacyNumericStrings:true });
+        target[key] = fallbackResult.ok ? fallbackResult.value : 0;
+        diagnostics.push({ field:field, action:'default-number', source:options.source });
+        return;
+      }
+      var result = _finiteNonNegativePopulation(target[key], field, options);
+      if (!result.ok) throw _populationSchemaError(result, options.source);
+      if (target[key] !== result.value) {
+        target[key] = result.value;
+        diagnostics.push({ field:field, action:'normalize-number', source:options.source });
+      }
+    }
+
+    var fallbackMouths = categoryKeys.length ? categoryMouths : defaults.nationalMouths;
+    normalizeRequired(national, 'mouths', 'population.national.mouths', fallbackMouths || 0);
+    var fallbackHouseholds = categoryHouseholds || defaults.nationalHouseholds;
+    if (fallbackHouseholds === undefined || fallbackHouseholds === null) {
+      fallbackHouseholds = Math.floor(national.mouths / 5.2);
+    }
+    normalizeRequired(national, 'households', 'population.national.households', fallbackHouseholds);
+    normalizeRequired(population, 'hiddenCount', 'population.hiddenCount', defaults.hiddenPopulation || 0);
+    normalizeRequired(population, 'fugitives', 'population.fugitives', defaults.nationalFugitives || 0);
+    _recordPopulationSchemaDiagnostics(gm, diagnostics);
+    return { ok:true, population:population, diagnostics:diagnostics };
+  }
+
+  function _validatePopulationSchema(gm, options) {
+    options = options || {};
+    var failures = [];
+    var population = gm && gm.population;
+    if (!population || typeof population !== 'object' || Array.isArray(population)) {
+      failures.push(_populationSchemaFailure('population-missing', 'population', population));
+    } else {
+      var national = population.national;
+      if (!national || typeof national !== 'object' || Array.isArray(national)) {
+        failures.push(_populationSchemaFailure('population-national-missing', 'population.national', national));
+      } else {
+        ['mouths', 'households'].forEach(function(key) {
+          var result = _finiteNonNegativePopulation(national[key], 'population.national.' + key, options);
+          if (!result.ok) failures.push(result);
+        });
+      }
+      ['hiddenCount', 'fugitives'].forEach(function(key) {
+        var result = _finiteNonNegativePopulation(population[key], 'population.' + key, options);
+        if (!result.ok) failures.push(result);
+      });
+      if (!population.byCategory || typeof population.byCategory !== 'object' || Array.isArray(population.byCategory)) {
+        failures.push(_populationSchemaFailure('population-categories-invalid', 'population.byCategory', population.byCategory));
+      } else {
+        Object.keys(population.byCategory).forEach(function(key) {
+          var row = population.byCategory[key];
+          if (!row || typeof row !== 'object' || Array.isArray(row)) {
+            failures.push(_populationSchemaFailure('population-category-invalid', 'population.byCategory.' + key, row));
+            return;
+          }
+          var result = _finiteNonNegativePopulation(row.mouths, 'population.byCategory.' + key + '.mouths', options);
+          if (!result.ok) failures.push(result);
+          if (row.households !== undefined && row.households !== null) {
+            var householdsResult = _finiteNonNegativePopulation(
+              row.households,
+              'population.byCategory.' + key + '.households',
+              options
+            );
+            if (!householdsResult.ok) failures.push(householdsResult);
+          }
+        });
+      }
+    }
+    return { ok:failures.length === 0, population:failures.length ? null : population, failures:failures };
+  }
+
+  function _reportPopulationSchemaFailure(gm, operation, validation) {
+    if (!validation || validation.ok) return;
+    var first = validation.failures && validation.failures[0] || validation;
+    var diagnostic = {
+      turn:Number(gm && gm.turn) || 0,
+      operation:String(operation || 'runtime'),
+      code:first.code || 'population-schema-invalid',
+      field:first.field || ''
+    };
+    if (gm) {
+      if (!Array.isArray(gm._populationSchemaDiagnostics)) gm._populationSchemaDiagnostics = [];
+      gm._populationSchemaDiagnostics.push(diagnostic);
+      if (gm._populationSchemaDiagnostics.length > 50) gm._populationSchemaDiagnostics = gm._populationSchemaDiagnostics.slice(-50);
+    }
+    try {
+      if (global.TM && global.TM.errors && typeof global.TM.errors.capture === 'function') {
+        global.TM.errors.capture(_populationSchemaError(first, operation), 'population-schema.' + diagnostic.operation, diagnostic);
+      }
+    } catch (_) {}
+  }
+
+  function _transferCategoryPopulation(population, options) {
+    options = options || {};
+    if (!population || typeof population !== 'object' || Array.isArray(population) ||
+        !population.byCategory || typeof population.byCategory !== 'object' || Array.isArray(population.byCategory)) {
+      return _populationSchemaFailure('population-categories-invalid', 'population.byCategory', population && population.byCategory);
+    }
+    var from = String(options.from || '');
+    var to = String(options.to || '');
+    var sourceRow = population.byCategory[from];
+    var targetRow = population.byCategory[to];
+    if (!sourceRow || typeof sourceRow !== 'object' || Array.isArray(sourceRow)) {
+      return _populationSchemaFailure('population-category-not-found', 'population.byCategory.' + from, sourceRow);
+    }
+    if (!targetRow || typeof targetRow !== 'object' || Array.isArray(targetRow)) {
+      return _populationSchemaFailure('population-category-not-found', 'population.byCategory.' + to, targetRow);
+    }
+    var readOptions = { allowLegacyNumericStrings:options.allowLegacyNumericStrings === true };
+    var source = _finiteNonNegativePopulation(sourceRow.mouths, 'population.byCategory.' + from + '.mouths', readOptions);
+    var target = _finiteNonNegativePopulation(targetRow.mouths, 'population.byCategory.' + to + '.mouths', readOptions);
+    var requested = _finiteNonNegativePopulation(options.count, 'count', readOptions);
+    if (!source.ok || !target.ok || !requested.ok) {
+      return {
+        ok:false,
+        code:'invalid-category-transfer-data',
+        failures:[source, target, requested].filter(function(result) { return !result.ok; })
+      };
+    }
+    if (from === to) return { ok:true, changed:false, requested:requested.value, actual:0, limitedBySource:false };
+    var actual = Math.min(source.value, requested.value);
+    sourceRow.mouths = source.value - actual;
+    targetRow.mouths = target.value + actual;
+    return {
+      ok:true,
+      changed:actual > 0,
+      requested:requested.value,
+      actual:actual,
+      limitedBySource:actual < requested.value,
+      from:from,
+      to:to
+    };
+  }
+
+  global.TM = global.TM || {};
+  global.TM.PopulationSchema = {
+    finiteNonNegative:_finiteNonNegativePopulation,
+    normalize:_normalizePopulationSchema,
+    validate:_validatePopulationSchema,
+    reportRuntimeFailure:_reportPopulationSchemaFailure,
+    transferCategory:_transferCategoryPopulation
+  };
+
   // ═══════════════════════════════════════════════════════════════════
   //  朝代默认参数
   // ═══════════════════════════════════════════════════════════════════
@@ -139,6 +403,31 @@
   //  初始化
   // ═══════════════════════════════════════════════════════════════════
 
+  function _initialPopulationNumber(value, fallback, field) {
+    if (value === undefined || value === null) return Math.floor(Number(fallback) || 0);
+    var schema = global.TM && global.TM.PopulationSchema;
+    var result = schema && typeof schema.finiteNonNegative === 'function'
+      ? schema.finiteNonNegative(value, field, { allowLegacyNumericStrings: true })
+      : { ok: typeof value === 'number' && Number.isFinite(value) && value >= 0, value: Math.floor(Number(value)) };
+    if (!result.ok) {
+      var error = new Error('户籍初始人口字段非法：' + field);
+      error.code = 'population-schema-invalid';
+      error.field = field;
+      throw error;
+    }
+    return result.value;
+  }
+
+  function _normalizePopulationBoundary(G, source, sc) {
+    var schema = global.TM && global.TM.PopulationSchema;
+    if (!schema || typeof schema.normalize !== 'function') return null;
+    return schema.normalize(G, {
+      source: source,
+      allowLegacyNumericStrings: true,
+      defaults: sc && sc.populationConfig && sc.populationConfig.initial || {}
+    });
+  }
+
   function init(sc) {
     var G = global.GM;
     if (!G) return;
@@ -164,6 +453,7 @@
         }
       });
       _ensureDeepDemographics(G.population);
+      _normalizePopulationBoundary(G, 'huji-existing-world', sc);
       return;
     }
 
@@ -171,11 +461,11 @@
     var config = (sc && sc.populationConfig) || {};
 
     var initial = config.initial || {};
-    var households = initial.nationalHouseholds || 1000000;
+    var households = _initialPopulationNumber(initial.nationalHouseholds, 1000000, 'populationConfig.initial.nationalHouseholds');
     var mouthsPerHh = DYNASTY_MOUTHS_PER_HOUSEHOLD[dynasty] || DYNASTY_MOUTHS_PER_HOUSEHOLD.default;
-    var mouths = initial.nationalMouths || Math.round(households * mouthsPerHh);
+    var mouths = _initialPopulationNumber(initial.nationalMouths, Math.round(households * mouthsPerHh), 'populationConfig.initial.nationalMouths');
     var dingRatio = DYNASTY_DING_PER_MOUTHS[dynasty] || DYNASTY_DING_PER_MOUTHS.default;
-    var ding = initial.nationalDing || Math.round(mouths * dingRatio);
+    var ding = _initialPopulationNumber(initial.nationalDing, Math.round(mouths * dingRatio), 'populationConfig.initial.nationalDing');
 
     var dingAge = config.dingAgeRange || DYNASTY_DING_AGE[dynasty] || DYNASTY_DING_AGE.default;
 
@@ -201,6 +491,7 @@
       triggeredMigrationEventIds: []
     };
     _ensureDeepDemographics(G.population);
+    _normalizePopulationBoundary(G, 'huji-new-game', sc);
   }
 
   function _inferDynasty(sc) {

--- a/web/tm-save-lifecycle.js
+++ b/web/tm-save-lifecycle.js
@@ -180,6 +180,17 @@ function _ensureGMDefaults(GM, P) {
   P = P || (typeof window !== 'undefined' ? window.P : null);
   if (!GM) return;
   _tmNormalizeCoreWorldCollections(GM);
+  var populationSchema = typeof window !== 'undefined' && window.TM && window.TM.PopulationSchema;
+  if (!populationSchema || typeof populationSchema.normalize !== 'function') {
+    var populationSchemaError = new Error('人口 schema provider 未加载，拒绝规范化世界');
+    populationSchemaError.code = 'population-schema-unavailable';
+    throw populationSchemaError;
+  }
+  populationSchema.normalize(GM, {
+    source: 'load-or-save-boundary',
+    allowLegacyNumericStrings: true,
+    p: P
+  });
   _tmEnsureCampaignId(GM);
   _tmEnsureTimelineIdentity(GM);
   _tmMigrateCoreStableIds(GM);


### PR DESCRIPTION
## Scope
- add one PopulationSchema normalization/validation boundary for new games and loads
- normalize category mouths and optional households in place, including legacy numeric strings
- reject unsafe damaged population values without propagating NaN
- make category transfers finite, non-negative, source-limited, and population-conserving
- retain runtime defensive checks for authority and grain-grant consumers

## Verification
- smoke-population-transfer-invariants.js: 44 assertions
- category households cover numeric strings, integer flooring, NaN, negative, and invalid strings
- save-integrity smoke loads the production PopulationSchema provider
- architecture guards passed locally

Stacked on the fiscal ledger PR. No package, release, or deployment was executed.