### PR TITLE
ci: validate fiscal population deployment and transaction hardening

### DIFF
--- a/main-impl.js
+++ b/main-impl.js
@@ -251,6 +251,59 @@ function writeFileAtomic(file, data, encoding) {
   }
 }
 
+function _readAppConfigForAtomicUpdate() {
+  if (!fs.existsSync(CONFIG_FILE)) return {};
+  const original = fs.readFileSync(CONFIG_FILE);
+  try {
+    const parsed = JSON.parse(original.toString('utf-8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('app_config.json 根节点必须是对象');
+    }
+    return parsed;
+  } catch (error) {
+    const stamp = new Date().toISOString().replace(/[-:TZ.]/g, '').slice(0, 17);
+    const backup = CONFIG_FILE + '.corrupt-' + stamp + '-' + process.pid + '-' + crypto.randomUUID();
+    writeFileAtomic(backup, original);
+    console.warn('[config] app_config.json 无法解析·已原字节备份后重建·'
+      + path.basename(backup) + '·' + (error && error.message || error));
+    return {};
+  }
+}
+
+function _normalizeWindowBounds(bounds) {
+  if (!bounds || typeof bounds !== 'object') throw new Error('窗口位置数据缺失');
+  const normalized = {};
+  ['x', 'y', 'width', 'height'].forEach(key => {
+    const value = Number(bounds[key]);
+    if (!Number.isFinite(value) || ((key === 'width' || key === 'height') && value <= 0)) {
+      throw new Error('窗口位置字段非法·' + key);
+    }
+    normalized[key] = value;
+  });
+  return normalized;
+}
+
+function _persistWindowBoundsForExit(targetWindow) {
+  try {
+    if (!targetWindow
+      || (typeof targetWindow.isDestroyed === 'function' && targetWindow.isDestroyed())
+      || typeof targetWindow.getBounds !== 'function') {
+      return { ok: true, skipped: true };
+    }
+    const bounds = _normalizeWindowBounds(targetWindow.getBounds());
+    const previous = _readAppConfigForAtomicUpdate();
+    writeJsonAtomic(CONFIG_FILE, Object.assign({}, previous, { window: bounds }));
+    return { ok: true, bounds };
+  } catch (error) {
+    console.warn('[config] 关闭前窗口配置原子写入失败·' + (error && error.message || error));
+    return {
+      ok: false,
+      code: 'window-config-write-failed',
+      reason: error && error.message || String(error)
+    };
+  }
+}
+
 function desktopSaveMetadataPath(storageKey) {
   storageKey = String(storageKey == null ? '' : storageKey);
   if (!storageKey || storageKey.length > 140 || path.basename(storageKey) !== storageKey || /[<>:"/\\|?*]/.test(storageKey)) {
@@ -2730,10 +2783,19 @@ function _requestApplicationExit(kind, reason, exitAction, winOverride) {
         error: String(result && result.reason || '后台保存未安全完成')
       };
     }
+    const configResult = _persistWindowBoundsForExit(targetWindow);
+    if (!(configResult && configResult.ok === true)) {
+      _resetApplicationExitRequest();
+      return {
+        success: false,
+        code: String(configResult && configResult.code || 'window-config-write-failed'),
+        error: String(configResult && configResult.reason || '窗口配置未安全写入')
+      };
+    }
     try {
       _allowAppClose = true;
       exitAction();
-      return { success: true, kind, flush: result };
+      return { success: true, kind, flush: result, config: configResult };
     } catch (error) {
       _allowAppClose = false;
       _resetApplicationExitRequest();
@@ -2774,6 +2836,11 @@ function requestApplicationUpdateInstall(reason, winOverride) {
   return _requestApplicationExit('update-install', reason, () => {
     autoUpdater.quitAndInstall(false, true);
   }, arguments.length >= 2 ? winOverride : mainWindow);
+}
+
+function _resetApplicationExitStateForTest() {
+  _allowAppClose = false;
+  _resetApplicationExitRequest();
 }
 
 function createWindow() {
@@ -2854,13 +2921,8 @@ function createWindow() {
     mainWindow.webContents.focus();
   });
 
-  // 窗口关闭前，保存窗口的位置和大小·merge 进 CONFIG_FILE 而不是覆盖 (保 webRootOverride 等字段)
+  // 第一次 close 先阻止退出；renderer 存档握手成功后，统一入口再原子保存最新窗口位置。
   mainWindow.on('close', event => {
-    try {
-      const bounds = mainWindow.getBounds();
-      const prev = readJsonSafe(CONFIG_FILE, {});
-      fs.writeFileSync(CONFIG_FILE, JSON.stringify(Object.assign({}, prev, { window: bounds }), null, 2), 'utf-8');
-    } catch (e) { /* 忽略 */ }
     if (!_allowAppClose && event && typeof event.preventDefault === 'function') {
       event.preventDefault();
       requestApplicationQuit('window-close').catch(error => {
@@ -3004,8 +3066,7 @@ function createMenu() {
             }
             try {
               const prev = readJsonSafe(CONFIG_FILE, {});
-              fs.writeFileSync(CONFIG_FILE, JSON.stringify(
-                Object.assign({}, prev, { webRootOverride: picked }), null, 2), 'utf-8');
+              writeJsonAtomic(CONFIG_FILE, Object.assign({}, prev, { webRootOverride: picked }));
               const choice = await dialog.showMessageBox(mainWindow, {
                 type: 'info', title: 'dev web override 已保存',
                 message: '已保存·' + picked,
@@ -3030,7 +3091,7 @@ function createMenu() {
                 return;
               }
               delete prev.webRootOverride;
-              fs.writeFileSync(CONFIG_FILE, JSON.stringify(prev, null, 2), 'utf-8');
+              writeJsonAtomic(CONFIG_FILE, prev);
               const choice = await dialog.showMessageBox(mainWindow, {
                 type: 'info', title: '已清除',
                 message: '已清除 web 目录覆盖·回到 bundled web',
@@ -4322,6 +4383,8 @@ if (TEST_MODE) {
     requestApplicationQuit,
     requestApplicationRelaunch,
     requestApplicationUpdateInstall,
+    persistWindowBoundsForExit: _persistWindowBoundsForExit,
+    resetApplicationExitStateForTest: _resetApplicationExitStateForTest,
     APP_CLOSE_FLUSH_TIMEOUT_MS,
     preflightWorkshopZip,
     extractZipToTemp,
@@ -4364,7 +4427,8 @@ if (TEST_MODE) {
       HOT_UPDATE_DIR,
       HOT_UPDATE_VERSIONS_DIR,
       HOT_UPDATE_STATE_FILE,
-      BOOT_ATTEMPT_FILE
+      BOOT_ATTEMPT_FILE,
+      CONFIG_FILE
     }
   };
 }

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -330,78 +330,189 @@ async function gateLive() {
   return { capgoManifest: capgo && Array.isArray(capgo.manifest) ? capgo.manifest : null };
 }
 
-// ── ④ 版本扇出盖戳（全部带「恰一处匹配」断言 + .bak 备份 + 写后回读复核） ────
+// ── ④ 版本扇出盖戳（只读规划 → 全量验证 → 原子写入；任一步失败恢复全部原字节） ──
+function _fanOutError(message, cause) {
+  const error = new Error(message);
+  error.code = 'release-version-fanout-failed';
+  if (cause) error.cause = cause;
+  return error;
+}
+
+function _readFanOutFile(file, description) {
+  if (!fs.existsSync(file)) throw _fanOutError('扇出失败·缺 ' + description + '（' + file + '）');
+  return fs.readFileSync(file);
+}
+
+function _parseFanOutJson(buffer, description) {
+  let raw = buffer.toString('utf-8');
+  if (raw.charCodeAt(0) === 0xFEFF) raw = raw.slice(1);
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw _fanOutError('扇出失败·' + description + ' 不是合法 JSON', error);
+  }
+}
+
+function _replaceFanOutAnchor(source, description, expression, replacement) {
+  const flags = expression.flags.indexOf('g') >= 0 ? expression.flags : expression.flags + 'g';
+  const matches = source.match(new RegExp(expression.source, flags)) || [];
+  if (matches.length !== 1) {
+    throw _fanOutError('扇出失败·' + description + '·期望恰 1 处匹配·实得 ' + matches.length);
+  }
+  return source.replace(expression, replacement);
+}
+
+function planVersionFanOut(code) {
+  const semver = mapBuildToSemver(CFG.version);
+  const packageFile = P.pkg();
+  const packageOriginal = _readFanOutFile(packageFile, 'package.json');
+  const pkg = _parseFanOutJson(packageOriginal, 'package.json');
+  // ★2026-07-04·四段 buildVersion 映射为 a.b.(c*100+d)，避免连续安装包共享三段版本。
+  pkg.version = semver;
+  pkg.build = pkg.build || {};
+  pkg.build.buildVersion = CFG.version;
+  if (pkg.build.directories && /测试版[\d.]+$/.test(String(pkg.build.directories.output || ''))) {
+    pkg.build.directories.output = String(pkg.build.directories.output).replace(/测试版[\d.]+$/, '测试版' + CFG.version);
+  }
+  if (typeof pkg.build.artifactName === 'string' && /[\d]+(\.[\d]+){2,3}/.test(pkg.build.artifactName)) {
+    pkg.build.artifactName = pkg.build.artifactName.replace(/[\d]+(\.[\d]+){2,3}/, CFG.version);
+  }
+
+  const lockFile = P.pkgLock();
+  const lockOriginal = _readFanOutFile(lockFile, 'package-lock.json');
+  const lock = _parseFanOutJson(lockOriginal, 'package-lock.json');
+  if (!lock.packages || !lock.packages['']) {
+    throw _fanOutError('扇出失败·package-lock.json 缺 packages[""]');
+  }
+  lock.version = semver;
+  lock.packages[''].version = semver;
+
+  const mobileFile = P.mobileReleaseVersion();
+  const mobileOriginal = _readFanOutFile(mobileFile, 'mobile/release-version.json');
+  _parseFanOutJson(mobileOriginal, 'mobile/release-version.json');
+
+  const versionFile = P.versionJson();
+  const versionOriginal = _readFanOutFile(versionFile, 'web/version.json');
+  _parseFanOutJson(versionOriginal, 'web/version.json');
+
+  const indexFile = P.indexHtml();
+  const indexOriginal = _readFanOutFile(indexFile, 'web/index.html');
+  let indexNext = indexOriginal.toString('utf-8');
+  indexNext = _replaceFanOutAnchor(indexNext, 'index.html meta tm-version',
+    /(<meta\s+name="tm-version"\s+content=")[\d.]+(")/, '$1' + CFG.version + '$2');
+  indexNext = _replaceFanOutAnchor(indexNext, 'index.html footer 版本号',
+    /(<span id="tm-foot-ver">)[\d.]+(<\/span>)/, '$1' + CFG.version + '$2');
+
+  return {
+    version: CFG.version,
+    versionCode: code,
+    semver,
+    descriptions: [
+      'package.json·version/buildVersion/output/artifactName',
+      'package-lock.json·version/packages[""]',
+      'mobile/release-version.json·version/versionCode',
+      'web/version.json',
+      'index.html meta tm-version',
+      'index.html footer 版本号'
+    ],
+    edits: [
+      { path: packageFile, original: packageOriginal, content: Buffer.from(JSON.stringify(pkg, null, 2) + '\n') },
+      { path: lockFile, original: lockOriginal, content: Buffer.from(JSON.stringify(lock, null, 2) + '\n') },
+      { path: mobileFile, original: mobileOriginal, content: Buffer.from(JSON.stringify({ version: CFG.version, versionCode: code }, null, 2) + '\n') },
+      { path: versionFile, original: versionOriginal, content: Buffer.from(JSON.stringify({ version: CFG.version, date: today(), notes: CFG.notes || '' }, null, 2) + '\n') },
+      { path: indexFile, original: indexOriginal, content: Buffer.from(indexNext) }
+    ]
+  };
+}
+
+function validateVersionFanOutPlan(plan) {
+  if (!plan || !Array.isArray(plan.edits) || plan.edits.length !== 5) {
+    throw _fanOutError('扇出计划必须完整包含 5 个目标文件');
+  }
+  const paths = new Set();
+  plan.edits.forEach(edit => {
+    if (!edit || !edit.path || !Buffer.isBuffer(edit.original) || !Buffer.isBuffer(edit.content)) {
+      throw _fanOutError('扇出计划包含非法编辑项');
+    }
+    const resolved = path.resolve(edit.path);
+    if (paths.has(resolved)) throw _fanOutError('扇出计划重复目标·' + resolved);
+    paths.add(resolved);
+  });
+  const byPath = new Map(plan.edits.map(edit => [path.resolve(edit.path), edit.content]));
+  const pkg = _parseFanOutJson(byPath.get(path.resolve(P.pkg())), '计划 package.json');
+  if (!pkg.build || pkg.build.buildVersion !== plan.version || pkg.version !== plan.semver) {
+    throw _fanOutError('扇出计划校验失败·package.json 版本');
+  }
+  const lock = _parseFanOutJson(byPath.get(path.resolve(P.pkgLock())), '计划 package-lock.json');
+  if (lock.version !== plan.semver || !lock.packages || !lock.packages[''] || lock.packages[''].version !== plan.semver) {
+    throw _fanOutError('扇出计划校验失败·package-lock.json 根版本');
+  }
+  const mobile = _parseFanOutJson(byPath.get(path.resolve(P.mobileReleaseVersion())), '计划 mobile/release-version.json');
+  if (mobile.version !== plan.version || Number(mobile.versionCode) !== Number(plan.versionCode)) {
+    throw _fanOutError('扇出计划校验失败·mobile/release-version.json');
+  }
+  const webVersion = _parseFanOutJson(byPath.get(path.resolve(P.versionJson())), '计划 web/version.json');
+  if (webVersion.version !== plan.version) throw _fanOutError('扇出计划校验失败·web/version.json');
+  const html = byPath.get(path.resolve(P.indexHtml())).toString('utf-8');
+  const escaped = plan.version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (!(new RegExp('<meta\\s+name="tm-version"\\s+content="' + escaped + '"')).test(html)
+    || !(new RegExp('<span id="tm-foot-ver">' + escaped + '<\\/span>')).test(html)) {
+    throw _fanOutError('扇出计划校验失败·index.html 版本锚点');
+  }
+  return plan;
+}
+
+function _writeReleaseFileAtomic(file, content) {
+  const tmp = file + '.tmp-release-' + process.pid + '-' + crypto.randomUUID();
+  let fd = null;
+  try {
+    fd = fs.openSync(tmp, 'wx');
+    fs.writeFileSync(fd, content);
+    fs.fsyncSync(fd);
+    fs.closeSync(fd);
+    fd = null;
+    fs.renameSync(tmp, file);
+  } catch (error) {
+    if (fd !== null) { try { fs.closeSync(fd); } catch (_) {} }
+    try { fs.rmSync(tmp, { force: true }); } catch (_) {}
+    throw error;
+  }
+}
+
+function applyVersionFanOutPlanAtomically(plan) {
+  validateVersionFanOutPlan(plan);
+  plan.edits.forEach(edit => {
+    const current = fs.readFileSync(edit.path);
+    if (!current.equals(edit.original)) {
+      throw _fanOutError('扇出源文件在规划后发生变化·' + edit.path);
+    }
+  });
+  try {
+    plan.edits.forEach(edit => {
+      _writeReleaseFileAtomic(edit.path + '.bak-release-' + CFG.ts, edit.original);
+      _writeReleaseFileAtomic(edit.path, edit.content);
+    });
+    plan.edits.forEach(edit => {
+      const written = fs.readFileSync(edit.path);
+      if (!written.equals(edit.content)) throw _fanOutError('扇出写后回读不一致·' + edit.path);
+    });
+    return plan;
+  } catch (error) {
+    const rollbackFailures = [];
+    plan.edits.slice().reverse().forEach(edit => {
+      try { _writeReleaseFileAtomic(edit.path, edit.original); }
+      catch (rollbackError) { rollbackFailures.push(edit.path + '·' + (rollbackError && rollbackError.message || rollbackError)); }
+    });
+    const failure = _fanOutError('版本扇出已回滚·' + (error && error.message || error), error);
+    if (rollbackFailures.length) failure.rollbackFailures = rollbackFailures;
+    throw failure;
+  }
+}
+
 function fanOutVersions(code) {
-  const edits = [];
-  function backup(file) { fs.copyFileSync(file, file + '.bak-release-' + CFG.ts); }
-  function regexEdit(file, desc, re, replacement) {
-    const src = fs.readFileSync(file, 'utf-8');
-    const matches = src.match(new RegExp(re.source, re.flags.replace('g', '') + 'g')) || [];
-    if (matches.length !== 1) die('扇出失败·' + desc + '·期望恰 1 处匹配·实得 ' + matches.length + '（' + file + '）');
-    backup(file);
-    const next = src.replace(re, replacement);
-    fs.writeFileSync(file, next, 'utf-8');
-    const verify = fs.readFileSync(file, 'utf-8');
-    if (verify.indexOf(typeof replacement === 'string' ? replacement.replace(/\$\d/g, '') : '') === -1 && !re.test(verify) === false) { /* 回读由具体调用断言 */ }
-    edits.push(desc);
-  }
-  // package.json·JSON round-trip（保键序·无注释·安全）
-  {
-    const file = P.pkg();
-    const pkg = readJson(file);
-    backup(file);
-    // ★2026-07-04·根治「新安装包打开仍旧版」：旧实现 `CFG.version.split('.').slice(0,3)` 把四段
-    //   1.3.4.5/1.3.4.6 一律截成 "1.3.4" → electron-builder/NSIS/electron-updater 认它·连续版同版本号
-    //   → 新安装包不当升级。改用映射 a.b.(c*100+d)·每版随 buildVersion 递增(见 scripts/version-map.js)。
-    pkg.version = mapBuildToSemver(CFG.version);
-    pkg.build = pkg.build || {};
-    pkg.build.buildVersion = CFG.version;
-    if (pkg.build.directories && /测试版[\d.]+$/.test(String(pkg.build.directories.output || ''))) {
-      pkg.build.directories.output = String(pkg.build.directories.output).replace(/测试版[\d.]+$/, '测试版' + CFG.version);
-    }
-    if (typeof pkg.build.artifactName === 'string' && /[\d]+(\.[\d]+){2,3}/.test(pkg.build.artifactName)) {
-      pkg.build.artifactName = pkg.build.artifactName.replace(/[\d]+(\.[\d]+){2,3}/, CFG.version);
-    }
-    fs.writeFileSync(file, JSON.stringify(pkg, null, 2) + '\n', 'utf-8');
-    const back = readJson(file);
-    if (back.build.buildVersion !== CFG.version) die('扇出回读失败·package.json buildVersion');
-    edits.push('package.json·version/buildVersion/output/artifactName');
-  }
-  // npm lockfile 的项目版本也是 canonical metadata。若 prepare 只改 package.json，
-  // npm ci/打包元数据会继续携带旧版本，且下一版 prepare 会重复制造漂移。
-  {
-    const file = P.pkgLock();
-    if (!fs.existsSync(file)) die('扇出失败·缺 package-lock.json');
-    const lock = readJson(file);
-    if (!lock.packages || !lock.packages['']) die('扇出失败·package-lock.json 缺 packages[""]');
-    backup(file);
-    const semver = mapBuildToSemver(CFG.version);
-    lock.version = semver;
-    lock.packages[''].version = semver;
-    fs.writeFileSync(file, JSON.stringify(lock, null, 2) + '\n', 'utf-8');
-    const back = readJson(file);
-    if (back.version !== semver || !back.packages || !back.packages[''] || back.packages[''].version !== semver) {
-      die('扇出回读失败·package-lock.json 根版本');
-    }
-    edits.push('package-lock.json·version/packages[""]');
-  }
-  {
-    const file = P.mobileReleaseVersion();
-    if (fs.existsSync(file)) backup(file);
-    fs.writeFileSync(file, JSON.stringify({ version: CFG.version, versionCode: code }, null, 2) + '\n', 'utf-8');
-    const back = readJson(file);
-    if (back.version !== CFG.version || Number(back.versionCode) !== code) die('扇出回读失败·mobile/release-version.json');
-    edits.push('mobile/release-version.json·version/versionCode');
-  }
-  {
-    const file = P.versionJson();
-    if (fs.existsSync(file)) backup(file);
-    fs.writeFileSync(file, JSON.stringify({ version: CFG.version, date: today(), notes: CFG.notes || '' }, null, 2) + '\n', 'utf-8');
-    edits.push('web/version.json');
-  }
-  regexEdit(P.indexHtml(), 'index.html meta tm-version', /(<meta\s+name="tm-version"\s+content=")[\d.]+(")/, '$1' + CFG.version + '$2');
-  regexEdit(P.indexHtml(), 'index.html footer 版本号', /(<span id="tm-foot-ver">)[\d.]+(<\/span>)/, '$1' + CFG.version + '$2');
-  log('④ 版本扇出·' + edits.length + ' 处盖戳完成（各留 .bak-release-' + CFG.ts + '）');
+  const plan = planVersionFanOut(code);
+  applyVersionFanOutPlanAtomically(plan);
+  log('④ 版本扇出·' + plan.descriptions.length + ' 处盖戳完成（各文件留 .bak-release-' + CFG.ts + '）');
 }
 
 function syncGeneratedAndroidVersion() {
@@ -861,7 +972,43 @@ function selfTest() {
   const code = gatePrepareVersion();
   ok(code === 9999, 'versionCode 显式');
   gateChangelog();
+  const transactionPlan = planVersionFanOut(code);
+  const originalFanOutBytes = new Map(transactionPlan.edits.map(edit => [edit.path, Buffer.from(edit.original)]));
+  let injectedFanOutFailure = null;
+  const originalRenameSync = fs.renameSync;
+  let injectedThirdWrite = false;
+  fs.renameSync = function (source, destination) {
+    if (!injectedThirdWrite && path.resolve(destination) === path.resolve(transactionPlan.edits[2].path)) {
+      injectedThirdWrite = true;
+      throw new Error('injected third-file write failure');
+    }
+    return originalRenameSync.apply(this, arguments);
+  };
+  try {
+    applyVersionFanOutPlanAtomically(transactionPlan);
+  } catch (error) {
+    injectedFanOutFailure = error;
+  } finally {
+    fs.renameSync = originalRenameSync;
+  }
+  ok(injectedFanOutFailure && injectedFanOutFailure.code === 'release-version-fanout-failed',
+    'fanOut·第三文件故障返回结构化事务错误');
+  ok(transactionPlan.edits.every(edit => fs.readFileSync(edit.path).equals(originalFanOutBytes.get(edit.path))),
+    'fanOut·中途失败后五个目标恢复原字节');
+  ok(transactionPlan.edits.every(edit => {
+    const backup = edit.path + '.bak-release-' + CFG.ts;
+    return !fs.existsSync(backup) || fs.readFileSync(backup).equals(originalFanOutBytes.get(edit.path));
+  }), 'fanOut·故障后现存备份与真实原状态一致');
+  const releaseTemps = [];
+  transactionPlan.edits.forEach(edit => {
+    fs.readdirSync(path.dirname(edit.path)).forEach(name => {
+      if (name.indexOf(path.basename(edit.path) + '.tmp-release-') === 0) releaseTemps.push(name);
+    });
+  });
+  ok(releaseTemps.length === 0, 'fanOut·失败回滚不遗留原子写临时文件');
   fanOutVersions(code);
+  ok(transactionPlan.edits.every(edit => !fs.readFileSync(edit.path).equals(originalFanOutBytes.get(edit.path))),
+    'fanOut·回滚后第二次执行可完整成功');
   ok(preparedVersionProblems(code, false).length === 0, 'publish 读取已盖戳版本·不再 fanOut');
   ok(!fs.existsSync(P.hotBaseline()), 'fresh tree·prepare 前可无 canonical 基线');
   fs.mkdirSync(path.join(tmp, 'release-hot', 'manifests'), { recursive: true });

--- a/scripts/verify-release-workflow-contract.js
+++ b/scripts/verify-release-workflow-contract.js
@@ -40,6 +40,21 @@ function main() {
   ok(release.includes('gateGitHubOwner()') && release.includes('validateGitHubOwnerFacts'), '正式外写前验证 gh 当前账号为仓库 owner');
   ok(release.includes("facts.branch === 'main'") && release.includes('!facts.originMainAncestor'), 'prepare 拒绝 main 与陈旧分支');
   ok(release.includes("--offline 仅可与 --publish --no-upload 合用"), 'offline 不能绕过正式发布线上闸');
+  const fanOutStart = release.indexOf('function planVersionFanOut(');
+  const fanOutEnd = release.indexOf('function syncGeneratedAndroidVersion(', fanOutStart);
+  const fanOut = release.slice(fanOutStart, fanOutEnd);
+  ok(fanOutStart >= 0
+    && fanOut.includes('function validateVersionFanOutPlan(')
+    && fanOut.includes('function applyVersionFanOutPlanAtomically('),
+  '版本扇出采用只读规划、全量验证和原子应用三阶段');
+  ok(fanOut.indexOf('validateVersionFanOutPlan(plan)') < fanOut.indexOf("edit.path + '.bak-release-'")
+    && fanOut.includes("fs.fsyncSync(fd)")
+    && fanOut.includes("fs.renameSync(tmp, file)"),
+  '版本文件与备份均经同目录 fsync+rename 原子提交');
+  ok(fanOut.includes("plan.edits.slice().reverse()")
+    && fanOut.includes("_writeReleaseFileAtomic(edit.path, edit.original)")
+    && !fanOut.includes('die('),
+  '版本扇出深层失败抛错并逆序恢复原字节，不以 process.exit 绕过回滚');
 
   // 在线版只经 workflow_dispatch 从 main 部署（github-pages 环境不放行 ship-* tag）·安全=actor==owner + ref 在 origin/main
   ok(!pages.includes('release:\n    types: [published]') && !pages.includes("github.event.release"), 'Pages 无 release/tag 触发（改 workflow_dispatch/main）');

--- a/web/scripts/lint-renderer-writeback-boundaries.js
+++ b/web/scripts/lint-renderer-writeback-boundaries.js
@@ -256,6 +256,16 @@ check(/ipcMain\.handle\('app-quit',\s*\(\)\s*=>\s*requestApplicationQuit\(/.test
   'renderer quit requests must pass through the background-save close handshake');
 check(/mainWindow\.on\('close',\s*event\s*=>[\s\S]*?event\.preventDefault\(\)[\s\S]*?requestApplicationQuit\('window-close'\)/.test(mainSource),
   'native window close must be intercepted until the renderer flush acknowledgement completes');
+const appExitStart = mainSource.indexOf('function _requestApplicationExit(');
+const appExitEnd = mainSource.indexOf('function requestApplicationQuit(', appExitStart);
+const appExitSource = mainSource.slice(appExitStart, appExitEnd);
+check(appExitStart >= 0
+  && appExitSource.indexOf('requestRendererCloseFlush(') < appExitSource.indexOf('_persistWindowBoundsForExit(')
+  && appExitSource.indexOf('_persistWindowBoundsForExit(') < appExitSource.indexOf('_allowAppClose = true'),
+  'application exit must flush renderer saves, atomically persist bounds, then permit close in that order');
+check(!/fs\.writeFileSync\(\s*CONFIG_FILE/.test(mainSource)
+  && /writeJsonAtomic\(CONFIG_FILE/.test(mainSource),
+  'app_config writes must use the shared atomic JSON writer');
 check(/app-close-flush-request/.test(mainSource) && /app-close-flush-complete/.test(mainSource),
   'main process must retain the bounded close-flush request/ack protocol');
 check(/onAppCloseFlushRequest[\s\S]*?_subscribeAppCloseFlush/.test(preloadSource)

--- a/web/scripts/smoke-app-close-background-flush.js
+++ b/web/scripts/smoke-app-close-background-flush.js
@@ -2,12 +2,16 @@
 'use strict';
 
 const EventEmitter = require('events');
+const fs = require('fs');
 const Module = require('module');
 const os = require('os');
 const path = require('path');
 const { pathToFileURL } = require('url');
 
 const ROOT = path.resolve(__dirname, '..', '..');
+const TEST_USER_DATA = path.join(os.tmpdir(), 'tm-close-flush-user-data-' + process.pid);
+fs.rmSync(TEST_USER_DATA, { recursive: true, force: true });
+fs.mkdirSync(TEST_USER_DATA, { recursive: true });
 const eventHandlers = new Map();
 let assertions = 0;
 const lifecycle = { quit: 0, relaunch: 0, exit: 0, updateInstall: 0 };
@@ -20,7 +24,7 @@ function check(value, message) {
 process.env.TIANMING_TEST_EXPORTS = '1';
 const electronStub = {
   app: {
-    getPath: () => path.join(os.tmpdir(), 'tm-close-flush-user-data'),
+    getPath: () => TEST_USER_DATA,
     getVersion: () => '1.3.4.11',
     getAppPath: () => ROOT,
     isPackaged: false,
@@ -54,9 +58,10 @@ Module._load = function (request) {
   return originalLoad.apply(this, arguments);
 };
 
-function makeWindow() {
+function makeWindow(initialBounds) {
   const webContents = new EventEmitter();
   const sent = [];
+  let bounds = initialBounds || null;
   const frame = {
     url: pathToFileURL(path.join(ROOT, 'web', 'index.html')).href,
     parent: null
@@ -68,15 +73,61 @@ function makeWindow() {
     sent,
     frame,
     webContents,
-    win: { isDestroyed: () => false, webContents }
+    setBounds(next) { bounds = next; },
+    win: Object.assign({ isDestroyed: () => false, webContents }, initialBounds ? {
+      getBounds: () => bounds
+    } : {})
   };
 }
 
 async function main() {
   const T = require(path.join(ROOT, 'main-impl.js')).__test;
   check(T && typeof T.requestRendererCloseFlush === 'function', 'main exports the production close-flush request helper in test mode');
+  check(typeof T.persistWindowBoundsForExit === 'function' && T.paths && T.paths.CONFIG_FILE,
+    'main exports the production atomic window-config helper and isolated test path');
   check(eventHandlers.has('app-close-flush-complete'), 'main registers one trusted close-flush acknowledgement channel');
   const acknowledge = eventHandlers.get('app-close-flush-complete');
+
+  const configFile = T.paths.CONFIG_FILE;
+  fs.mkdirSync(path.dirname(configFile), { recursive: true });
+  fs.writeFileSync(configFile, JSON.stringify({ webRootOverride: 'D:\\dev-web', retained: true }), 'utf-8');
+  const persisted = T.persistWindowBoundsForExit(makeWindow({ x: -120, y: 30, width: 1440, height: 900 }).win);
+  const mergedConfig = JSON.parse(fs.readFileSync(configFile, 'utf-8'));
+  check(persisted.ok === true && mergedConfig.webRootOverride === 'D:\\dev-web' && mergedConfig.retained === true,
+    'atomic window persistence preserves unrelated app_config fields');
+  check(mergedConfig.window.x === -120 && mergedConfig.window.width === 1440,
+    'atomic window persistence stores the validated latest bounds');
+
+  const bytesBeforeFailure = fs.readFileSync(configFile);
+  const originalRenameSync = fs.renameSync;
+  fs.renameSync = function (source, destination) {
+    if (path.resolve(destination) === path.resolve(configFile)) throw new Error('injected config rename failure');
+    return originalRenameSync.apply(this, arguments);
+  };
+  let failedPersist;
+  try {
+    failedPersist = T.persistWindowBoundsForExit(makeWindow({ x: 1, y: 2, width: 800, height: 600 }).win);
+  } finally {
+    fs.renameSync = originalRenameSync;
+  }
+  check(failedPersist.ok === false && failedPersist.code === 'window-config-write-failed',
+    'atomic window persistence reports injected commit failure');
+  check(fs.readFileSync(configFile).equals(bytesBeforeFailure), 'failed atomic config write preserves the old file byte-for-byte');
+  check(fs.readdirSync(path.dirname(configFile)).every(name => name.indexOf(path.basename(configFile) + '.tmp-') !== 0),
+    'failed atomic config write removes its temporary file');
+
+  const corruptBytes = Buffer.from('{"webRootOverride":');
+  fs.writeFileSync(configFile, corruptBytes);
+  const backupsBefore = new Set(fs.readdirSync(path.dirname(configFile)));
+  const recovered = T.persistWindowBoundsForExit(makeWindow({ x: 9, y: 8, width: 1024, height: 768 }).win);
+  const backupsAfter = fs.readdirSync(path.dirname(configFile)).filter(name =>
+    name.indexOf(path.basename(configFile) + '.corrupt-') === 0 && !backupsBefore.has(name));
+  check(recovered.ok === true && backupsAfter.length === 1,
+    'invalid legacy config is explicitly backed up before safe recovery');
+  check(fs.readFileSync(path.join(path.dirname(configFile), backupsAfter[0])).equals(corruptBytes),
+    'corrupt-config recovery preserves the original bytes in its diagnostic backup');
+  check(JSON.parse(fs.readFileSync(configFile, 'utf-8')).window.width === 1024,
+    'corrupt-config recovery replaces the invalid root with a valid window config');
 
   const success = makeWindow();
   const successPromise = T.requestRendererCloseFlush(success.win, 'renderer-test', 1000);
@@ -115,6 +166,40 @@ async function main() {
 
   const unavailable = await T.requestRendererCloseFlush(null, 'window-close', 10);
   check(unavailable.ok === true && unavailable.skipped === true, 'already unavailable renderer has no pending queue to flush');
+
+  T.resetApplicationExitStateForTest();
+  fs.writeFileSync(configFile, JSON.stringify({ webRootOverride: 'E:\\preserve-me' }), 'utf-8');
+  const repeatedClose = makeWindow({ x: 10, y: 20, width: 1200, height: 700 });
+  let configCommitCount = 0;
+  fs.renameSync = function (source, destination) {
+    if (path.resolve(destination) === path.resolve(configFile)) configCommitCount += 1;
+    return originalRenameSync.apply(this, arguments);
+  };
+  const firstClosePromise = T.requestApplicationQuit('window-close', repeatedClose.win);
+  const secondClosePromise = T.requestApplicationQuit('window-close', repeatedClose.win);
+  check(firstClosePromise === secondClosePromise && repeatedClose.sent.length === 1,
+    'repeated close requests share one save-and-config transaction');
+  repeatedClose.setBounds({ x: 40, y: 50, width: 1600, height: 1000 });
+  acknowledge({ sender: repeatedClose.webContents, senderFrame: repeatedClose.frame }, {
+    requestId: repeatedClose.sent[0].payload.requestId,
+    ok: true,
+    reason: 'queue-drained'
+  });
+  let repeatedCloseResult;
+  try {
+    repeatedCloseResult = await firstClosePromise;
+    await new Promise(resolve => setImmediate(resolve));
+  } finally {
+    fs.renameSync = originalRenameSync;
+  }
+  const closeConfig = JSON.parse(fs.readFileSync(configFile, 'utf-8'));
+  check(repeatedCloseResult.success === true && configCommitCount === 1,
+    'successful repeated close writes app_config exactly once after the renderer handshake');
+  check(closeConfig.webRootOverride === 'E:\\preserve-me' && closeConfig.window.x === 40 && closeConfig.window.width === 1600,
+    'close transaction persists the latest bounds while preserving existing config fields');
+  check(lifecycle.quit === 1, 'successful close schedules one normal app.quit');
+  lifecycle.quit = 0;
+  T.resetApplicationExitStateForTest();
 
   check(typeof T.requestApplicationRelaunch === 'function' && typeof T.requestApplicationUpdateInstall === 'function',
     'test exports expose the production relaunch and installer lifecycle coordinators');


### PR DESCRIPTION
## Purpose
Draft integration-only PR for remote CI of the complete five-layer stack after follow-up hardening.

Includes:
- canonical edict fiscal ledgers
- population schema/category transfer invariants, including category households normalization
- Desktop and Capgo streaming object deployment with atomic publication
- NUL-safe Git parsing and bounded reactive cascades
- transactional window config and release metadata fan-out

This PR is not intended to merge. Merge the reviewed stacked PRs #64 -> #65 -> #66 -> #67 -> #68 instead.

## Local final-stack verification
- targeted fiscal: 27 assertions
- targeted population: 44 assertions
- deployment atomicity: 50 assertions; Desktop and Capgo 300 MiB peaks both 5 MiB
- production-builder deployment: 32 assertions
- reactive cascade: 16 assertions
- architecture guards: 13/13
- full Smoke: 900 selected; 898 pass + 2 unchanged missing-asset exemptions; 0 non-exempt failures
- release contract: 166 assertions
- official scenario parity: 27 assertions
- hot builder gates: 27 assertions
- release transaction self-test: 48 assertions
- npm audit: 0 vulnerabilities

No package, release, or deployment was executed.