### PR TITLE
fix: harden deployment manifest and publication atomicity

### DIFF
--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -4,7 +4,7 @@
 2026-06-11·更新功能全面升级 S9·取代每版手写 deploy-XXXX.py。
 
 从 GitHub Release 拉制品（dev 侧 SSH 被墙·全走 HTTP），内存安全（大 zip 全程流式落盘），
-全部写入原子化（.tmp + os.replace）+ 旧 feed 留 .bak-<ts>，发布顺序「内容先、feed 最后」
+全部写入原子化（唯一临时文件 + os.replace）+ 旧 feed 留 .bak-<ts>，发布顺序「内容先、feed 最后」
 （杜绝 feed 已说新版、包还没到位的 404 竞态）。
 
 服务器一行（release.js 会按版补好 DEFAULT_TAG 并把本文件传到 release 资产里）：
@@ -22,6 +22,17 @@
   --skip-verify                             跳过发布后公网回读校验
 """
 import urllib.request, json, os, zipfile, hashlib, time, shutil, sys, re, base64
+import contextlib, pathlib, tempfile
+
+try:
+    import fcntl
+except ImportError:  # Windows local verifier; production host is Linux.
+    fcntl = None
+
+try:
+    import msvcrt
+except ImportError:
+    msvcrt = None
 
 DEFAULT_TAG = ""  # release.js 每版自动补 "ship-X.Y.Z.W"
 REPO = "misfit-user/tianming"
@@ -56,6 +67,11 @@ FORCE = flag("force")
 ENABLE_MANIFEST = flag("enable-manifest")
 DISABLE_MANIFEST = flag("disable-manifest")
 SKIP_VERIFY = flag("skip-verify") or bool(ASSETS_DIR) or (BASE != DEFAULT_BASE)
+REPORT_PEAK_MEMORY = flag("report-peak-memory")
+
+if REPORT_PEAK_MEMORY:
+    import tracemalloc
+    tracemalloc.start()
 
 REL = f"https://github.com/{REPO}/releases/download/{TAG}"
 HOT = BASE + "/hot"
@@ -66,6 +82,16 @@ CAPGO_BUNDLES = CAPGO + "/bundles"
 CAPGO_FILES = CAPGO + "/files"
 RELEASES_WIN = BASE + "/releases/win"
 TS = time.strftime("%Y%m%d-%H%M%S")
+HEX64 = re.compile(r"^[0-9a-f]{64}$")
+STREAM_CHUNK_BYTES = 1024 * 1024
+DEPLOY_LOCK_TIMEOUT_SECONDS = 900
+
+
+class DeployError(Exception):
+    def __init__(self, code, message, exit_code=3):
+        super().__init__(message)
+        self.code = code
+        self.exit_code = exit_code
 
 def want(channel):
     return (not ONLY) or (channel in ONLY)
@@ -73,23 +99,109 @@ def want(channel):
 # ── 基础设施（承袭 deploy-1334.py 验证过的范式） ───────────────────────────────
 def log(msg): print(msg, flush=True)
 
+def _remove_if_exists(path):
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
+
+def _new_temp_path(directory, prefix):
+    os.makedirs(directory, exist_ok=True)
+    fd, path = tempfile.mkstemp(prefix=prefix, dir=directory)
+    os.close(fd)
+    _remove_if_exists(path)
+    return path
+
+def _copy_stream_atomic(src, dst):
+    """Copy a path/file-like object to dst through a unique fsynced sibling."""
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".deploy-", dir=os.path.dirname(dst))
+    try:
+        with os.fdopen(fd, "wb") as out:
+            if hasattr(src, "read"):
+                shutil.copyfileobj(src, out, length=STREAM_CHUNK_BYTES)
+            else:
+                with open(src, "rb") as inp:
+                    shutil.copyfileobj(inp, out, length=STREAM_CHUNK_BYTES)
+            out.flush()
+            os.fsync(out.fileno())
+        os.replace(tmp, dst)
+    finally:
+        _remove_if_exists(tmp)
+
+def _atomic_write_bytes(path, data):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".deploy-", dir=os.path.dirname(path))
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    finally:
+        _remove_if_exists(tmp)
+
+@contextlib.contextmanager
+def deployment_lock():
+    """Serialize the entire publication. Linux uses flock; Windows supports local CI."""
+    if DRY:
+        yield
+        return
+    os.makedirs(BASE, exist_ok=True)
+    lock_path = os.path.join(BASE, ".deploy.lock")
+    lock_file = open(lock_path, "a+b")
+    locked = False
+    started = time.monotonic()
+    warned = False
+    try:
+        if msvcrt is not None:
+            lock_file.seek(0, os.SEEK_END)
+            if lock_file.tell() == 0:
+                lock_file.write(b"0")
+                lock_file.flush()
+        while not locked:
+            try:
+                if fcntl is not None:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                elif msvcrt is not None:
+                    lock_file.seek(0)
+                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+                else:
+                    raise DeployError("LOCK_UNSUPPORTED", "当前平台没有可用的进程互斥锁", 9)
+                locked = True
+            except (BlockingIOError, OSError):
+                if not warned:
+                    log("  [lock] 另一部署正在运行·等待部署锁")
+                    warned = True
+                if time.monotonic() - started >= DEPLOY_LOCK_TIMEOUT_SECONDS:
+                    raise DeployError("LOCK_TIMEOUT", "等待部署锁超时", 9)
+                time.sleep(0.05)
+        if warned:
+            log(f"  [lock] 等待 {time.monotonic() - started:.3f}s 后取得部署锁")
+        yield
+    finally:
+        if locked:
+            if fcntl is not None:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            elif msvcrt is not None:
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+        lock_file.close()
+
 def download(name, dst, tries=6):
     """资产 → dst·流式 1MB chunk·恒定低内存。--assets-dir 时从本地拷。"""
     if ASSETS_DIR:
         src = os.path.join(ASSETS_DIR, name)
         if not os.path.exists(src): raise FileNotFoundError(src)
-        os.makedirs(os.path.dirname(dst), exist_ok=True)
-        shutil.copyfile(src, dst + ".part"); os.replace(dst + ".part", dst)
+        _copy_stream_atomic(src, dst)
         return dst
     url = f"{REL}/{name}"
     last = None
     for i in range(tries):
         try:
             req = urllib.request.Request(url, headers={"User-Agent": "tm-deploy/2"})
-            os.makedirs(os.path.dirname(dst), exist_ok=True)
-            with urllib.request.urlopen(req, timeout=900) as r, open(dst + ".part", "wb") as fh:
-                shutil.copyfileobj(r, fh, length=1024 * 1024)
-            os.replace(dst + ".part", dst)
+            with urllib.request.urlopen(req, timeout=900) as r:
+                _copy_stream_atomic(r, dst)
             return dst
         except Exception as e:
             last = e; log(f"  download retry {i+1}: {type(e).__name__} {e}"); time.sleep(3)
@@ -147,8 +259,7 @@ def publish_bytes(path, data, label):
         return
     os.makedirs(os.path.dirname(path), exist_ok=True)
     if os.path.exists(path): shutil.copy2(path, path + f".bak-{TS}")
-    with open(path + ".tmp", "wb") as fh: fh.write(data)
-    os.replace(path + ".tmp", path); os.chmod(path, 0o644)
+    _atomic_write_bytes(path, data); os.chmod(path, 0o644)
     log(f"  发布 {label} → {path}")
 
 def publish_move(src, dst, label):
@@ -183,64 +294,288 @@ def gate_monotonic(live_path, new_ver, channel):
     log(f"ABORT: {channel} 版本不单调·新 v{new_ver} < 线上 v{live}。降级会让全部客户端拒装/搁浅。--force 可强行。")
     sys.exit(5)
 
+def _validate_desktop_manifest(z, manifest):
+    """Validate every manifest identity before publishing any content object."""
+    if not isinstance(manifest, dict) or not isinstance(manifest.get("files"), list):
+        raise DeployError("MANIFEST_INVALID", "manifest.files 必须为数组")
+
+    zip_entries = {}
+    for info in z.infolist():
+        zip_entries.setdefault(info.filename, []).append(info)
+
+    seen_paths = set()
+    normalized = []
+    for index, raw in enumerate(manifest["files"]):
+        if not isinstance(raw, dict):
+            raise DeployError("MANIFEST_INVALID", f"manifest.files[{index}] 不是对象")
+        path_value = raw.get("path")
+        if not isinstance(path_value, str) or not path_value or "\x00" in path_value:
+            raise DeployError("MANIFEST_PATH_INVALID", f"manifest.files[{index}].path 非法")
+        posix_path = pathlib.PurePosixPath(path_value)
+        if (posix_path.is_absolute() or ".." in posix_path.parts or "\\" in path_value
+                or path_value.endswith("/") or posix_path.name in ("", ".", "..")):
+            raise DeployError("MANIFEST_PATH_INVALID", f"manifest path 越界或不规范: {path_value!r}")
+        if path_value in seen_paths:
+            raise DeployError("MANIFEST_PATH_DUPLICATE", f"manifest path 重复: {path_value!r}")
+        seen_paths.add(path_value)
+
+        sha_value = raw.get("sha256")
+        if not isinstance(sha_value, str):
+            raise DeployError("MANIFEST_SHA_INVALID", f"{path_value}: sha256 缺失或不是字符串")
+        sha_value = sha_value.lower()
+        if not HEX64.fullmatch(sha_value):
+            raise DeployError("MANIFEST_SHA_INVALID", f"{path_value}: sha256 不是 64 位 hex")
+
+        infos = zip_entries.get(path_value, [])
+        if not infos:
+            raise DeployError("INCOMPLETE", f"manifest 文件不在 zip: {path_value!r}")
+        if len(infos) != 1 or infos[0].is_dir():
+            raise DeployError("MANIFEST_ZIP_ENTRY_INVALID", f"ZIP 条目重复或不是文件: {path_value!r}")
+        info = infos[0]
+
+        declared_size = raw.get("size")
+        size = None
+        if declared_size is not None:
+            if isinstance(declared_size, bool):
+                raise DeployError("MANIFEST_SIZE_INVALID", f"{path_value}: size 非法")
+            try:
+                size = int(declared_size)
+            except (TypeError, ValueError):
+                raise DeployError("MANIFEST_SIZE_INVALID", f"{path_value}: size 不是整数")
+            if size < 0 or size != info.file_size:
+                raise DeployError("MANIFEST_SIZE_MISMATCH",
+                                  f"{path_value}: manifest size={size}，ZIP size={info.file_size}")
+
+        normalized.append({
+            "path": path_value,
+            "sha256": sha_value,
+            "size": size,
+            "info": info,
+        })
+    return normalized
+
+def _desktop_object_path(entry):
+    files_root = os.path.abspath(FILES)
+    dst = os.path.abspath(os.path.join(
+        files_root,
+        entry["sha256"][:2],
+        entry["sha256"][2:],
+        os.path.basename(entry["path"]),
+    ))
+    try:
+        contained = os.path.commonpath([files_root, dst]) == files_root
+    except ValueError:
+        contained = False
+    if not contained:
+        raise DeployError("OBJECT_PATH_ESCAPE", f"对象目标越界: {entry['path']!r}")
+    return dst
+
+def _stream_desktop_entry(z, entry):
+    """Hash while streaming; publish only a fully verified object."""
+    dst = _desktop_object_path(entry)
+    existing_valid = False
+    if os.path.exists(dst):
+        size_ok = entry["size"] is None or os.path.getsize(dst) == entry["size"]
+        if size_ok and sha256_file(dst) == entry["sha256"]:
+            existing_valid = True
+
+    hasher = hashlib.sha256()
+    written = 0
+    if DRY or existing_valid:
+        try:
+            with z.open(entry["info"], "r") as src:
+                for chunk in iter(lambda: src.read(STREAM_CHUNK_BYTES), b""):
+                    hasher.update(chunk)
+                    written += len(chunk)
+        except Exception as error:
+            raise DeployError("OBJECT_READ_FAILED", f"{entry['path']}: {error}") from error
+    else:
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        fd, tmp = tempfile.mkstemp(prefix=".deploy-", dir=os.path.dirname(dst))
+        try:
+            try:
+                with os.fdopen(fd, "wb") as out, z.open(entry["info"], "r") as src:
+                    for chunk in iter(lambda: src.read(STREAM_CHUNK_BYTES), b""):
+                        hasher.update(chunk)
+                        written += len(chunk)
+                        out.write(chunk)
+                    out.flush()
+                    os.fsync(out.fileno())
+            except Exception as error:
+                raise DeployError("OBJECT_READ_FAILED", f"{entry['path']}: {error}") from error
+            if hasher.hexdigest() != entry["sha256"]:
+                raise DeployError("OBJECT_HASH_MISMATCH", f"{entry['path']}: 实际 sha256 与 manifest 不符")
+            if entry["size"] is not None and written != entry["size"]:
+                raise DeployError("OBJECT_SIZE_MISMATCH", f"{entry['path']}: 实际写入大小与 manifest 不符")
+            os.replace(tmp, dst)
+            os.chmod(dst, 0o644)
+        finally:
+            _remove_if_exists(tmp)
+
+    if hasher.hexdigest() != entry["sha256"]:
+        raise DeployError("OBJECT_HASH_MISMATCH", f"{entry['path']}: 实际 sha256 与 manifest 不符")
+    if entry["size"] is not None and written != entry["size"]:
+        raise DeployError("OBJECT_SIZE_MISMATCH", f"{entry['path']}: 实际读取大小与 manifest 不符")
+    return "skipped" if existing_valid else "added"
+
+def _validate_capgo_object_pack(z):
+    """Build the complete Capgo object identity table before writing anything."""
+    seen_hashes = set()
+    entries = []
+    for info in z.infolist():
+        if info.is_dir():
+            continue
+        object_hash = os.path.basename(info.filename)
+        if not HEX64.fullmatch(object_hash):
+            raise DeployError(
+                "CAPGO_OBJECT_HASH_INVALID",
+                f"Capgo 对象 hash 非法: {info.filename!r}",
+                7,
+            )
+        if object_hash in seen_hashes:
+            raise DeployError(
+                "CAPGO_OBJECT_DUPLICATE",
+                f"Capgo 对象重复: {object_hash}",
+                7,
+            )
+        seen_hashes.add(object_hash)
+        entries.append({"hash": object_hash, "info": info})
+    return entries
+
+def _stream_capgo_object(z, entry):
+    """Verify and atomically publish one Capgo content-addressed object."""
+    expected_hash = str(entry["hash"]).lower()
+    if not HEX64.fullmatch(expected_hash):
+        raise DeployError(
+            "CAPGO_OBJECT_HASH_INVALID",
+            f"Capgo 对象 hash 非法: {expected_hash!r}",
+            7,
+        )
+    info = entry["info"]
+    dst = os.path.join(CAPGO_FILES, expected_hash)
+    existing_valid = False
+    if os.path.exists(dst):
+        existing_valid = sha256_file(dst) == expected_hash
+        if not existing_valid:
+            log(f"  [capgo] 既有对象损坏·重新写入 {expected_hash[:12]}")
+
+    hasher = hashlib.sha256()
+    written = 0
+    if DRY or existing_valid:
+        try:
+            with z.open(info, "r") as src:
+                for chunk in iter(lambda: src.read(STREAM_CHUNK_BYTES), b""):
+                    hasher.update(chunk)
+                    written += len(chunk)
+        except Exception as error:
+            raise DeployError(
+                "CAPGO_OBJECT_READ_FAILED",
+                f"Capgo 对象读取失败: {info.filename}: {error}",
+                7,
+            ) from error
+    else:
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        fd, tmp = tempfile.mkstemp(prefix=".deploy-", dir=os.path.dirname(dst))
+        try:
+            try:
+                with os.fdopen(fd, "wb") as out, z.open(info, "r") as src:
+                    for chunk in iter(lambda: src.read(STREAM_CHUNK_BYTES), b""):
+                        hasher.update(chunk)
+                        written += len(chunk)
+                        out.write(chunk)
+                    out.flush()
+                    os.fsync(out.fileno())
+            except Exception as error:
+                raise DeployError(
+                    "CAPGO_OBJECT_READ_FAILED",
+                    f"Capgo 对象读取失败: {info.filename}: {error}",
+                    7,
+                ) from error
+            if hasher.hexdigest() != expected_hash:
+                raise DeployError(
+                    "CAPGO_OBJECT_HASH_MISMATCH",
+                    f"Capgo 对象内容与名称不一致: {info.filename}",
+                    7,
+                )
+            if written != info.file_size:
+                raise DeployError(
+                    "CAPGO_OBJECT_SIZE_MISMATCH",
+                    f"Capgo 对象实际大小与 ZIP 元数据不一致: {info.filename}",
+                    7,
+                )
+            os.replace(tmp, dst)
+            os.chmod(dst, 0o644)
+        finally:
+            _remove_if_exists(tmp)
+
+    if hasher.hexdigest() != expected_hash:
+        raise DeployError(
+            "CAPGO_OBJECT_HASH_MISMATCH",
+            f"Capgo 对象内容与名称不一致: {info.filename}",
+            7,
+        )
+    if written != info.file_size:
+        raise DeployError(
+            "CAPGO_OBJECT_SIZE_MISMATCH",
+            f"Capgo 对象实际大小与 ZIP 元数据不一致: {info.filename}",
+            7,
+        )
+    return "skipped" if existing_valid else "added"
+
 # ── 电脑端 Electron 热更 ──────────────────────────────────────────────────────
 def deploy_desktop():
     zip_name = f"tianming-hot-{VER}.zip"
     log(f"[desktop] 下载热更整包（流式·落 serve 真实磁盘）...")
     os.makedirs(FILES, exist_ok=True); os.makedirs(MANIFESTS, exist_ok=True)
-    zpath = f"{HOT}/{zip_name}.new"
-    download(zip_name, zpath)
-    zsha = sha256_file(zpath)
-    log(f"  zip {os.path.getsize(zpath)/1048576:.1f}MB sha={zsha[:12]}")
+    zpath = _new_temp_path(HOT, f".{zip_name}.deploy-")
+    try:
+        download(zip_name, zpath)
+        zsha = sha256_file(zpath)
+        log(f"  zip {os.path.getsize(zpath)/1048576:.1f}MB sha={zsha[:12]}")
 
-    hotlatest = parse_json_bytes(fetch_small("hot-latest.json"))
-    if str(hotlatest.get("version", "")) != VER:
-        os.remove(zpath); log(f"ABORT: hot-latest.json version={hotlatest.get('version')} ≠ {VER}"); sys.exit(2)
-    if hotlatest.get("sha256") and hotlatest["sha256"].lower() != zsha.lower():
-        os.remove(zpath); log("ABORT: hot-latest.json sha256 ≠ 实际 zip sha·不发布"); sys.exit(2)
-    if hotlatest.get("size") and int(hotlatest["size"]) != os.path.getsize(zpath):
-        os.remove(zpath); log("ABORT: hot-latest.json size ≠ 实际 zip 大小·不发布"); sys.exit(2)
+        hotlatest = parse_json_bytes(fetch_small("hot-latest.json"))
+        if str(hotlatest.get("version", "")) != VER:
+            log(f"ABORT: hot-latest.json version={hotlatest.get('version')} ≠ {VER}"); sys.exit(2)
+        if hotlatest.get("sha256") and hotlatest["sha256"].lower() != zsha.lower():
+            log("ABORT: hot-latest.json sha256 ≠ 实际 zip sha·不发布"); sys.exit(2)
+        if hotlatest.get("size") and int(hotlatest["size"]) != os.path.getsize(zpath):
+            log("ABORT: hot-latest.json size ≠ 实际 zip 大小·不发布"); sys.exit(2)
 
-    feed_action = gate_monotonic(f"{HOT}/hot-latest.json", VER, "desktop")
+        feed_action = gate_monotonic(f"{HOT}/hot-latest.json", VER, "desktop")
 
-    z = zipfile.ZipFile(zpath)
-    mbytes = z.read("manifest.json"); m = json.loads(mbytes)
-    znames = set(z.namelist())
-    # 完备闸·manifest 每个文件都必须在 zip 里（1.3.3.4 类事故在服务器侧的最后防线）
-    miss = [f["path"] for f in m["files"] if f["path"] not in znames]
-    if miss:
-        z.close(); os.remove(zpath)
-        log(f"ABORT_INCOMPLETE: manifest 有 {len(miss)} 个文件不在 zip 里（前 10: {miss[:10]}）·服务器未动")
-        sys.exit(3)
+        try:
+            with zipfile.ZipFile(zpath) as z:
+                try:
+                    mbytes = z.read("manifest.json")
+                    m = json.loads(mbytes)
+                except (KeyError, ValueError, UnicodeDecodeError) as error:
+                    raise DeployError("MANIFEST_INVALID", f"manifest.json 无法读取: {error}") from error
+                entries = _validate_desktop_manifest(z, m)
 
-    moved = skipped = 0
-    for f in m["files"]:
-        dst = f"{FILES}/{f['sha256'][:2]}/{f['sha256'][2:]}/{os.path.basename(f['path'])}"
-        if os.path.exists(dst): skipped += 1; continue
-        data = z.read(f["path"])  # 单文件逐个读·内存安全
-        if DRY: moved += 1; continue
-        os.makedirs(os.path.dirname(dst), exist_ok=True)
-        with open(dst + ".tmp", "wb") as fh: fh.write(data)
-        os.replace(dst + ".tmp", dst); moved += 1
-    log(f"  files 库·新入 {moved}·已有跳过 {skipped}")
+                moved = skipped = 0
+                for entry in entries:
+                    result = _stream_desktop_entry(z, entry)
+                    if result == "skipped": skipped += 1
+                    else: moved += 1
+                log(f"  files 库·新入 {moved}·已有跳过 {skipped}")
 
-    if not DRY:
-        with open(f"{MANIFESTS}/{VER}.json.tmp", "wb") as fh: fh.write(mbytes)
-        os.replace(f"{MANIFESTS}/{VER}.json.tmp", f"{MANIFESTS}/{VER}.json")
-        os.chmod(f"{MANIFESTS}/{VER}.json", 0o644)
-        log(f"  manifest 就位 manifests/{VER}.json ({len(m['files'])} 文件)")
+                changelog_bytes = None
+                for nm in ("changelog.json", "web/changelog.json"):
+                    try: changelog_bytes = z.read(nm); break
+                    except KeyError: continue
+        except zipfile.BadZipFile as error:
+            raise DeployError("ZIP_INVALID", f"热更 ZIP 损坏: {error}") from error
 
-    changelog_bytes = None
-    for nm in ("changelog.json", "web/changelog.json"):
-        try: changelog_bytes = z.read(nm); break
-        except KeyError: continue
-    z.close()
-    publish_move(zpath, f"{HOT}/{zip_name}", "热更整包")
-    if feed_action == "publish":
-        publish_bytes(f"{HOT}/hot-latest.json",
-                      json.dumps(hotlatest, ensure_ascii=False, indent=2).encode("utf-8"),
-                      f"hot-latest.json v{VER}")
-    return changelog_bytes
+        publish_bytes(f"{MANIFESTS}/{VER}.json", mbytes,
+                      f"manifest manifests/{VER}.json ({len(entries)} 文件)")
+        publish_move(zpath, f"{HOT}/{zip_name}", "热更整包")
+        if feed_action == "publish":
+            publish_bytes(f"{HOT}/hot-latest.json",
+                          json.dumps(hotlatest, ensure_ascii=False, indent=2).encode("utf-8"),
+                          f"hot-latest.json v{VER}")
+        return changelog_bytes
+    finally:
+        _remove_if_exists(zpath)
 
 # ── 邸报 ─────────────────────────────────────────────────────────────────────
 def deploy_changelog(from_zip_bytes=None):
@@ -282,24 +617,27 @@ def deploy_capgo():
     # 差量对象包（可选资产）→ capgo/files/·条目名必须 64hex
     pack_name = f"capgo-files-{VER}.zip"
     if asset_exists(pack_name):
-        ppath = f"{CAPGO}/{pack_name}.new"
-        download(pack_name, ppath)
-        pz = zipfile.ZipFile(ppath)
-        added = skipped = bad = 0
-        os.makedirs(CAPGO_FILES, exist_ok=True)
-        for nm in pz.namelist():
-            base = os.path.basename(nm)
-            if not re.fullmatch(r"[0-9a-f]{64}", base): bad += 1; continue
-            dst = f"{CAPGO_FILES}/{base}"
-            if os.path.exists(dst): skipped += 1; continue
-            data = pz.read(nm)
-            if hashlib.sha256(data).hexdigest() != base: bad += 1; continue  # 名实必须相符
-            if DRY: added += 1; continue
-            with open(dst + ".tmp", "wb") as fh: fh.write(data)
-            os.replace(dst + ".tmp", dst); os.chmod(dst, 0o644); added += 1
-        pz.close(); os.remove(ppath)
-        log(f"  [capgo] 对象包·新入 {added}·已有 {skipped}·非法/名实不符 {bad}")
-        if bad: log("ABORT: 对象包内有名实不符条目·不发布"); sys.exit(7)
+        ppath = _new_temp_path(CAPGO, f".{pack_name}.deploy-")
+        try:
+            download(pack_name, ppath)
+            try:
+                with zipfile.ZipFile(ppath) as pz:
+                    entries = _validate_capgo_object_pack(pz)
+                    added = skipped = 0
+                    os.makedirs(CAPGO_FILES, exist_ok=True)
+                    for entry in entries:
+                        result = _stream_capgo_object(pz, entry)
+                        if result == "skipped": skipped += 1
+                        else: added += 1
+            except zipfile.BadZipFile as error:
+                raise DeployError(
+                    "CAPGO_OBJECT_PACK_INVALID",
+                    f"Capgo 对象包损坏: {error}",
+                    7,
+                ) from error
+        finally:
+            _remove_if_exists(ppath)
+        log(f"  [capgo] 对象包·新入 {added}·已有验证 {skipped}")
     else:
         log("  [capgo] 无 capgo-files 对象包资产（纯全量发布或对象已全在服务器）")
 
@@ -321,11 +659,15 @@ def deploy_capgo():
         log(f"  [capgo] bundle 已在位且大小一致·跳过下载"); need_dl = False
     if need_dl:
         log(f"[capgo] 下载全量 bundle（流式）...")
-        download(zip_name, cbp + ".new")
-        got = os.path.getsize(cbp + ".new")
-        if latest.get("size") and int(latest["size"]) != got:
-            os.remove(cbp + ".new"); log(f"ABORT: latest.size({latest['size']}) ≠ 实际({got})"); sys.exit(4)
-        publish_move(cbp + ".new", cbp, f"capgo bundle ({got/1048576:.1f}MB)")
+        staged_bundle = _new_temp_path(CAPGO_BUNDLES, f".{zip_name}.deploy-")
+        try:
+            download(zip_name, staged_bundle)
+            got = os.path.getsize(staged_bundle)
+            if latest.get("size") and int(latest["size"]) != got:
+                log(f"ABORT: latest.size({latest['size']}) ≠ 实际({got})"); sys.exit(4)
+            publish_move(staged_bundle, cbp, f"capgo bundle ({got/1048576:.1f}MB)")
+        finally:
+            _remove_if_exists(staged_bundle)
 
     # feed·默认剥 manifest（全量兜底=今天的行为）·--enable-manifest 才带差量上线
     out = dict(latest)
@@ -356,14 +698,23 @@ def deploy_installer():
         log("  [installer] exe 已在位且 sha512 一致·跳过下载")
     else:
         log(f"[installer] 下载本体安装包（~{int(ysize or 0)/1048576:.0f}MB·流式）...")
-        download(alias, exe_dst + ".new")
-        actual = sha512_b64_file(exe_dst + ".new")
-        if actual != ysha:
-            os.remove(exe_dst + ".new"); log("ABORT: 安装包 sha512 与 latest.yml 不符·不发布"); sys.exit(8)
-        publish_move(exe_dst + ".new", exe_dst, f"本体 {ypath}")
+        staged_exe = _new_temp_path(RELEASES_WIN, f".{os.path.basename(ypath)}.deploy-")
+        try:
+            download(alias, staged_exe)
+            actual = sha512_b64_file(staged_exe)
+            if actual != ysha:
+                log("ABORT: 安装包 sha512 与 latest.yml 不符·不发布"); sys.exit(8)
+            publish_move(staged_exe, exe_dst, f"本体 {ypath}")
+        finally:
+            _remove_if_exists(staged_exe)
     if asset_exists(alias + ".blockmap"):
-        download(alias + ".blockmap", f"{RELEASES_WIN}/{ypath}.blockmap.new")
-        publish_move(f"{RELEASES_WIN}/{ypath}.blockmap.new", f"{RELEASES_WIN}/{ypath}.blockmap", "blockmap（差量安装）")
+        blockmap_dst = f"{RELEASES_WIN}/{ypath}.blockmap"
+        staged_blockmap = _new_temp_path(RELEASES_WIN, f".{os.path.basename(ypath)}.blockmap.deploy-")
+        try:
+            download(alias + ".blockmap", staged_blockmap)
+            publish_move(staged_blockmap, blockmap_dst, "blockmap（差量安装）")
+        finally:
+            _remove_if_exists(staged_blockmap)
     if gate == "publish":
         publish_bytes(f"{RELEASES_WIN}/latest.yml", yml_text.encode("utf-8"), f"latest.yml v{yver}")
 
@@ -394,23 +745,32 @@ def post_verify():
             log(f"  [verify] {name}·回读异常·fresh={fresh[:80]!r}")
 
 def main():
-    log(f"=== tianming deploy v{VER}（tag {TAG}）{'·DRY-RUN' if DRY else ''} ===")
-    log(f"    base={BASE}{'·assets=' + ASSETS_DIR if ASSETS_DIR else ''}·only={ONLY or '全部'}")
-    changelog_from_zip = None
-    if DISABLE_MANIFEST:
-        deploy_capgo(); log("=== DONE（manifest 已剥·全量回退） ==="); return
-    if want("desktop"):
-        changelog_from_zip = deploy_desktop()
-    if want("changelog"):
-        deploy_changelog(changelog_from_zip)
-    if want("capgo"):
-        deploy_capgo()
-    if want("installer"):
-        deploy_installer()
-    post_verify()
-    log(f"=== DONE v{VER} ===")
-    log(f"验证: curl -s {PUBLIC_BASE}/hot/hot-latest.json | head -3")
-    log(f"      curl -s {PUBLIC_BASE}/capgo/latest.json | head -3")
+    with deployment_lock():
+        log(f"=== tianming deploy v{VER}（tag {TAG}）{'·DRY-RUN' if DRY else ''} ===")
+        log(f"    base={BASE}{'·assets=' + ASSETS_DIR if ASSETS_DIR else ''}·only={ONLY or '全部'}")
+        changelog_from_zip = None
+        if DISABLE_MANIFEST:
+            deploy_capgo(); log("=== DONE（manifest 已剥·全量回退） ==="); return
+        if want("desktop"):
+            changelog_from_zip = deploy_desktop()
+        if want("changelog"):
+            deploy_changelog(changelog_from_zip)
+        if want("capgo"):
+            deploy_capgo()
+        if want("installer"):
+            deploy_installer()
+        post_verify()
+        log(f"=== DONE v{VER} ===")
+        log(f"验证: curl -s {PUBLIC_BASE}/hot/hot-latest.json | head -3")
+        log(f"      curl -s {PUBLIC_BASE}/capgo/latest.json | head -3")
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except DeployError as error:
+        log(f"ABORT_{error.code}: {error}")
+        sys.exit(error.exit_code)
+    finally:
+        if REPORT_PEAK_MEMORY:
+            _current, peak = tracemalloc.get_traced_memory()
+            log(f"PEAK_TRACED_BYTES={peak}")

--- a/web/scripts/smoke-deploy-manifest-atomicity.js
+++ b/web/scripts/smoke-deploy-manifest-atomicity.js
@@ -1,0 +1,327 @@
+// Desktop/Capgo deployment manifest/path/hash/streaming/concurrency regression.
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+const { spawn, spawnSync } = require('child_process');
+const AdmZip = require('adm-zip');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const DEPLOY = path.join(ROOT, 'scripts', 'deploy.py');
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-deploy-atomicity-'));
+const VER = '9.7.0.1';
+const PY_ENV = Object.assign({}, process.env, { PYTHONUTF8: '1' });
+let assertions = 0;
+
+function assert(condition, label) {
+  if (!condition) throw new Error('FAIL·' + label);
+  assertions++;
+  console.log('  ok·' + label);
+}
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function sha256File(file) {
+  const hash = crypto.createHash('sha256');
+  const fd = fs.openSync(file, 'r');
+  const buffer = Buffer.allocUnsafe(1024 * 1024);
+  try {
+    let read;
+    while ((read = fs.readSync(fd, buffer, 0, buffer.length, null)) > 0) hash.update(buffer.subarray(0, read));
+  } finally {
+    fs.closeSync(fd);
+  }
+  return hash.digest('hex');
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8').replace(/^\uFEFF/, ''));
+}
+
+function writeSmallAssets(directory, editManifest, editZip) {
+  fs.mkdirSync(directory, { recursive: true });
+  const files = [
+    { path: 'a.js', data: Buffer.from('var deployAtomicity = true;\n') },
+    { path: 'nested/中文.json', data: Buffer.from('{"ok":true}\n') }
+  ];
+  const manifest = {
+    version: VER,
+    files: files.map((row) => ({ path: row.path, sha256: sha256(row.data), size: row.data.length }))
+  };
+  if (editManifest) editManifest(manifest, files);
+  const zip = new AdmZip();
+  files.forEach((row) => zip.addFile(row.path, row.data));
+  zip.addFile('manifest.json', Buffer.from(JSON.stringify(manifest)));
+  if (editZip) editZip(zip, manifest, files);
+  const zipPath = path.join(directory, 'tianming-hot-' + VER + '.zip');
+  zip.writeZip(zipPath);
+  const zipBytes = fs.readFileSync(zipPath);
+  fs.writeFileSync(path.join(directory, 'hot-latest.json'), JSON.stringify({
+    version: VER,
+    sha256: sha256(zipBytes),
+    size: zipBytes.length
+  }));
+  return { manifest, files, zipPath };
+}
+
+function deployArgs(server, assets, extra, channel) {
+  return [DEPLOY, '--version', VER, '--base-dir', server, '--assets-dir', assets,
+    '--skip-verify', '--only', channel || 'desktop'].concat(extra || []);
+}
+
+function runDeploy(server, assets, extra, channel) {
+  return spawnSync('python', deployArgs(server, assets, extra, channel), {
+    encoding: 'utf8', env: PY_ENV, maxBuffer: 32 * 1024 * 1024
+  });
+}
+
+function spawnDeploy(server, assets, extra, channel) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('python', deployArgs(server, assets, extra, channel), { env: PY_ENV });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk.toString('utf8'); });
+    child.stderr.on('data', (chunk) => { stderr += chunk.toString('utf8'); });
+    child.on('error', reject);
+    child.on('close', (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
+function objectPath(server, row) {
+  return path.join(server, 'hot', 'files', row.sha256.slice(0, 2), row.sha256.slice(2), path.basename(row.path));
+}
+
+function capgoObjectPath(server, objectHash) {
+  return path.join(server, 'capgo', 'files', objectHash);
+}
+
+function writeCapgoAssets(directory, options) {
+  options = options || {};
+  fs.mkdirSync(directory, { recursive: true });
+  const expectedData = options.expectedData || Buffer.from('capgo-object-content\n');
+  const entryData = options.entryData || expectedData;
+  const objectHash = options.objectHash || sha256(expectedData);
+  const pack = new AdmZip();
+  pack.addFile(objectHash, entryData);
+  if (options.duplicate) pack.addFile('duplicate/' + objectHash, entryData);
+  pack.writeZip(path.join(directory, 'capgo-files-' + VER + '.zip'));
+  const bundle = Buffer.from('capgo-full-bundle\n');
+  fs.writeFileSync(path.join(directory, VER + '.zip'), bundle);
+  const latest = {
+    version: VER,
+    url: 'https://example.invalid/' + VER + '.zip',
+    size: bundle.length,
+    manifest: [{
+      file_name: 'capgo-object.bin',
+      file_hash: objectHash,
+      download_url: 'https://example.invalid/files/' + objectHash
+    }]
+  };
+  fs.writeFileSync(path.join(directory, 'latest.json'), JSON.stringify(latest));
+  return { objectHash, expectedData, latest };
+}
+
+function tempLeaks(root) {
+  const leaks = [];
+  (function walk(directory) {
+    if (!fs.existsSync(directory)) return;
+    fs.readdirSync(directory, { withFileTypes: true }).forEach((entry) => {
+      const full = path.join(directory, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name !== '.deploy.lock' &&
+          (entry.name.startsWith('.deploy-') || /\.(?:tmp|new|part)$/.test(entry.name))) leaks.push(full);
+    });
+  })(root);
+  return leaks;
+}
+
+function createLargeAssets(directory) {
+  fs.mkdirSync(directory, { recursive: true });
+  const script = [
+    'import hashlib,json,os,sys,zipfile',
+    'out=sys.argv[1]',
+    'ver=sys.argv[2]',
+    'size=300*1024*1024',
+    'chunk=b"\\0"*(1024*1024)',
+    'h=hashlib.sha256()',
+    'zp=os.path.join(out,"tianming-hot-"+ver+".zip")',
+    'with zipfile.ZipFile(zp,"w",zipfile.ZIP_DEFLATED,compresslevel=1) as z:',
+    '  with z.open("large.bin","w",force_zip64=True) as target:',
+    '    for _ in range(300):',
+    '      target.write(chunk); h.update(chunk)',
+    '  manifest={"version":ver,"files":[{"path":"large.bin","sha256":h.hexdigest(),"size":size}]}',
+    '  z.writestr("manifest.json",json.dumps(manifest,separators=(",",":")))',
+    'zh=hashlib.sha256()',
+    'with open(zp,"rb") as source:',
+    '  for part in iter(lambda:source.read(1024*1024),b""): zh.update(part)',
+    'feed={"version":ver,"sha256":zh.hexdigest(),"size":os.path.getsize(zp)}',
+    'open(os.path.join(out,"hot-latest.json"),"w",encoding="utf8").write(json.dumps(feed))'
+  ].join('\n');
+  const result = spawnSync('python', ['-c', script, directory, VER], { encoding: 'utf8', env: PY_ENV });
+  assert(result.status === 0, '300MB 流式测试制品生成');
+  return readJson(path.join(directory, 'hot-latest.json'));
+}
+
+function createLargeCapgoAssets(directory) {
+  fs.mkdirSync(directory, { recursive: true });
+  const script = [
+    'import hashlib,json,os,sys,zipfile',
+    'out=sys.argv[1]',
+    'ver=sys.argv[2]',
+    'chunk=b"\\0"*(1024*1024)',
+    'h=hashlib.sha256()',
+    'for _ in range(300): h.update(chunk)',
+    'object_hash=h.hexdigest()',
+    'pack=os.path.join(out,"capgo-files-"+ver+".zip")',
+    'with zipfile.ZipFile(pack,"w",zipfile.ZIP_DEFLATED,compresslevel=1,allowZip64=True) as z:',
+    '  with z.open(object_hash,"w",force_zip64=True) as target:',
+    '    for _ in range(300): target.write(chunk)',
+    'bundle=b"capgo-full-bundle\\n"',
+    'open(os.path.join(out,ver+".zip"),"wb").write(bundle)',
+    'latest={"version":ver,"url":"https://example.invalid/"+ver+".zip","size":len(bundle),"manifest":[{"file_name":"large.bin","file_hash":object_hash,"download_url":"https://example.invalid/files/"+object_hash}]}',
+    'open(os.path.join(out,"latest.json"),"w",encoding="utf8").write(json.dumps(latest))'
+  ].join('\n');
+  const result = spawnSync('python', ['-c', script, directory, VER], { encoding: 'utf8', env: PY_ENV });
+  assert(result.status === 0, '300MB Capgo 流式测试制品生成');
+  return readJson(path.join(directory, 'latest.json'));
+}
+
+async function main() {
+  try {
+    const goodAssets = path.join(TMP, 'assets-good');
+    const good = writeSmallAssets(goodAssets);
+    const goodServer = path.join(TMP, 'server-good');
+    let result = runDeploy(goodServer, goodAssets);
+    assert(result.status === 0, '合法 manifest 部署成功');
+    const firstObject = objectPath(goodServer, good.manifest.files[0]);
+    assert(fs.existsSync(firstObject), '对象按已验证 sha256 寻址');
+    assert(sha256(fs.readFileSync(firstObject)) === good.manifest.files[0].sha256, '落盘对象内容 hash 正确');
+    assert(readJson(path.join(goodServer, 'hot', 'hot-latest.json')).version === VER, '内容与 manifest 后才发布 feed');
+    assert(tempLeaks(goodServer).length === 0, '成功部署不残留共享或唯一临时文件');
+
+    const invalidCases = [
+      ['sha 路径载荷', (manifest) => { manifest.files[0].sha256 = '../../..'; }, 'MANIFEST_SHA_INVALID'],
+      ['非 hex sha', (manifest) => { manifest.files[0].sha256 = 'g'.repeat(64); }, 'MANIFEST_SHA_INVALID'],
+      ['63 位 sha', (manifest) => { manifest.files[0].sha256 = 'a'.repeat(63); }, 'MANIFEST_SHA_INVALID'],
+      ['65 位 sha', (manifest) => { manifest.files[0].sha256 = 'a'.repeat(65); }, 'MANIFEST_SHA_INVALID'],
+      ['越界 path', (manifest) => { manifest.files[0].path = '../escape.js'; }, 'MANIFEST_PATH_INVALID'],
+      ['重复 manifest path', (manifest) => { manifest.files.push(Object.assign({}, manifest.files[0])); }, 'MANIFEST_PATH_DUPLICATE'],
+      ['ZIP size 不符', (manifest) => { manifest.files[0].size += 1; }, 'MANIFEST_SIZE_MISMATCH']
+    ];
+    invalidCases.forEach((row, index) => {
+      const assets = path.join(TMP, 'assets-invalid-' + index);
+      writeSmallAssets(assets, row[1]);
+      const server = path.join(TMP, 'server-invalid-' + index);
+      const attempt = runDeploy(server, assets);
+      assert(attempt.status === 3 && attempt.stdout.includes(row[2]), row[0] + ' 在写盘前拒绝');
+      assert(!fs.existsSync(path.join(server, 'hot', 'hot-latest.json')), row[0] + ' 不发布 feed');
+    });
+
+    const mismatchAssets = path.join(TMP, 'assets-hash-mismatch');
+    writeSmallAssets(mismatchAssets, null, (zip, _manifest, files) => {
+      zip.updateFile('a.js', Buffer.alloc(files[0].data.length, 0x78));
+    });
+    const mismatchServer = path.join(TMP, 'server-hash-mismatch');
+    fs.mkdirSync(path.join(mismatchServer, 'hot'), { recursive: true });
+    const oldFeedBytes = Buffer.from('{"version":"9.6.9.9","sentinel":"unchanged"}\n');
+    fs.writeFileSync(path.join(mismatchServer, 'hot', 'hot-latest.json'), oldFeedBytes);
+    result = runDeploy(mismatchServer, mismatchAssets);
+    if (result.status !== 3 || !result.stdout.includes('OBJECT_HASH_MISMATCH')) {
+      throw new Error('FAIL·实际 entry hash 不符时拒绝\n' + (result.stdout + result.stderr).slice(-800));
+    }
+    assert(true, '实际 entry hash 不符时拒绝');
+    assert(fs.readFileSync(path.join(mismatchServer, 'hot', 'hot-latest.json')).equals(oldFeedBytes), '中途失败时 live feed 字节不变');
+    assert(!fs.existsSync(path.join(mismatchServer, 'hot', 'manifests', VER + '.json')), '内容失败时版本 manifest 不发布');
+    assert(tempLeaks(mismatchServer).length === 0, '内容失败清理唯一临时文件');
+    const goodFeedBeforeRetry = fs.readFileSync(path.join(goodServer, 'hot', 'hot-latest.json'));
+    result = runDeploy(goodServer, mismatchAssets);
+    assert(result.status === 3 && result.stdout.includes('OBJECT_HASH_MISMATCH'), '已有正确对象也不能遮蔽 ZIP 内损坏 entry');
+    assert(fs.readFileSync(path.join(goodServer, 'hot', 'hot-latest.json')).equals(goodFeedBeforeRetry), '幂等重跑内容损坏时 feed 仍不变');
+
+    const largeAssets = path.join(TMP, 'assets-large');
+    createLargeAssets(largeAssets);
+    const memoryServer = path.join(TMP, 'server-memory');
+    result = runDeploy(memoryServer, largeAssets, ['--dry-run', '--report-peak-memory']);
+    const peakMatch = result.stdout.match(/PEAK_TRACED_BYTES=(\d+)/);
+    assert(result.status === 0 && peakMatch, '300MB 条目 dry-run 完整校验成功并报告峰值');
+    const peakBytes = Number(peakMatch[1]);
+    assert(peakBytes < 48 * 1024 * 1024, '300MB 条目 Python traced peak < 48MiB（实际 ' + Math.round(peakBytes / 1048576) + 'MiB）');
+
+    const capgoAssets = path.join(TMP, 'assets-capgo-good');
+    const capgoGood = writeCapgoAssets(capgoAssets);
+    const capgoServer = path.join(TMP, 'server-capgo-good');
+    const corruptObject = capgoObjectPath(capgoServer, capgoGood.objectHash);
+    fs.mkdirSync(path.dirname(corruptObject), { recursive: true });
+    fs.writeFileSync(corruptObject, 'truncated');
+    result = runDeploy(capgoServer, capgoAssets, [], 'capgo');
+    assert(result.status === 0, 'Capgo 对象包部署成功');
+    assert(result.stdout.includes('既有对象损坏·重新写入'), '同名损坏 Capgo 对象不会被错误跳过');
+    assert(sha256File(corruptObject) === capgoGood.objectHash, '损坏 Capgo 对象被原子重写为正确内容');
+    assert(fs.readFileSync(corruptObject).equals(capgoGood.expectedData), 'Capgo 对象落盘内容完整');
+    assert(readJson(path.join(capgoServer, 'capgo', 'latest.json')).version === VER, 'Capgo 对象完成后才发布 latest feed');
+    assert(tempLeaks(capgoServer).length === 0, 'Capgo 成功部署不残留临时文件');
+
+    const duplicateCapgoAssets = path.join(TMP, 'assets-capgo-duplicate');
+    writeCapgoAssets(duplicateCapgoAssets, { duplicate: true });
+    const duplicateCapgoServer = path.join(TMP, 'server-capgo-duplicate');
+    fs.mkdirSync(path.join(duplicateCapgoServer, 'capgo'), { recursive: true });
+    const duplicateFeedBytes = Buffer.from('{"version":"9.6.9.9","sentinel":"duplicate-unchanged"}\n');
+    fs.writeFileSync(path.join(duplicateCapgoServer, 'capgo', 'latest.json'), duplicateFeedBytes);
+    result = runDeploy(duplicateCapgoServer, duplicateCapgoAssets, [], 'capgo');
+    assert(result.status === 7 && result.stdout.includes('CAPGO_OBJECT_DUPLICATE'), 'Capgo 对象包重复 hash 在任何对象写入前拒绝');
+    assert(fs.readFileSync(path.join(duplicateCapgoServer, 'capgo', 'latest.json')).equals(duplicateFeedBytes), 'Capgo 重复对象失败不改变 live feed');
+    assert(tempLeaks(duplicateCapgoServer).length === 0, 'Capgo 重复对象失败清理临时文件');
+
+    const mismatchCapgoAssets = path.join(TMP, 'assets-capgo-mismatch');
+    writeCapgoAssets(mismatchCapgoAssets, {
+      expectedData: Buffer.from('expected-capgo-object\n'),
+      entryData: Buffer.from('corrupt-capgo-object\n')
+    });
+    const mismatchCapgoServer = path.join(TMP, 'server-capgo-mismatch');
+    fs.mkdirSync(path.join(mismatchCapgoServer, 'capgo'), { recursive: true });
+    const mismatchCapgoFeedBytes = Buffer.from('{"version":"9.6.9.9","sentinel":"hash-unchanged"}\n');
+    fs.writeFileSync(path.join(mismatchCapgoServer, 'capgo', 'latest.json'), mismatchCapgoFeedBytes);
+    result = runDeploy(mismatchCapgoServer, mismatchCapgoAssets, [], 'capgo');
+    assert(result.status === 7 && result.stdout.includes('CAPGO_OBJECT_HASH_MISMATCH'), 'Capgo 对象名实不符时拒绝');
+    assert(fs.readFileSync(path.join(mismatchCapgoServer, 'capgo', 'latest.json')).equals(mismatchCapgoFeedBytes), 'Capgo hash 失败不改变 live feed');
+    assert(tempLeaks(mismatchCapgoServer).length === 0, 'Capgo hash 失败不残留临时文件');
+
+    const largeCapgoAssets = path.join(TMP, 'assets-capgo-large');
+    createLargeCapgoAssets(largeCapgoAssets);
+    const largeCapgoServer = path.join(TMP, 'server-capgo-memory');
+    result = runDeploy(largeCapgoServer, largeCapgoAssets, ['--dry-run', '--report-peak-memory'], 'capgo');
+    const capgoPeakMatch = result.stdout.match(/PEAK_TRACED_BYTES=(\d+)/);
+    assert(result.status === 0 && capgoPeakMatch, '300MB Capgo 对象 dry-run 完整校验成功并报告峰值');
+    const capgoPeakBytes = Number(capgoPeakMatch[1]);
+    assert(capgoPeakBytes < 48 * 1024 * 1024, '300MB Capgo 对象 Python traced peak < 48MiB（实际 ' + Math.round(capgoPeakBytes / 1048576) + 'MiB）');
+    assert(tempLeaks(largeCapgoServer).length === 0, 'Capgo 大对象 dry-run 不残留临时文件');
+
+    const concurrentServer = path.join(TMP, 'server-concurrent');
+    const first = spawnDeploy(concurrentServer, largeAssets);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const second = spawnDeploy(concurrentServer, largeAssets);
+    const pair = await Promise.all([first, second]);
+    assert(pair[0].status === 0 && pair[1].status === 0, '两个并发部署进程均完成');
+    assert(pair.some((item) => item.stdout.includes('等待部署锁')), '并发进程通过部署互斥锁串行化');
+    const largeManifest = readJson(path.join(concurrentServer, 'hot', 'manifests', VER + '.json'));
+    const largeObject = objectPath(concurrentServer, largeManifest.files[0]);
+    assert(fs.statSync(largeObject).size === 300 * 1024 * 1024, '并发后 300MB 对象完整');
+    assert(sha256File(largeObject) === largeManifest.files[0].sha256, '并发后对象 hash 正确');
+    assert(readJson(path.join(concurrentServer, 'hot', 'hot-latest.json')).version === VER, '并发后 live feed 有效');
+    assert(tempLeaks(concurrentServer).length === 0, '并发部署不残留临时文件');
+
+    console.log('PASS assertions=' + assertions);
+  } finally {
+    try { fs.rmSync(TMP, { recursive: true, force: true }); } catch (_) {}
+  }
+}
+
+main().catch((error) => {
+  console.error(error && error.stack || error);
+  try { fs.rmSync(TMP, { recursive: true, force: true }); } catch (_) {}
+  process.exit(1);
+});

--- a/web/scripts/verify-deploy-local.js
+++ b/web/scripts/verify-deploy-local.js
@@ -20,6 +20,9 @@ const HOT_BUILDER = path.join(ROOT, 'web', 'tools', 'build-hot-update-package.js
 const CAPGO_BUILDER = path.join(ROOT, 'mobile', 'scripts', 'build-capgo-bundle.ps1');
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-verify-deploy-'));
 const VER = '9.0.0.1';
+const POWERSHELL = spawnSync('pwsh', ['-NoProfile', '-Command', '$PSVersionTable.PSVersion.ToString()'], {
+  encoding: 'utf8'
+}).status === 0 ? 'pwsh' : 'powershell';
 
 let assertions = 0;
 function assert(cond, label) {
@@ -49,6 +52,16 @@ fs.writeFileSync(path.join(WEB, 'a.js'), 'var a=1;');
 fs.writeFileSync(path.join(WEB, 'styles.css'), 'body{}');
 fs.writeFileSync(path.join(WEB, 'changelog.json'), JSON.stringify({ entries: [{ date: '2026-06-11', module: VER + '·更新功能升级测试', title: 't', items: [] }] }));
 fs.writeFileSync(path.join(WEB, 'version.json'), JSON.stringify({ version: VER }));
+fs.mkdirSync(path.join(WEB, 'bundled-scenarios'), { recursive: true });
+fs.writeFileSync(path.join(WEB, '.hot-update-manifest.json'), JSON.stringify({ version: VER, files: [] }));
+fs.writeFileSync(path.join(WEB, 'bundled-scenarios', 'manifest.json'), JSON.stringify({ scenarios: [] }));
+fs.writeFileSync(path.join(WEB, 'bundled-scenarios', 'manifest.js'), 'window.TM_BUNDLED_SCENARIO_MANIFEST={scenarios:[]};\n');
+// Keep the synthetic release tree above the same production safety floor enforced by stage-web-release.
+fs.mkdirSync(path.join(WEB, 'fixture-runtime'), { recursive: true });
+for (let i = 0; i < 300; i++) {
+  fs.writeFileSync(path.join(WEB, 'fixture-runtime', 'part-' + String(i).padStart(3, '0') + '.js'),
+    'window.__deployFixture' + i + '=' + i + ';\n');
+}
 fs.writeFileSync(path.join(APP, 'main-impl.js'), '// main');
 fs.writeFileSync(path.join(APP, 'preload-impl.js'), '// preload');
 let r = spawnSync('node', [HOT_BUILDER, '--version', VER, '--out', ASSETS, '--notes', 'deploy-verify',
@@ -57,7 +70,7 @@ assert(r.status === 0, '制品·桌面热更构建（' + (r.status === 0 ? 'ok' 
 fs.copyFileSync(path.join(WEB, 'changelog.json'), path.join(ASSETS, 'changelog.json'));
 
 // 安卓侧·真构建器产全量 zip + manifest + 对象包
-r = spawnSync('powershell', ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', CAPGO_BUILDER,
+r = spawnSync(POWERSHELL, ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', CAPGO_BUILDER,
   '-Version', VER, '-WebDir', WEB, '-OutDir', ASSETS, '-Manifest', '-PackFiles'], { encoding: 'utf-8' });
 assert(r.status === 0, '制品·capgo 构建（' + (r.status === 0 ? 'ok' : (r.stderr || r.stdout)) + '）');
 const capgoManifest = readJson(path.join(ASSETS, VER + '-manifest.json'));


### PR DESCRIPTION
## Scope
- validate manifest paths, duplicate entries, SHA-256 shape, ZIP size, and destination containment before publication
- stream Desktop and Capgo ZIP members with simultaneous hash/size verification and fsync-backed unique temporary files
- validate the complete Capgo object identity table before writes and reject duplicate hashes
- verify existing Capgo objects by content hash and atomically replace damaged objects
- serialize the complete deployment under a process lock
- publish content and manifest before the live feed

## Verification
- smoke-deploy-manifest-atomicity.js: 50 assertions
- separate 300 MiB Desktop and Capgo fixtures: 5 MiB traced Python peak each
- corrupt existing Capgo object repair, duplicate-hash rejection, hash mismatch, unchanged-feed, and temp cleanup passed
- concurrent deployment serialization passed
- verify-deploy-local.js: 32 assertions

Stacked on the population PR. No production deployment was executed.