### PR TITLE
fix(editor): resolve region paths and reject phantom writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
         run: node scripts/verify-electron-bridge.js --building-appraisal
       - name: Edict polish complete text and visible failure recovery
         run: node scripts/verify-electron-bridge.js --edict-polish
+      - name: Authoring region paths and real editor persistence
+        run: node scripts/verify-electron-bridge.js --authoring-regions
       - name: Controlled TLS address binding and redirects
         run: node scripts/verify-remote-tls.js
       - name: Preserve Electron evidence (including startup failures)

--- a/docs/bugfix-authoring-region-paths-2026-09-08.md
+++ b/docs/bugfix-authoring-region-paths-2026-09-08.md
@@ -1,0 +1,58 @@
+# 工坊地区查找与写入一致性修复
+
+基线：`main@12942b78fe64d20f4eb9ee01827a2c3567b38bf1`（PR #73 合并后）。
+分支：`codex/fix-authoring-region-paths`。本轮仅授权本地代码、测试与提交；未推送、未合并、未发布。
+
+## 已确认的根因与修复
+
+- `editor-authoring-agent.js::_searchEntities` 原本直接取 `draft[collection]`，因此 `map.regions`、`adminHierarchy.楚.divisions` 虽然真实存在仍被报为不存在。现在搜索、批量修改、数值统计与单字段读写使用同一个路径解析器，搜索结果附带 ID 与可直接读写的完整路径。
+- `_resolvePath` / `applyEdit` 的旧失败回退会把未匹配到的数组实体名变成非索引属性，返回成功，但下一次读取不认，JSON 序列化也会丢弃。现在数组只允许现有索引或唯一 ID/名称；未知与歧义引用明确失败，新增实体须显式 `applyPush`。
+- 合法实体下新增深层对象字段同样受到旧回退影响。现在先在脱离草稿的分支构造缺失对象链，整条路径通过后才挂接，后续索引失败不遗留半截字段。
+- ID 优先于显示名称；重名不再首项匹配。数组 `length` 可读但不可写，缺失叶子的 `getField/getFields` 不再报作已找到。`applyPush/applyRemove/multiEdit` 保留追加、删除和整批回滚语义；已有可变数组不重复赋值给只读父属性。
+
+这些是工坊编辑路径修复，不改地图美术、地名、游戏数值、财政/民心机制或历史存档。实际导出含186个地图地块和186个行政区；地区经济位于行政节点的 `economyBase`。存在同名地区，不能用模糊名称自动挑选其中一项。
+
+## 行为证据
+
+同一组33个行为测试直接执行工作树实现，或通过 `--ref` 读取基线完整模块；未替换旧夹具或预期答案。
+
+```text
+node web/scripts/smoke-authoring-region-paths.js --ref 12942b78fe64d20f4eb9ee01827a2c3567b38bf1
+node web/scripts/smoke-authoring-region-paths.js
+node scripts/verify-electron-bridge.js --authoring-regions
+node scripts/verify-electron-bridge.js
+```
+
+基线33组：12 PASS / 21 FAIL（退出1）；修复后33 PASS（退出0）。包含嵌套与中文路径、ID/同名/重排、缺失与歧义失败、数组边界、对象字段新增、原型链保护、批量回滚、序列化读回、不同草稿隔离及旧追加语义。
+
+Electron 33.4.11 在独立临时 userData 中加载真实 main/preload 和新旧两个工坊 HTML，通过实际 `makeResetEditorAdapter` 应用修改、`saveProjectSnapshot` 持久化、重载页面清空内存，再以 `loadProjectSnapshot` 读取。外部网络被阻断，无成功存储桩、真实账号调用或物理鼠标操作声明。
+
+默认使用公开合成样本。另以只读的玩家导出复跑：设置 `TM_AUTHORING_REGION_FIXTURE` 为自己的 JSON 路径，再执行上述 `--authoring-regions` 命令。玩家完整 JSON 不入库，原文件 SHA-256 保持 `964a16eb2a86f34b1ad045e91f9a70ff8bac2ffb2cd4f4c1639fe7a7fd057bf9`。
+
+最终正式门禁与原始命令结果见 [evidence.json](bugfix-authoring-region-paths/evidence.json)。其中每次执行含 HEAD、工作区状态、平台、Node、命令、退出码、源码哈希与脱敏日志。测试执行时 HEAD 仍为基线，补丁位于已记录哈希的工作树；这些测试完成后仅补充文档/证据，再一起提交，不把基线 SHA 当成已经包含补丁。
+
+| 最终命令/对象 | 退出码 | 实际结果 |
+|---|---:|---|
+| `smoke-authoring-region-paths.js` | 0 | 33 PASS |
+| 原有 authoring / office-source 相关脚本 | 0 | 9脚本 PASS |
+| `verify-electron-bridge.js` | 0 | 29 PASS（生产 / 测试导出 / 重启） |
+| `verify-electron-bridge.js --authoring-regions` | 0 | 合成样本12 PASS |
+| 同命令 + `TM_AUTHORING_REGION_FIXTURE` | 0 | 玩家导出只读副本12 PASS |
+| `lint-arch-all.js` | 0 | 13守卫 PASS |
+| `verify-release-contract.js` | 0 | 166断言 PASS |
+| `verify-official-scenario-parity.js` | 0 | 27断言 PASS |
+| `verify-hot-builder-gates.js` | 0 | 27合成构建夹具断言 PASS |
+| `audit-repro.cjs --repo <本工作树> --expect-clean` | 0 | 11探针未复现旧缺陷，2对照通过，0框架错误；不代替本轮正向行为测试 |
+| `npm audit --omit=dev --audit-level=high --registry=https://registry.npmjs.org`（实际npm CLI） | 0 | 0 vulnerabilities |
+| `ci-smokes.js` 最终冻结代码 | 0 | **917 PASS / 0 FAIL / 0 SKIP / 2 WAIVED，919脚本全部执行** |
+
+最终全量运行身份为 `e78ffeba-9018-4bc7-a930-c58e7736e02a`。两项 WAIVED 仍只对应音频5项、地图编辑器2项缺席资产检查，不曾扩大豁免。证据导出器核对9个生产/测试/入口文件哈希与最终全量执行一致。Electron 的12/29计数为检查记录，含重复的基础桥接断言，不冒充互不重复的完整游戏流程。新的合成工坊 Electron 用例已接入既有 Windows CI，但本轮尚未推送或取得远端检查。
+
+## 初次失败与验证边界
+
+- 首个 Electron 测试在 `did-finish-load` 后立即断言 ready，早于编辑器实际的异步 IndexedDB 初始化。测试适配为等待现有 ready 标记；没有改应用行为或扩大外层超时。
+- 修复中自查发现追加已有数组时多余的父属性赋值会使只读父属性报错。单独失败回归记录为32 PASS / 1 FAIL；一行修正后锁定33组，重新运行最终门禁。
+- 首次审计记录器不能直接 spawn Windows 的 `npm.cmd`（EINVAL），不是依赖审计结果。之后直接调用实际 `npm-cli.js` 完成审计。
+- 原始 `git diff --check` 将纯 CRLF 的 preview HTML 两条修改行末尾的 CR 报作空白（退出2）。遵守字节冻结保留该文件594条 CRLF；采用 `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check` 验证通过，未关闭真正的行尾空格/空行/制表符检查，也未修改仓库 Git 配置。
+- 脚本 HTML 缓存戳按既有双文件家族同步，保留原行尾。官方生成器维护热更清单，1094条保留、无移除、版本仍1.3.4.11；没有制作用于发布的安装包或热更包。
+- 不声称玩家那次未知工具参数已逐字重演，也不把本轮编辑器读写验证扩展成所有地方数值的开局/回合机制验收。历史上已丢失、从未真正写入 JSON 的编辑，不能凭空恢复，应在修复后重新提交。

--- a/docs/bugfix-authoring-region-paths/evidence.json
+++ b/docs/bugfix-authoring-region-paths/evidence.json
@@ -1,0 +1,2511 @@
+{
+  "baseline": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+  "sourceHashes": {
+    "web/editor-authoring-agent.js": "761784e028cdf9dc527b7a113c334a29d929f6eda99a629352e4f1a2875fdd67",
+    "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+    "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+    "web/.hot-update-manifest.json": "41da7460d7882c1472ff53e4f1784f991d242f4bb5bac42685fa8c7908add25f",
+    "web/scripts/smoke-authoring-region-paths.js": "43a6f29f98c32b4f3c8d2482ff899cbe4fe1000fa8b6b63bec92bd6ee76554da",
+    "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+    "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+    "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+    ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501"
+  },
+  "executions": [
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-append-repro-5bece1f8-1fc2-4770-acca-87de7761a181",
+      "run": {
+        "label": "authoring-region-append-repro",
+        "command": [
+          "node",
+          "web/scripts/smoke-authoring-region-paths.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:10:21.111Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "4370ab1fad23b743737b174571e0ea688f0a970c38d335901bf644ee0f1fbc46",
+          "web/editor-authoring-agent.js": "cf2279d228e97df8e790ee10e23c556fbe10b97cd686c553748152036e10b133",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "43a6f29f98c32b4f3c8d2482ff899cbe4fe1000fa8b6b63bec92bd6ee76554da"
+        },
+        "exitCode": 1,
+        "signal": null,
+        "elapsedMs": 265.7804,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "774f3c9684763cd3eb6cf9dd71bf33cb1b9378fe2947e884bc8991ec05675ae6",
+          "text": "PASS nested map search returns a readable concrete path and ID\nPASS nested faction administrative search and write/read persistence\nPASS nested children collection supports explicit stable parent ID\nPASS virtual region collection roundtrips through its reported collection name\nPASS legacy mapData-only alias returns its real path without creating map\nPASS top-level character searches remain compatible and bounded\nPASS global search returned bracket paths still read and write the real row\nPASS reject intermediate array write without mutation\nPASS reject terminal array write without mutation\nPASS reject array length array write without mutation\nPASS reject negative index array write without mutation\nPASS reject out of bounds array write without mutation\nPASS failed append through a missing named region is not falsely successful\nPASS failed read and batch read accurately report a missing leaf\nPASS duplicate names cannot silently select the first region\nPASS explicit unique ID updates only the requested duplicate-name region\nPASS ID takes precedence over an unrelated name that happens to equal it\nPASS duplicate IDs are rejected without choosing an arbitrary row\nPASS new object fields under a valid named entity are created and persist\nPASS missing object chain remains supported without partial invalid bracket scaffolding\nPASS explicit append can create a child collection under the actual selected ID\nPASS remove keeps legitimate ID/index operations but rejects missing and ambiguous names\nPASS atomic multi-edit rollback includes a later unresolved named entity\nPASS unsafe or prototype paths remain rejected even with force\nPASS detached draft edits do not touch caller-owned scenario data\nPASS stable ID still selects the intended region after reordering\nPASS zero, false, null and readable array length are not mistaken for missing values\nPASS copy from missing field already fails and remains non-mutating\nPASS nested bracket indices including Chinese object keys remain supported\nPASS separate drafts with reused IDs never share lookup state\nPASS filtered bulk update accepts the same nested collection as search\nPASS numeric aggregate reads the same nested administrative values\n{\"source\":\"worktree\",\"pass\":32,\"fail\":1,\"total\":33,\"scope\":\"actual public authoring tools; no network or player data\"}\n"
+        },
+        "stderr.log": {
+          "sha256": "71eee24eb7671fda1b751b7efc4b7602bb459ce47d7bb6dc7e4315ac721b723e",
+          "text": "FAIL append preserves an existing array without reassigning its read-only owner property: Cannot assign to read only property 'items' of object '[object Object]'\n"
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-arch-190d82d1-b610-4a1f-bf38-9a8c08220865",
+      "run": {
+        "label": "authoring-region-arch",
+        "command": [
+          "node",
+          "web/scripts/lint-arch-all.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M web/editor-authoring-agent.js\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T14:53:09.133Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          "web/editor-authoring-agent.js": "8fc466deeeea342f82704a55387566ef576de2a9d59bac5617a11e4162f2f404",
+          "web/scripts/smoke-authoring-region-paths.js": "331e7aa4ab535c234bb0da16a708d0afcc7f35212ccee97119f1077c3ada8d43"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 22586.6885,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "5f58f3846b9f48ba35726d653ccad07a3e93402e50a51dd3f87b8c3cb896b816",
+          "text": "[lint-arch-all] PASS  lint-gm-writes (3.3s)\n[lint-arch-all] PASS  lint-dep-graph (1.2s)\n[lint-arch-all] PASS  lint-global-providers (4.7s)\n[lint-arch-all] PASS  lint-feature-boundaries (0.3s)\n[lint-arch-all] PASS  lint-runtime-template-immutability (0.4s)\n[lint-arch-all] PASS  lint-renderer-writeback-boundaries (8.6s)\n[lint-arch-all] PASS  lint-renderer-module-boundaries (0.8s)\n[lint-arch-all] PASS  lint-file-size (0.5s)\n[lint-arch-all] PASS  lint-control-bytes (0.4s)\n[lint-arch-all] PASS  lint-split-contracts (0.2s)\n[lint-arch-all] PASS  lint-split-stamps (0.2s)\n[lint-arch-all] PASS  lint-smoke-family-order (0.9s)\n[lint-arch-all] PASS  ref-check (1.2s)\n\n[lint-arch-all] PASS — 架构守卫全绿\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-arch-final-74dd2c04-94da-45c7-a20b-5337e6437604",
+      "run": {
+        "label": "authoring-region-arch-final",
+        "command": [
+          "node",
+          "web/scripts/lint-arch-all.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:05:28.631Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "8bfd3a173dd60d078adb1fc1f32c573d875f3d88d88f39884791de07e99f650c",
+          "web/editor-authoring-agent.js": "cf2279d228e97df8e790ee10e23c556fbe10b97cd686c553748152036e10b133",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "0dd507646958f6cc2112162e12ae3e95bb779287dce76311e4253f72bf046617"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 23547.2578,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "7ee10c33db96d26a456a2c0cd45c3b1888f68dd77a64e7b22581a00382783be0",
+          "text": "[lint-arch-all] PASS  lint-gm-writes (4.1s)\n[lint-arch-all] PASS  lint-dep-graph (1.5s)\n[lint-arch-all] PASS  lint-global-providers (4.3s)\n[lint-arch-all] PASS  lint-feature-boundaries (0.4s)\n[lint-arch-all] PASS  lint-runtime-template-immutability (0.3s)\n[lint-arch-all] PASS  lint-renderer-writeback-boundaries (8.1s)\n[lint-arch-all] PASS  lint-renderer-module-boundaries (0.9s)\n[lint-arch-all] PASS  lint-file-size (0.5s)\n[lint-arch-all] PASS  lint-control-bytes (0.5s)\n[lint-arch-all] PASS  lint-split-contracts (0.1s)\n[lint-arch-all] PASS  lint-split-stamps (0.2s)\n[lint-arch-all] PASS  lint-smoke-family-order (0.9s)\n[lint-arch-all] PASS  ref-check (1.4s)\n\n[lint-arch-all] PASS — 架构守卫全绿\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-arch-locked-f23e113e-8a1f-48d9-a2f8-2dbf7d269992",
+      "run": {
+        "label": "authoring-region-arch-locked",
+        "command": [
+          "node",
+          "web/scripts/lint-arch-all.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? docs/bugfix-authoring-region-paths-2026-09-08.md\n?? scripts/collect-authoring-region-evidence.cjs\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:13:25.154Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "docs/bugfix-authoring-region-paths-2026-09-08.md": "f7c8da0b46dd33adac9b05b80574e10a9b93abcf8b7a1c5958418ef0e7273c8e",
+          "scripts/collect-authoring-region-evidence.cjs": "04ddc90173bc3beff6715ea2ec9748182b38e479cd3d85c832c5fbe6513ac30f",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "41da7460d7882c1472ff53e4f1784f991d242f4bb5bac42685fa8c7908add25f",
+          "web/editor-authoring-agent.js": "761784e028cdf9dc527b7a113c334a29d929f6eda99a629352e4f1a2875fdd67",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "43a6f29f98c32b4f3c8d2482ff899cbe4fe1000fa8b6b63bec92bd6ee76554da"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 22082.290100000002,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "bab5470f7f3b063f5c54ee611d01c8ffbd06733f1217adb419742d69fbd9b002",
+          "text": "[lint-arch-all] PASS  lint-gm-writes (3.3s)\n[lint-arch-all] PASS  lint-dep-graph (1.3s)\n[lint-arch-all] PASS  lint-global-providers (4.1s)\n[lint-arch-all] PASS  lint-feature-boundaries (0.4s)\n[lint-arch-all] PASS  lint-runtime-template-immutability (0.4s)\n[lint-arch-all] PASS  lint-renderer-writeback-boundaries (7.4s)\n[lint-arch-all] PASS  lint-renderer-module-boundaries (0.9s)\n[lint-arch-all] PASS  lint-file-size (0.7s)\n[lint-arch-all] PASS  lint-control-bytes (0.5s)\n[lint-arch-all] PASS  lint-split-contracts (0.2s)\n[lint-arch-all] PASS  lint-split-stamps (0.3s)\n[lint-arch-all] PASS  lint-smoke-family-order (1.2s)\n[lint-arch-all] PASS  ref-check (1.2s)\n\n[lint-arch-all] PASS — 架构守卫全绿\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-audit-final-4923b66f-f0a9-4db3-a5bb-ecab1dc12ef4",
+      "run": {
+        "label": "authoring-region-audit-final",
+        "command": [
+          "node",
+          "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js",
+          "audit",
+          "--omit=dev",
+          "--audit-level=high",
+          "--registry=https://registry.npmjs.org"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:07:41.957Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "4370ab1fad23b743737b174571e0ea688f0a970c38d335901bf644ee0f1fbc46",
+          "web/editor-authoring-agent.js": "cf2279d228e97df8e790ee10e23c556fbe10b97cd686c553748152036e10b133",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "0dd507646958f6cc2112162e12ae3e95bb779287dce76311e4253f72bf046617"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 6098.3095,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "6d8c5c8f3d7684adb070417bd608d01ae90aa3dc26a65af03ffda4955f38d9a3",
+          "text": "found 0 vulnerabilities\n"
+        },
+        "stderr.log": {
+          "sha256": "85f486e0beab44838d371df3d3bc54e5889ce2f4b2369e3c3088c4301dde67d7",
+          "text": "npm warn Unknown project config \"electron_mirror\". This will stop working in the next major version of npm.\nnpm warn Unknown project config \"electron_builder_binaries_mirror\". This will stop working in the next major version of npm.\n"
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-audit-probe-301d6f73-a251-45db-8c79-71c986e5559a",
+      "run": {
+        "label": "authoring-region-audit-probe",
+        "command": [
+          "node",
+          "web/scripts/audit-repro.cjs",
+          "--repo",
+          "<user-profile>/Desktop/tianming-perf-round1",
+          "--expect-clean"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? docs/bugfix-authoring-region-paths-2026-09-08.md\n?? scripts/collect-authoring-region-evidence.cjs\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:14:01.682Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "docs/bugfix-authoring-region-paths-2026-09-08.md": "f7c8da0b46dd33adac9b05b80574e10a9b93abcf8b7a1c5958418ef0e7273c8e",
+          "scripts/collect-authoring-region-evidence.cjs": "04ddc90173bc3beff6715ea2ec9748182b38e479cd3d85c832c5fbe6513ac30f",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "41da7460d7882c1472ff53e4f1784f991d242f4bb5bac42685fa8c7908add25f",
+          "web/editor-authoring-agent.js": "761784e028cdf9dc527b7a113c334a29d929f6eda99a629352e4f1a2875fdd67",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "43a6f29f98c32b4f3c8d2482ff899cbe4fe1000fa8b6b63bec92bd6ee76554da"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 1083.2615999999998,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "f69cf07ece47871904df6783e2f500c7f6913c32aa9301f3c249d5937ecb5164",
+          "text": "CONTROL_PASS CONTROL-01 stable keys and turn validation reject known aliases\n  {\"ok\":true,\"rejected\":[true,true,true,true,true]}\nCONTROL_PASS CONTROL-02 same turn transaction publish is idempotent\n  {\"ok\":true,\"recovered\":true}\nNOT_REPRODUCED TM-AUD-01 different timelines overwrite the same per-turn bundle\n  {\"defect\":false,\"sameFinalPath\":false,\"branchAtOriginalPath\":\"A\",\"oldRecoveryError\":null}\nNOT_REPRODUCED TM-AUD-02 workshop overwrite loses old package when copying fails\n  {\"defect\":false,\"error\":\"Injected copy ENOSPC\",\"oldPreserved\":true,\"partialNewTree\":false,\"indexWritten\":false}\nNOT_REPRODUCED TM-AUD-03a stale account/me combines a new token with old account identity\n  {\"defect\":false,\"tokenOwner\":\"B\",\"displayedUser\":\"B\"}\nNOT_REPRODUCED TM-AUD-03b late login response restores session after logout completed\n  {\"defect\":false,\"loggedOutBeforeReply\":true,\"loggedInAfterStaleReply\":false}\nNOT_REPRODUCED TM-AUD-04 manual save callback mutates a different live world\n  {\"defect\":false,\"liveWorld\":\"world-B\",\"liveSaveName\":\"SAVE-FOR-B\",\"enterGameCalls\":0}\nNOT_REPRODUCED TM-AUD-05 legacy save string loads but list-style object is rejected\n  {\"defect\":false,\"stringReferenceWorks\":true,\"objectReferenceError\":null}\nNOT_REPRODUCED TM-AUD-06a CI accepts an empty report after runner failure\n  {\"defect\":false,\"exitCode\":1,\"messages\":[\"[ci-smokes] run=current HEAD=test-head report=<user-profile>\\\\Desktop\\\\tianming-perf-round1\\\\web\\\\dev-tools\\\\arch-guard\\\\ci-unique\\\\smoke-report.json\",\"smoke-evidence-runner-failed\"]}\nNOT_REPRODUCED TM-AUD-06b CI waives an unrelated syntax failure by file name\n  {\"defect\":false,\"exitCode\":1,\"messages\":[\"[ci-smokes] run=current HEAD=test-head report=<user-profile>\\\\Desktop\\\\tianming-perf-round1\\\\web\\\\dev-tools\\\\arch-guard\\\\ci-unique\\\\smoke-report.json\",\"smoke-evidence-test-failed\"]}\nNOT_REPRODUCED TM-AUD-07 network predicate misses hexadecimal IPv4-mapped loopback\n  {\"defect\":false,\"dottedMappedBlocked\":true,\"hexMappedBlocked\":true,\"literalV4Blocked\":true,\"scope\":\"predicate only; no DNS/TLS/Electron exploitation attempted\"}\nNOT_REPRODUCED TM-AUD-08 export write failure destroys an existing backup payload\n  {\"defect\":false,\"reportedFailure\":true,\"originalPreserved\":true,\"resultingBytes\":21}\nNOT_REPRODUCED TM-AUD-09 saveToSlot loses both success and failure return values\n  {\"defect\":false,\"successResult\":\"true\",\"failureResult\":\"false\"}\n\nSUMMARY {\"probes\":11,\"defectsPresent\":0,\"controlsPassed\":2,\"harnessErrors\":0}\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-baseline-bb703c6a-31c3-497d-b0de-4e87b51d2ed3",
+      "run": {
+        "label": "authoring-region-baseline",
+        "command": [
+          "node",
+          "web/scripts/smoke-authoring-region-paths.js",
+          "--ref",
+          "12942b78fe64d20f4eb9ee01827a2c3567b38bf1"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T14:48:43.666Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          "web/scripts/smoke-authoring-region-paths.js": "81ce39786dd86678ffebd319dcd872a6ff2e6d325c8f21e0a07805c6d310676f"
+        },
+        "exitCode": 1,
+        "signal": null,
+        "elapsedMs": 429.8838999999999,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "f999b1f821d51657ad6191862a2d41327fa4b1846d6ed2dc3b921b662a11069b",
+          "text": "PASS top-level character searches remain compatible and bounded\nPASS global search returned bracket paths still read and write the real row\nPASS reject out of bounds array write without mutation\nPASS explicit unique ID updates only the requested duplicate-name region\nPASS explicit append can create a child collection under the actual selected ID\nPASS unsafe or prototype paths remain rejected even with force\nPASS detached draft edits do not touch caller-owned scenario data\n{\"source\":\"12942b78fe64d20f4eb9ee01827a2c3567b38bf1\",\"pass\":7,\"fail\":18,\"total\":25,\"scope\":\"actual public authoring tools; no network or player data\"}\n"
+        },
+        "stderr.log": {
+          "sha256": "3476b5b9aa31744f47870505b3e366e503b20a1eaea9e03ce385fe9412218a27",
+          "text": "FAIL nested map search returns a readable concrete path and ID: Expected values to be strictly equal:\n\nfalse !== true\n\nFAIL nested faction administrative search and write/read persistence: Expected values to be strictly equal:\n\nfalse !== true\n\nFAIL nested children collection supports explicit stable parent ID: Expected values to be strictly equal:\n\nfalse !== true\n\nFAIL virtual region collection roundtrips through its reported collection name: Expected values to be strictly equal:\n\nundefined !== 1\n\nFAIL legacy mapData-only alias returns its real path without creating map: Expected values to be strictly equal:\n+ actual - expected\n\n+ 'map.regions'\n- 'mapData.regions'\n      ^\n\nFAIL reject intermediate array write without mutation: operation must report failure\n\ntrue !== false\n\nFAIL reject terminal array write without mutation: operation must report failure\n\ntrue !== false\n\nFAIL reject array length array write without mutation: operation must report failure\n\ntrue !== false\n\nFAIL reject negative index array write without mutation: operation must report failure\n\ntrue !== false\n\nFAIL failed append through a missing named region is not falsely successful: operation must report failure\n\ntrue !== false\n\nFAIL failed read and batch read accurately report a missing leaf: Expected values to be strictly equal:\n\ntrue !== false\n\nFAIL duplicate names cannot silently select the first region: Expected values to be strictly equal:\n\ntrue !== false\n\nFAIL ID takes precedence over an unrelated name that happens to equal it: Expected values to be strictly equal:\n\n77 !== 58\n\nFAIL duplicate IDs are rejected without choosing an arbitrary row: operation must report failure\n\ntrue !== false\n\nFAIL new object fields under a valid named entity are created and persist: Expected values to be strictly equal:\n+ actual - expected\n\n+ undefined\n- 1.25\n\nFAIL missing object chain remains supported without partial invalid bracket scaffolding: no partial serialized writes\n+ actual - expected\n... Skipped lines\n\n  {\n    adminHierarchy: {\n      '楚': {\n        divisions: [\n          {\n...\n    name: '隔离路径回归',\n+   newConfig: {},\n    worldSettings: {\n      religion: '儒'\n    }\n  }\n\nFAIL remove keeps legitimate ID/index operations but rejects missing and ambiguous names: operation must report failure\n\ntrue !== false\n\nFAIL atomic multi-edit rollback includes a later unresolved named entity: operation must report failure\n\ntrue !== false\n\n"
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-baseline-complete-ef69c695-d7aa-4b0a-9178-50a627c09e38",
+      "run": {
+        "label": "authoring-region-baseline-complete",
+        "command": [
+          "node",
+          "web/scripts/smoke-authoring-region-paths.js",
+          "--ref",
+          "12942b78fe64d20f4eb9ee01827a2c3567b38bf1"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:04:30.712Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "8bfd3a173dd60d078adb1fc1f32c573d875f3d88d88f39884791de07e99f650c",
+          "web/editor-authoring-agent.js": "cf2279d228e97df8e790ee10e23c556fbe10b97cd686c553748152036e10b133",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "0dd507646958f6cc2112162e12ae3e95bb779287dce76311e4253f72bf046617"
+        },
+        "exitCode": 1,
+        "signal": null,
+        "elapsedMs": 763.2133000000001,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "67b789688de7740aa3c1a88fd7439107642bd34d4779d58154e1956d3fe9c361",
+          "text": "PASS top-level character searches remain compatible and bounded\nPASS global search returned bracket paths still read and write the real row\nPASS reject out of bounds array write without mutation\nPASS explicit unique ID updates only the requested duplicate-name region\nPASS explicit append can create a child collection under the actual selected ID\nPASS unsafe or prototype paths remain rejected even with force\nPASS detached draft edits do not touch caller-owned scenario data\nPASS stable ID still selects the intended region after reordering\nPASS zero, false, null and readable array length are not mistaken for missing values\nPASS copy from missing field already fails and remains non-mutating\nPASS separate drafts with reused IDs never share lookup state\n{\"source\":\"12942b78fe64d20f4eb9ee01827a2c3567b38bf1\",\"pass\":11,\"fail\":21,\"total\":32,\"scope\":\"actual public authoring tools; no network or player data\"}\n"
+        },
+        "stderr.log": {
+          "sha256": "fabcf79b56b4930181db1a7ccb399fa15441a2b3b3df08384c832b4f902f536b",
+          "text": "FAIL nested map search returns a readable concrete path and ID: Expected values to be strictly equal:\n\nfalse !== true\n\nFAIL nested faction administrative search and write/read persistence: Expected values to be strictly equal:\n\nfalse !== true\n\nFAIL nested children collection supports explicit stable parent ID: Expected values to be strictly equal:\n\nfalse !== true\n\nFAIL virtual region collection roundtrips through its reported collection name: Expected values to be strictly equal:\n\nundefined !== 1\n\nFAIL legacy mapData-only alias returns its real path without creating map: Expected values to be strictly equal:\n+ actual - expected\n\n+ 'map.regions'\n- 'mapData.regions'\n      ^\n\nFAIL reject intermediate array write without mutation: operation must report failure\n\ntrue !== false\n\nFAIL reject terminal array write without mutation: operation must report failure\n\ntrue !== false\n\nFAIL reject array length array write without mutation: operation must report failure\n\ntrue !== false\n\nFAIL reject negative index array write without mutation: operation must report failure\n\ntrue !== false\n\nFAIL failed append through a missing named region is not falsely successful: operation must report failure\n\ntrue !== false\n\nFAIL failed read and batch read accurately report a missing leaf: Expected values to be strictly equal:\n\ntrue !== false\n\nFAIL duplicate names cannot silently select the first region: Expected values to be strictly equal:\n\ntrue !== false\n\nFAIL ID takes precedence over an unrelated name that happens to equal it: Expected values to be strictly equal:\n\n77 !== 58\n\nFAIL duplicate IDs are rejected without choosing an arbitrary row: operation must report failure\n\ntrue !== false\n\nFAIL new object fields under a valid named entity are created and persist: Expected values to be strictly equal:\n+ actual - expected\n\n+ undefined\n- 1.25\n\nFAIL missing object chain remains supported without partial invalid bracket scaffolding: no partial serialized writes\n+ actual - expected\n... Skipped lines\n\n  {\n    adminHierarchy: {\n      '楚': {\n        divisions: [\n          {\n...\n    name: '隔离路径回归',\n+   newConfig: {},\n    worldSettings: {\n      religion: '儒'\n    }\n  }\n\nFAIL remove keeps legitimate ID/index operations but rejects missing and ambiguous names: operation must report failure\n\ntrue !== false\n\nFAIL atomic multi-edit rollback includes a later unresolved named entity: operation must report failure\n\ntrue !== false\n\nFAIL nested bracket indices including Chinese object keys remain supported: Expected values to be strictly equal:\n\nfalse !== true\n\nFAIL filtered bulk update accepts the same nested collection as search: Expected values to be strictly equal:\n\nfalse !== true\n\nFAIL numeric aggregate reads the same nested administrative values: Expected values to be strictly equal:\n\nfalse !== true\n\n"
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-baseline-final-11a5fa5d-c0da-4f1c-943f-ed43c4f98343",
+      "run": {
+        "label": "authoring-region-baseline-final",
+        "command": [
+          "node",
+          "web/scripts/smoke-authoring-region-paths.js",
+          "--ref",
+          "12942b78fe64d20f4eb9ee01827a2c3567b38bf1"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:01:49.392Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "8bfd3a173dd60d078adb1fc1f32c573d875f3d88d88f39884791de07e99f650c",
+          "web/editor-authoring-agent.js": "81c0079e2c7d4d35290da3118bc323e6023e94e8b1865a809aa260b97aa4ac25",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "03553e2c031c694c7aecd7f105fdda75039c2aa77eb056ca7eb08f3fc0289a15"
+        },
+        "exitCode": 1,
+        "signal": null,
+        "elapsedMs": 503.5348,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "946f6aec1306a29b252d7905f1661fb9053ae44f96b3e6efeaabcee1170247ab",
+          "text": "PASS top-level character searches remain compatible and bounded\nPASS global search returned bracket paths still read and write the real row\nPASS reject out of bounds array write without mutation\nPASS explicit unique ID updates only the requested duplicate-name region\nPASS explicit append can create a child collection under the actual selected ID\nPASS unsafe or prototype paths remain rejected even with force\nPASS detached draft edits do not touch caller-owned scenario data\nPASS stable ID still selects the intended region after reordering\nPASS zero, false, null and readable array length are not mistaken for missing values\nPASS copy from missing field already fails and remains non-mutating\nPASS separate drafts with reused IDs never share lookup state\n{\"source\":\"12942b78fe64d20f4eb9ee01827a2c3567b38bf1\",\"pass\":11,\"fail\":19,\"total\":30,\"scope\":\"actual public authoring tools; no network or player data\"}\n"
+        },
+        "stderr.log": {
+          "sha256": "a461f06a2d26c75b9c31c750aef217cc2bb0d198a60e6a3eab5f3a1ac3ad817d",
+          "text": "FAIL nested map search returns a readable concrete path and ID: Expected values to be strictly equal:\n\nfalse !== true\n\nFAIL nested faction administrative search and write/read persistence: Expected values to be strictly equal:\n\nfalse !== true\n\nFAIL nested children collection supports explicit stable parent ID: Expected values to be strictly equal:\n\nfalse !== true\n\nFAIL virtual region collection roundtrips through its reported collection name: Expected values to be strictly equal:\n\nundefined !== 1\n\nFAIL legacy mapData-only alias returns its real path without creating map: Expected values to be strictly equal:\n+ actual - expected\n\n+ 'map.regions'\n- 'mapData.regions'\n      ^\n\nFAIL reject intermediate array write without mutation: operation must report failure\n\ntrue !== false\n\nFAIL reject terminal array write without mutation: operation must report failure\n\ntrue !== false\n\nFAIL reject array length array write without mutation: operation must report failure\n\ntrue !== false\n\nFAIL reject negative index array write without mutation: operation must report failure\n\ntrue !== false\n\nFAIL failed append through a missing named region is not falsely successful: operation must report failure\n\ntrue !== false\n\nFAIL failed read and batch read accurately report a missing leaf: Expected values to be strictly equal:\n\ntrue !== false\n\nFAIL duplicate names cannot silently select the first region: Expected values to be strictly equal:\n\ntrue !== false\n\nFAIL ID takes precedence over an unrelated name that happens to equal it: Expected values to be strictly equal:\n\n77 !== 58\n\nFAIL duplicate IDs are rejected without choosing an arbitrary row: operation must report failure\n\ntrue !== false\n\nFAIL new object fields under a valid named entity are created and persist: Expected values to be strictly equal:\n+ actual - expected\n\n+ undefined\n- 1.25\n\nFAIL missing object chain remains supported without partial invalid bracket scaffolding: no partial serialized writes\n+ actual - expected\n... Skipped lines\n\n  {\n    adminHierarchy: {\n      '楚': {\n        divisions: [\n          {\n...\n    name: '隔离路径回归',\n+   newConfig: {},\n    worldSettings: {\n      religion: '儒'\n    }\n  }\n\nFAIL remove keeps legitimate ID/index operations but rejects missing and ambiguous names: operation must report failure\n\ntrue !== false\n\nFAIL atomic multi-edit rollback includes a later unresolved named entity: operation must report failure\n\ntrue !== false\n\nFAIL nested bracket indices including Chinese object keys remain supported: Expected values to be strictly equal:\n\nfalse !== true\n\n"
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-baseline-locked-e11fa019-1085-461f-a9c8-ae0ec8924609",
+      "run": {
+        "label": "authoring-region-baseline-locked",
+        "command": [
+          "node",
+          "web/scripts/smoke-authoring-region-paths.js",
+          "--ref",
+          "12942b78fe64d20f4eb9ee01827a2c3567b38bf1"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:10:24.634Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "4370ab1fad23b743737b174571e0ea688f0a970c38d335901bf644ee0f1fbc46",
+          "web/editor-authoring-agent.js": "761784e028cdf9dc527b7a113c334a29d929f6eda99a629352e4f1a2875fdd67",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "43a6f29f98c32b4f3c8d2482ff899cbe4fe1000fa8b6b63bec92bd6ee76554da"
+        },
+        "exitCode": 1,
+        "signal": null,
+        "elapsedMs": 566.3178,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "1bd7752e0a043aa60fb0e997f473363f0c4154920d38f2bd13e1131e3552f7fe",
+          "text": "PASS top-level character searches remain compatible and bounded\nPASS global search returned bracket paths still read and write the real row\nPASS reject out of bounds array write without mutation\nPASS explicit unique ID updates only the requested duplicate-name region\nPASS explicit append can create a child collection under the actual selected ID\nPASS unsafe or prototype paths remain rejected even with force\nPASS detached draft edits do not touch caller-owned scenario data\nPASS stable ID still selects the intended region after reordering\nPASS zero, false, null and readable array length are not mistaken for missing values\nPASS copy from missing field already fails and remains non-mutating\nPASS separate drafts with reused IDs never share lookup state\nPASS append preserves an existing array without reassigning its read-only owner property\n{\"source\":\"12942b78fe64d20f4eb9ee01827a2c3567b38bf1\",\"pass\":12,\"fail\":21,\"total\":33,\"scope\":\"actual public authoring tools; no network or player data\"}\n"
+        },
+        "stderr.log": {
+          "sha256": "fabcf79b56b4930181db1a7ccb399fa15441a2b3b3df08384c832b4f902f536b",
+          "text": "FAIL nested map search returns a readable concrete path and ID: Expected values to be strictly equal:\n\nfalse !== true\n\nFAIL nested faction administrative search and write/read persistence: Expected values to be strictly equal:\n\nfalse !== true\n\nFAIL nested children collection supports explicit stable parent ID: Expected values to be strictly equal:\n\nfalse !== true\n\nFAIL virtual region collection roundtrips through its reported collection name: Expected values to be strictly equal:\n\nundefined !== 1\n\nFAIL legacy mapData-only alias returns its real path without creating map: Expected values to be strictly equal:\n+ actual - expected\n\n+ 'map.regions'\n- 'mapData.regions'\n      ^\n\nFAIL reject intermediate array write without mutation: operation must report failure\n\ntrue !== false\n\nFAIL reject terminal array write without mutation: operation must report failure\n\ntrue !== false\n\nFAIL reject array length array write without mutation: operation must report failure\n\ntrue !== false\n\nFAIL reject negative index array write without mutation: operation must report failure\n\ntrue !== false\n\nFAIL failed append through a missing named region is not falsely successful: operation must report failure\n\ntrue !== false\n\nFAIL failed read and batch read accurately report a missing leaf: Expected values to be strictly equal:\n\ntrue !== false\n\nFAIL duplicate names cannot silently select the first region: Expected values to be strictly equal:\n\ntrue !== false\n\nFAIL ID takes precedence over an unrelated name that happens to equal it: Expected values to be strictly equal:\n\n77 !== 58\n\nFAIL duplicate IDs are rejected without choosing an arbitrary row: operation must report failure\n\ntrue !== false\n\nFAIL new object fields under a valid named entity are created and persist: Expected values to be strictly equal:\n+ actual - expected\n\n+ undefined\n- 1.25\n\nFAIL missing object chain remains supported without partial invalid bracket scaffolding: no partial serialized writes\n+ actual - expected\n... Skipped lines\n\n  {\n    adminHierarchy: {\n      '楚': {\n        divisions: [\n          {\n...\n    name: '隔离路径回归',\n+   newConfig: {},\n    worldSettings: {\n      religion: '儒'\n    }\n  }\n\nFAIL remove keeps legitimate ID/index operations but rejects missing and ambiguous names: operation must report failure\n\ntrue !== false\n\nFAIL atomic multi-edit rollback includes a later unresolved named entity: operation must report failure\n\ntrue !== false\n\nFAIL nested bracket indices including Chinese object keys remain supported: Expected values to be strictly equal:\n\nfalse !== true\n\nFAIL filtered bulk update accepts the same nested collection as search: Expected values to be strictly equal:\n\nfalse !== true\n\nFAIL numeric aggregate reads the same nested administrative values: Expected values to be strictly equal:\n\nfalse !== true\n\n"
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-builder-5e60ce26-2963-4c83-aa21-fc4e2858b741",
+      "run": {
+        "label": "authoring-region-builder",
+        "command": [
+          "node",
+          "web/scripts/verify-hot-builder-gates.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:06:00.321Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "4370ab1fad23b743737b174571e0ea688f0a970c38d335901bf644ee0f1fbc46",
+          "web/editor-authoring-agent.js": "cf2279d228e97df8e790ee10e23c556fbe10b97cd686c553748152036e10b133",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "0dd507646958f6cc2112162e12ae3e95bb779287dce76311e4253f72bf046617"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 4928.7016,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "c87c1e03f318ed2f676e34813f0589a7f187719930dd957127b82cdf29dabb99",
+          "text": "  ok·A·健康树全量构建通过（exit 0）\n  ok·A·feed 版本正确\n  ok·A·清单含 index.html\n  ok·A·清单含 a.js\n  ok·A·清单含 b.js\n  ok·A·清单含 styles.css\n  ok·A·清单含 changelog.json\n  ok·A·清单含 version.json\n  ok·A·清单含 bundled-scenarios/合成（官方）.json\n  ok·A·草案/自用剧本不进入热更\n  ok·A2·GLB 运行资产可进入热更\n  ok·A2·GLB 自动要求 1.3.4.10 壳层\n  ok·A2·低于 ONNX 壳层能力的同版热更被 GATE-7 拒绝\n  ok·A2·1.3.4.12 可发布 ONNX 运行资产\n  ok·A2·ONNX 自动要求 1.3.4.12 壳层\n  ok·B·GATE-0 拦 --files 部分包\n  ok·B·危险旗标放行（调试用）\n  ok·C·GATE-2 拦 index 引用缺失（1.3.3.4 病灶类）\n  ok·D·GATE-2 拦必含文件缺失\n  ok·E·首次构建通过\n  ok·E·GATE-3 拦相同版本重发\n  ok·E·GATE-3 拦更低版本\n  ok·E·更高版本放行\n  ok·F·GATE-5 拦 version.json 戳不一致\n  ok·F·--skip-stamp-check 放行（调试用）\n  ok·F·GATE-5 拦 meta 缺失\n  ok·G·GATE-4 zip↔manifest 对账在构建路径上\nPASS assertions=27\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-builder-locked-202f817a-1bb1-4d92-a784-f1b1cf05a213",
+      "run": {
+        "label": "authoring-region-builder-locked",
+        "command": [
+          "node",
+          "web/scripts/verify-hot-builder-gates.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? docs/bugfix-authoring-region-paths-2026-09-08.md\n?? scripts/collect-authoring-region-evidence.cjs\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:13:55.730Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "docs/bugfix-authoring-region-paths-2026-09-08.md": "f7c8da0b46dd33adac9b05b80574e10a9b93abcf8b7a1c5958418ef0e7273c8e",
+          "scripts/collect-authoring-region-evidence.cjs": "04ddc90173bc3beff6715ea2ec9748182b38e479cd3d85c832c5fbe6513ac30f",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "41da7460d7882c1472ff53e4f1784f991d242f4bb5bac42685fa8c7908add25f",
+          "web/editor-authoring-agent.js": "761784e028cdf9dc527b7a113c334a29d929f6eda99a629352e4f1a2875fdd67",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "43a6f29f98c32b4f3c8d2482ff899cbe4fe1000fa8b6b63bec92bd6ee76554da"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 4801.186000000001,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "c87c1e03f318ed2f676e34813f0589a7f187719930dd957127b82cdf29dabb99",
+          "text": "  ok·A·健康树全量构建通过（exit 0）\n  ok·A·feed 版本正确\n  ok·A·清单含 index.html\n  ok·A·清单含 a.js\n  ok·A·清单含 b.js\n  ok·A·清单含 styles.css\n  ok·A·清单含 changelog.json\n  ok·A·清单含 version.json\n  ok·A·清单含 bundled-scenarios/合成（官方）.json\n  ok·A·草案/自用剧本不进入热更\n  ok·A2·GLB 运行资产可进入热更\n  ok·A2·GLB 自动要求 1.3.4.10 壳层\n  ok·A2·低于 ONNX 壳层能力的同版热更被 GATE-7 拒绝\n  ok·A2·1.3.4.12 可发布 ONNX 运行资产\n  ok·A2·ONNX 自动要求 1.3.4.12 壳层\n  ok·B·GATE-0 拦 --files 部分包\n  ok·B·危险旗标放行（调试用）\n  ok·C·GATE-2 拦 index 引用缺失（1.3.3.4 病灶类）\n  ok·D·GATE-2 拦必含文件缺失\n  ok·E·首次构建通过\n  ok·E·GATE-3 拦相同版本重发\n  ok·E·GATE-3 拦更低版本\n  ok·E·更高版本放行\n  ok·F·GATE-5 拦 version.json 戳不一致\n  ok·F·--skip-stamp-check 放行（调试用）\n  ok·F·GATE-5 拦 meta 缺失\n  ok·G·GATE-4 zip↔manifest 对账在构建路径上\nPASS assertions=27\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-bulk-repro-e089cd9c-ba02-484a-a1ce-13c1ba479c21",
+      "run": {
+        "label": "authoring-region-bulk-repro",
+        "command": [
+          "node",
+          "web/scripts/smoke-authoring-region-paths.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:03:24.639Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "8bfd3a173dd60d078adb1fc1f32c573d875f3d88d88f39884791de07e99f650c",
+          "web/editor-authoring-agent.js": "81c0079e2c7d4d35290da3118bc323e6023e94e8b1865a809aa260b97aa4ac25",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "0dd507646958f6cc2112162e12ae3e95bb779287dce76311e4253f72bf046617"
+        },
+        "exitCode": 1,
+        "signal": null,
+        "elapsedMs": 171.89019999999994,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "6a850a12374ba9063c35e75ea318e8a0c6b12126a4b0a27ea91997f8e3791e80",
+          "text": "PASS nested map search returns a readable concrete path and ID\nPASS nested faction administrative search and write/read persistence\nPASS nested children collection supports explicit stable parent ID\nPASS virtual region collection roundtrips through its reported collection name\nPASS legacy mapData-only alias returns its real path without creating map\nPASS top-level character searches remain compatible and bounded\nPASS global search returned bracket paths still read and write the real row\nPASS reject intermediate array write without mutation\nPASS reject terminal array write without mutation\nPASS reject array length array write without mutation\nPASS reject negative index array write without mutation\nPASS reject out of bounds array write without mutation\nPASS failed append through a missing named region is not falsely successful\nPASS failed read and batch read accurately report a missing leaf\nPASS duplicate names cannot silently select the first region\nPASS explicit unique ID updates only the requested duplicate-name region\nPASS ID takes precedence over an unrelated name that happens to equal it\nPASS duplicate IDs are rejected without choosing an arbitrary row\nPASS new object fields under a valid named entity are created and persist\nPASS missing object chain remains supported without partial invalid bracket scaffolding\nPASS explicit append can create a child collection under the actual selected ID\nPASS remove keeps legitimate ID/index operations but rejects missing and ambiguous names\nPASS atomic multi-edit rollback includes a later unresolved named entity\nPASS unsafe or prototype paths remain rejected even with force\nPASS detached draft edits do not touch caller-owned scenario data\nPASS stable ID still selects the intended region after reordering\nPASS zero, false, null and readable array length are not mistaken for missing values\nPASS copy from missing field already fails and remains non-mutating\nPASS nested bracket indices including Chinese object keys remain supported\nPASS separate drafts with reused IDs never share lookup state\n{\"source\":\"worktree\",\"pass\":30,\"fail\":2,\"total\":32,\"scope\":\"actual public authoring tools; no network or player data\"}\n"
+        },
+        "stderr.log": {
+          "sha256": "928da64588c47499c8a2c6b40f17f86d66e378cf0b25ba0286fffa0f4c877aea",
+          "text": "FAIL filtered bulk update accepts the same nested collection as search: Expected values to be strictly equal:\n\nfalse !== true\n\nFAIL numeric aggregate reads the same nested administrative values: Expected values to be strictly equal:\n\nfalse !== true\n\n"
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-diff-check-6634ec0d-f5d5-45d4-9ea7-c645bcfd7381",
+      "run": {
+        "label": "authoring-region-diff-check",
+        "command": [
+          "git",
+          "diff",
+          "--check"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? docs/bugfix-authoring-region-paths-2026-09-08.md\n?? scripts/collect-authoring-region-evidence.cjs\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:20:55.431Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "docs/bugfix-authoring-region-paths-2026-09-08.md": "f7c8da0b46dd33adac9b05b80574e10a9b93abcf8b7a1c5958418ef0e7273c8e",
+          "scripts/collect-authoring-region-evidence.cjs": "04ddc90173bc3beff6715ea2ec9748182b38e479cd3d85c832c5fbe6513ac30f",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "41da7460d7882c1472ff53e4f1784f991d242f4bb5bac42685fa8c7908add25f",
+          "web/editor-authoring-agent.js": "761784e028cdf9dc527b7a113c334a29d929f6eda99a629352e4f1a2875fdd67",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "43a6f29f98c32b4f3c8d2482ff899cbe4fe1000fa8b6b63bec92bd6ee76554da"
+        },
+        "exitCode": 2,
+        "signal": null,
+        "elapsedMs": 273.21889999999996,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "bbdaf05f177b5a1db11722933eb91fd512886e5a2eea7a7672b62fe546beb52f",
+          "text": "web/preview/scenario-editor-reset-preview.html:578: trailing whitespace.\n+  <script src=\"../editor-authoring-agent-provider.js?v=20260908-region-paths1\"></script>\r\nweb/preview/scenario-editor-reset-preview.html:579: trailing whitespace.\n+  <script src=\"../editor-authoring-agent.js?v=20260908-region-paths1\"></script>\r\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-diff-crlf-68584c8f-b28c-4751-b342-0c23ee68dc90",
+      "run": {
+        "label": "authoring-region-diff-crlf",
+        "command": [
+          "git",
+          "-c",
+          "core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol",
+          "diff",
+          "--check"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? docs/bugfix-authoring-region-paths-2026-09-08.md\n?? scripts/collect-authoring-region-evidence.cjs\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:20:56.746Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "docs/bugfix-authoring-region-paths-2026-09-08.md": "f7c8da0b46dd33adac9b05b80574e10a9b93abcf8b7a1c5958418ef0e7273c8e",
+          "scripts/collect-authoring-region-evidence.cjs": "04ddc90173bc3beff6715ea2ec9748182b38e479cd3d85c832c5fbe6513ac30f",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "41da7460d7882c1472ff53e4f1784f991d242f4bb5bac42685fa8c7908add25f",
+          "web/editor-authoring-agent.js": "761784e028cdf9dc527b7a113c334a29d929f6eda99a629352e4f1a2875fdd67",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "43a6f29f98c32b4f3c8d2482ff899cbe4fe1000fa8b6b63bec92bd6ee76554da"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 272.6349,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-editor-locked-4b1a0618-2331-4830-9909-587bb098c2bc",
+      "run": {
+        "label": "authoring-region-editor-locked",
+        "command": [
+          "node",
+          "scripts/verify-electron-bridge.js",
+          "--authoring-regions"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? docs/bugfix-authoring-region-paths-2026-09-08.md\n?? scripts/collect-authoring-region-evidence.cjs\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:13:48.898Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "docs/bugfix-authoring-region-paths-2026-09-08.md": "f7c8da0b46dd33adac9b05b80574e10a9b93abcf8b7a1c5958418ef0e7273c8e",
+          "scripts/collect-authoring-region-evidence.cjs": "04ddc90173bc3beff6715ea2ec9748182b38e479cd3d85c832c5fbe6513ac30f",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "41da7460d7882c1472ff53e4f1784f991d242f4bb5bac42685fa8c7908add25f",
+          "web/editor-authoring-agent.js": "761784e028cdf9dc527b7a113c334a29d929f6eda99a629352e4f1a2875fdd67",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "43a6f29f98c32b4f3c8d2482ff899cbe4fe1000fa8b6b63bec92bd6ee76554da"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 31343.8583,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "a6585a5b5704f47f09c97eb7483d8fd710dd22dc1543c854feaa42d1c144b146",
+          "text": "{\"mode\":\"authoring-regions\",\"ok\":true,\"exitCode\":0,\"detail\":{\"complete\":true,\"ok\":true,\"mode\":\"authoring-regions\",\"baseline\":false,\"versions\":{\"node\":\"20.18.3\",\"acorn\":\"8.14.0\",\"ada\":\"2.9.2\",\"ares\":\"1.34.4\",\"base64\":\"0.5.2\",\"brotli\":\"1.0.9\",\"cjs_module_lexer\":\"1.4.1\",\"cldr\":\"44.1\",\"icu\":\"74.2\",\"llhttp\":\"8.1.2\",\"modules\":\"130\",\"napi\":\"9\",\"nghttp2\":\"1.61.0\",\"openssl\":\"0.0.0\",\"simdutf\":\"5.6.4\",\"tz\":\"2024a\",\"undici\":\"6.21.1\",\"unicode\":\"15.1\",\"uv\":\"1.46.0\",\"uvwasi\":\"0.0.21\",\"v8\":\"13.0.245.25-electron.0\",\"zlib\":\"1.3.0.1-motley\",\"electron\":\"33.4.11\",\"chrome\":\"130.0.6723.191\"},\"results\":[{\"name\":\"locked-electron-runtime\",\"status\":\"PASS\"},{\"name\":\"production-webpreferences\",\"status\":\"PASS\"},{\"name\":\"observed-turn-data-protocol\",\"value\":2,\"status\":\"PASS\",\"required\":2},{\"name\":\"real-bridge-and-ipc\",\"status\":\"PASS\"},{\"name\":\"production-test-exports-boundary\",\"status\":\"PASS\"},{\"name\":\"actual-editor-page-and-bridge\",\"status\":\"PASS\"},{\"name\":\"nested-search-and-real-ID-readback\",\"status\":\"PASS\"},{\"name\":\"missing-region-error-has-no-partial-write\",\"status\":\"PASS\"},{\"name\":\"actual-adapter-commits-valid-region-economy-and-minxin\",\"status\":\"PASS\"},{\"name\":\"saved-region-state-survives-actual-editor-reload\",\"status\":\"PASS\"},{\"name\":\"legacy-editor-entry-loads-the-same-production-tools\",\"status\":\"PASS\"},{\"name\":\"original-fixture-is-unchanged\",\"status\":\"PASS\"}],\"failures\":[],\"securityScope\":\"real unpackaged production main/preload; hidden window; temporary userData; external network denied; no player data\",\"temporaryUserData\":\"<user-profile>\\\\AppData\\\\Local\\\\Temp\\\\tm-bridge-series-40wIXl\\\\production\"}}\nELECTRON_REPORT web\\dev-tools\\electron-bridge\\0bacf75e-ef9e-4fb8-bf09-51ee38cfd4be\\report.json\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-electron-ef0f57ce-f136-4ea9-94f0-c25c72fe239e",
+      "run": {
+        "label": "authoring-region-electron",
+        "command": [
+          "node",
+          "scripts/verify-electron-bridge.js",
+          "--authoring-regions"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T14:58:02.481Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          "scripts/electron/authoring-region-cases.cjs": "6c9e1492b2f08773a60a73b26d7c2d815002549b96c2cd0034328d5abe5dc374",
+          "scripts/electron/bridge-main.cjs": "1255a5094a4054ee07295d29748c2600673aa5cd4bf5943fc45d62ffb03692b7",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/editor-authoring-agent.js": "8fc466deeeea342f82704a55387566ef576de2a9d59bac5617a11e4162f2f404",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "62491ee866138a5b03576e741b0f8278aef3065f9aefdb848012e3ef80ab2d2d",
+          "web/scripts/smoke-authoring-region-paths.js": "331e7aa4ab535c234bb0da16a708d0afcc7f35212ccee97119f1077c3ada8d43"
+        },
+        "exitCode": 1,
+        "signal": null,
+        "elapsedMs": 6606.3068,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "eefce8819da8d572a7422cef4fbfbc61ca46c1959141737da6f78af3120ebc1a",
+          "text": "{\"mode\":\"authoring-regions\",\"ok\":false,\"exitCode\":1,\"detail\":{\"complete\":true,\"ok\":false,\"mode\":\"authoring-regions\",\"baseline\":false,\"versions\":{\"node\":\"20.18.3\",\"acorn\":\"8.14.0\",\"ada\":\"2.9.2\",\"ares\":\"1.34.4\",\"base64\":\"0.5.2\",\"brotli\":\"1.0.9\",\"cjs_module_lexer\":\"1.4.1\",\"cldr\":\"44.1\",\"icu\":\"74.2\",\"llhttp\":\"8.1.2\",\"modules\":\"130\",\"napi\":\"9\",\"nghttp2\":\"1.61.0\",\"openssl\":\"0.0.0\",\"simdutf\":\"5.6.4\",\"tz\":\"2024a\",\"undici\":\"6.21.1\",\"unicode\":\"15.1\",\"uv\":\"1.46.0\",\"uvwasi\":\"0.0.21\",\"v8\":\"13.0.245.25-electron.0\",\"zlib\":\"1.3.0.1-motley\",\"electron\":\"33.4.11\",\"chrome\":\"130.0.6723.191\"},\"results\":[{\"name\":\"locked-electron-runtime\",\"status\":\"PASS\"},{\"name\":\"production-webpreferences\",\"status\":\"PASS\"},{\"name\":\"observed-turn-data-protocol\",\"value\":2,\"status\":\"PASS\",\"required\":2},{\"name\":\"real-bridge-and-ipc\",\"status\":\"PASS\"},{\"name\":\"production-test-exports-boundary\",\"status\":\"PASS\"}],\"failures\":[\"AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\\n\\nfalse !== true\\n\\n    at <user-profile>\\\\Desktop\\\\tianming-perf-round1\\\\scripts\\\\electron\\\\authoring-region-cases.cjs:15:12\\n    at async check (<user-profile>\\\\Desktop\\\\tianming-perf-round1\\\\scripts\\\\electron\\\\bridge-main.cjs:67:34)\\n    at async module.exports (<user-profile>\\\\Desktop\\\\tianming-perf-round1\\\\scripts\\\\electron\\\\authoring-region-cases.cjs:14:3)\\n    at async WebContents.<anonymous> (<user-profile>\\\\Desktop\\\\tianming-perf-round1\\\\scripts\\\\electron\\\\bridge-main.cjs:113:46)\"],\"securityScope\":\"real unpackaged production main/preload; hidden window; temporary userData; external network denied; no player data\",\"temporaryUserData\":\"<user-profile>\\\\AppData\\\\Local\\\\Temp\\\\tm-bridge-series-8rYcoH\\\\production\"}}\nELECTRON_REPORT web\\dev-tools\\electron-bridge\\63b00f8a-0fa2-4af5-8102-9eee71785c6d\\report.json\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-electron-final-d94cc464-1735-46cb-9a0d-358cd8adabca",
+      "run": {
+        "label": "authoring-region-electron-final",
+        "command": [
+          "node",
+          "scripts/verify-electron-bridge.js",
+          "--authoring-regions"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:05:53.469Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "4370ab1fad23b743737b174571e0ea688f0a970c38d335901bf644ee0f1fbc46",
+          "web/editor-authoring-agent.js": "cf2279d228e97df8e790ee10e23c556fbe10b97cd686c553748152036e10b133",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "0dd507646958f6cc2112162e12ae3e95bb779287dce76311e4253f72bf046617"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 26836.182800000002,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "b481c015958b2a8e098276763c544b216f085bd72d592081e4e172efda079de3",
+          "text": "{\"mode\":\"authoring-regions\",\"ok\":true,\"exitCode\":0,\"detail\":{\"complete\":true,\"ok\":true,\"mode\":\"authoring-regions\",\"baseline\":false,\"versions\":{\"node\":\"20.18.3\",\"acorn\":\"8.14.0\",\"ada\":\"2.9.2\",\"ares\":\"1.34.4\",\"base64\":\"0.5.2\",\"brotli\":\"1.0.9\",\"cjs_module_lexer\":\"1.4.1\",\"cldr\":\"44.1\",\"icu\":\"74.2\",\"llhttp\":\"8.1.2\",\"modules\":\"130\",\"napi\":\"9\",\"nghttp2\":\"1.61.0\",\"openssl\":\"0.0.0\",\"simdutf\":\"5.6.4\",\"tz\":\"2024a\",\"undici\":\"6.21.1\",\"unicode\":\"15.1\",\"uv\":\"1.46.0\",\"uvwasi\":\"0.0.21\",\"v8\":\"13.0.245.25-electron.0\",\"zlib\":\"1.3.0.1-motley\",\"electron\":\"33.4.11\",\"chrome\":\"130.0.6723.191\"},\"results\":[{\"name\":\"locked-electron-runtime\",\"status\":\"PASS\"},{\"name\":\"production-webpreferences\",\"status\":\"PASS\"},{\"name\":\"observed-turn-data-protocol\",\"value\":2,\"status\":\"PASS\",\"required\":2},{\"name\":\"real-bridge-and-ipc\",\"status\":\"PASS\"},{\"name\":\"production-test-exports-boundary\",\"status\":\"PASS\"},{\"name\":\"actual-editor-page-and-bridge\",\"status\":\"PASS\"},{\"name\":\"nested-search-and-real-ID-readback\",\"status\":\"PASS\"},{\"name\":\"missing-region-error-has-no-partial-write\",\"status\":\"PASS\"},{\"name\":\"actual-adapter-commits-valid-region-economy-and-minxin\",\"status\":\"PASS\"},{\"name\":\"saved-region-state-survives-actual-editor-reload\",\"status\":\"PASS\"},{\"name\":\"legacy-editor-entry-loads-the-same-production-tools\",\"status\":\"PASS\"},{\"name\":\"original-fixture-is-unchanged\",\"status\":\"PASS\"}],\"failures\":[],\"securityScope\":\"real unpackaged production main/preload; hidden window; temporary userData; external network denied; no player data\",\"temporaryUserData\":\"<user-profile>\\\\AppData\\\\Local\\\\Temp\\\\tm-bridge-series-Ep9Oo2\\\\production\"}}\nELECTRON_REPORT web\\dev-tools\\electron-bridge\\91e8d91e-0a56-4803-8426-0ca7bd54060b\\report.json\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-electron-ready-4c01cdf5-c568-46a4-8bce-855452d8f001",
+      "run": {
+        "label": "authoring-region-electron-ready",
+        "command": [
+          "node",
+          "scripts/verify-electron-bridge.js",
+          "--authoring-regions"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T14:59:24.769Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "1255a5094a4054ee07295d29748c2600673aa5cd4bf5943fc45d62ffb03692b7",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/editor-authoring-agent.js": "8fc466deeeea342f82704a55387566ef576de2a9d59bac5617a11e4162f2f404",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "62491ee866138a5b03576e741b0f8278aef3065f9aefdb848012e3ef80ab2d2d",
+          "web/scripts/smoke-authoring-region-paths.js": "331e7aa4ab535c234bb0da16a708d0afcc7f35212ccee97119f1077c3ada8d43"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 13632.221500000001,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "c8792892ad5de3d562a2bb3cb6782904b73d8ca17ed0ea6c26e3771067f7cc01",
+          "text": "{\"mode\":\"authoring-regions\",\"ok\":true,\"exitCode\":0,\"detail\":{\"complete\":true,\"ok\":true,\"mode\":\"authoring-regions\",\"baseline\":false,\"versions\":{\"node\":\"20.18.3\",\"acorn\":\"8.14.0\",\"ada\":\"2.9.2\",\"ares\":\"1.34.4\",\"base64\":\"0.5.2\",\"brotli\":\"1.0.9\",\"cjs_module_lexer\":\"1.4.1\",\"cldr\":\"44.1\",\"icu\":\"74.2\",\"llhttp\":\"8.1.2\",\"modules\":\"130\",\"napi\":\"9\",\"nghttp2\":\"1.61.0\",\"openssl\":\"0.0.0\",\"simdutf\":\"5.6.4\",\"tz\":\"2024a\",\"undici\":\"6.21.1\",\"unicode\":\"15.1\",\"uv\":\"1.46.0\",\"uvwasi\":\"0.0.21\",\"v8\":\"13.0.245.25-electron.0\",\"zlib\":\"1.3.0.1-motley\",\"electron\":\"33.4.11\",\"chrome\":\"130.0.6723.191\"},\"results\":[{\"name\":\"locked-electron-runtime\",\"status\":\"PASS\"},{\"name\":\"production-webpreferences\",\"status\":\"PASS\"},{\"name\":\"observed-turn-data-protocol\",\"value\":2,\"status\":\"PASS\",\"required\":2},{\"name\":\"real-bridge-and-ipc\",\"status\":\"PASS\"},{\"name\":\"production-test-exports-boundary\",\"status\":\"PASS\"},{\"name\":\"actual-editor-page-and-bridge\",\"status\":\"PASS\"},{\"name\":\"nested-search-and-real-ID-readback\",\"status\":\"PASS\"},{\"name\":\"missing-region-error-has-no-partial-write\",\"status\":\"PASS\"},{\"name\":\"actual-adapter-commits-valid-region-economy-and-minxin\",\"status\":\"PASS\"},{\"name\":\"saved-region-state-survives-actual-editor-reload\",\"status\":\"PASS\"},{\"name\":\"legacy-editor-entry-loads-the-same-production-tools\",\"status\":\"PASS\"},{\"name\":\"original-fixture-is-unchanged\",\"status\":\"PASS\"}],\"failures\":[],\"securityScope\":\"real unpackaged production main/preload; hidden window; temporary userData; external network denied; no player data\",\"temporaryUserData\":\"<user-profile>\\\\AppData\\\\Local\\\\Temp\\\\tm-bridge-series-7EsqUF\\\\production\"}}\nELECTRON_REPORT web\\dev-tools\\electron-bridge\\807320b4-5c8c-4a77-bba5-6bbafceadd64\\report.json\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-electron-standard-0b3d421b-3931-4fe5-b1fa-85a9a31eef85",
+      "run": {
+        "label": "authoring-region-electron-standard",
+        "command": [
+          "node",
+          "scripts/verify-electron-bridge.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:05:29.023Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "8bfd3a173dd60d078adb1fc1f32c573d875f3d88d88f39884791de07e99f650c",
+          "web/editor-authoring-agent.js": "cf2279d228e97df8e790ee10e23c556fbe10b97cd686c553748152036e10b133",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "0dd507646958f6cc2112162e12ae3e95bb779287dce76311e4253f72bf046617"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 23199.966999999997,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "eaf908f0d287a756c5bebac3752ce984ba9604c110c75c06419c66f2fea38e5b",
+          "text": "{\"mode\":\"production\",\"ok\":true,\"exitCode\":0,\"detail\":{\"complete\":true,\"ok\":true,\"mode\":\"production\",\"baseline\":false,\"versions\":{\"node\":\"20.18.3\",\"acorn\":\"8.14.0\",\"ada\":\"2.9.2\",\"ares\":\"1.34.4\",\"base64\":\"0.5.2\",\"brotli\":\"1.0.9\",\"cjs_module_lexer\":\"1.4.1\",\"cldr\":\"44.1\",\"icu\":\"74.2\",\"llhttp\":\"8.1.2\",\"modules\":\"130\",\"napi\":\"9\",\"nghttp2\":\"1.61.0\",\"openssl\":\"0.0.0\",\"simdutf\":\"5.6.4\",\"tz\":\"2024a\",\"undici\":\"6.21.1\",\"unicode\":\"15.1\",\"uv\":\"1.46.0\",\"uvwasi\":\"0.0.21\",\"v8\":\"13.0.245.25-electron.0\",\"zlib\":\"1.3.0.1-motley\",\"electron\":\"33.4.11\",\"chrome\":\"130.0.6723.191\"},\"results\":[{\"name\":\"locked-electron-runtime\",\"status\":\"PASS\"},{\"name\":\"production-webpreferences\",\"status\":\"PASS\"},{\"name\":\"observed-turn-data-protocol\",\"value\":2,\"status\":\"PASS\",\"required\":2},{\"name\":\"real-bridge-and-ipc\",\"status\":\"PASS\"},{\"name\":\"production-test-exports-boundary\",\"status\":\"PASS\"},{\"name\":\"legacy-and-hash-save-real-ipc-roundtrip\",\"status\":\"PASS\"},{\"name\":\"autosave-text-bridge-real-ipc-and-invalid-input-preserves-disk\",\"status\":\"PASS\"},{\"name\":\"manual-save-world-switch-barrier-and-late-real-ipc\",\"status\":\"PASS\"},{\"name\":\"atomic-export-real-ipc-failure-and-cancel\",\"status\":\"PASS\"},{\"name\":\"real-worker-import-cancel-timeout-error-and-recovery\",\"status\":\"PASS\"},{\"name\":\"workshop-overwrite-rollback-through-real-ipc\",\"status\":\"PASS\"},{\"name\":\"canonical-world-and-receipt-committed-before-process-exit\",\"status\":\"PASS\"}],\"failures\":[],\"securityScope\":\"real unpackaged production main/preload; hidden window; temporary userData; external network denied; no player data\",\"temporaryUserData\":\"<user-profile>\\\\AppData\\\\Local\\\\Temp\\\\tm-bridge-series-gnopk0\\\\production\"}}\n{\"mode\":\"test-exports\",\"ok\":true,\"exitCode\":0,\"detail\":{\"complete\":true,\"ok\":true,\"mode\":\"test-exports\",\"baseline\":false,\"versions\":{\"node\":\"20.18.3\",\"acorn\":\"8.14.0\",\"ada\":\"2.9.2\",\"ares\":\"1.34.4\",\"base64\":\"0.5.2\",\"brotli\":\"1.0.9\",\"cjs_module_lexer\":\"1.4.1\",\"cldr\":\"44.1\",\"icu\":\"74.2\",\"llhttp\":\"8.1.2\",\"modules\":\"130\",\"napi\":\"9\",\"nghttp2\":\"1.61.0\",\"openssl\":\"0.0.0\",\"simdutf\":\"5.6.4\",\"tz\":\"2024a\",\"undici\":\"6.21.1\",\"unicode\":\"15.1\",\"uv\":\"1.46.0\",\"uvwasi\":\"0.0.21\",\"v8\":\"13.0.245.25-electron.0\",\"zlib\":\"1.3.0.1-motley\",\"electron\":\"33.4.11\",\"chrome\":\"130.0.6723.191\"},\"results\":[{\"name\":\"locked-electron-runtime\",\"status\":\"PASS\"},{\"name\":\"production-webpreferences\",\"status\":\"PASS\"},{\"name\":\"observed-turn-data-protocol\",\"value\":2,\"status\":\"PASS\",\"required\":2},{\"name\":\"real-bridge-and-ipc\",\"status\":\"PASS\"},{\"name\":\"production-test-exports-boundary\",\"status\":\"PASS\"},{\"name\":\"legacy-and-hash-save-real-ipc-roundtrip\",\"status\":\"PASS\"},{\"name\":\"autosave-text-bridge-real-ipc-and-invalid-input-preserves-disk\",\"status\":\"PASS\"},{\"name\":\"manual-save-world-switch-barrier-and-late-real-ipc\",\"status\":\"PASS\"},{\"name\":\"atomic-export-real-ipc-failure-and-cancel\",\"status\":\"PASS\"},{\"name\":\"real-worker-import-cancel-timeout-error-and-recovery\",\"status\":\"PASS\"},{\"name\":\"workshop-overwrite-rollback-through-real-ipc\",\"status\":\"PASS\"}],\"failures\":[],\"securityScope\":\"real unpackaged production main/preload; hidden window; temporary userData; external network denied; no player data\",\"temporaryUserData\":\"<user-profile>\\\\AppData\\\\Local\\\\Temp\\\\tm-bridge-series-gnopk0\\\\exports\"}}\n{\"mode\":\"restart\",\"ok\":true,\"exitCode\":0,\"detail\":{\"complete\":true,\"ok\":true,\"mode\":\"restart\",\"baseline\":false,\"versions\":{\"node\":\"20.18.3\",\"acorn\":\"8.14.0\",\"ada\":\"2.9.2\",\"ares\":\"1.34.4\",\"base64\":\"0.5.2\",\"brotli\":\"1.0.9\",\"cjs_module_lexer\":\"1.4.1\",\"cldr\":\"44.1\",\"icu\":\"74.2\",\"llhttp\":\"8.1.2\",\"modules\":\"130\",\"napi\":\"9\",\"nghttp2\":\"1.61.0\",\"openssl\":\"0.0.0\",\"simdutf\":\"5.6.4\",\"tz\":\"2024a\",\"undici\":\"6.21.1\",\"unicode\":\"15.1\",\"uv\":\"1.46.0\",\"uvwasi\":\"0.0.21\",\"v8\":\"13.0.245.25-electron.0\",\"zlib\":\"1.3.0.1-motley\",\"electron\":\"33.4.11\",\"chrome\":\"130.0.6723.191\"},\"results\":[{\"name\":\"locked-electron-runtime\",\"status\":\"PASS\"},{\"name\":\"production-webpreferences\",\"status\":\"PASS\"},{\"name\":\"observed-turn-data-protocol\",\"value\":2,\"status\":\"PASS\",\"required\":2},{\"name\":\"real-bridge-and-ipc\",\"status\":\"PASS\"},{\"name\":\"production-test-exports-boundary\",\"status\":\"PASS\"},{\"name\":\"canonical-receipt-and-folio-recover-after-real-process-exit\",\"status\":\"PASS\"}],\"failures\":[],\"securityScope\":\"real unpackaged production main/preload; hidden window; temporary userData; external network denied; no player data\",\"temporaryUserData\":\"<user-profile>\\\\AppData\\\\Local\\\\Temp\\\\tm-bridge-series-gnopk0\\\\production\"}}\nELECTRON_REPORT web\\dev-tools\\electron-bridge\\c70ba729-2d30-4ff9-9663-77751f4081a6\\report.json\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-fixed-552371dc-9aa3-43f9-9262-58cd94cbc3ff",
+      "run": {
+        "label": "authoring-region-fixed",
+        "command": [
+          "node",
+          "web/scripts/smoke-authoring-region-paths.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M web/editor-authoring-agent.js\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T14:52:03.521Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          "web/editor-authoring-agent.js": "8fc466deeeea342f82704a55387566ef576de2a9d59bac5617a11e4162f2f404",
+          "web/scripts/smoke-authoring-region-paths.js": "331e7aa4ab535c234bb0da16a708d0afcc7f35212ccee97119f1077c3ada8d43"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 279.17859999999996,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "fdd6d259a4af2af33ade8050cf878e424f4197e6fd91236674e2f7329bd2bd7a",
+          "text": "PASS nested map search returns a readable concrete path and ID\nPASS nested faction administrative search and write/read persistence\nPASS nested children collection supports explicit stable parent ID\nPASS virtual region collection roundtrips through its reported collection name\nPASS legacy mapData-only alias returns its real path without creating map\nPASS top-level character searches remain compatible and bounded\nPASS global search returned bracket paths still read and write the real row\nPASS reject intermediate array write without mutation\nPASS reject terminal array write without mutation\nPASS reject array length array write without mutation\nPASS reject negative index array write without mutation\nPASS reject out of bounds array write without mutation\nPASS failed append through a missing named region is not falsely successful\nPASS failed read and batch read accurately report a missing leaf\nPASS duplicate names cannot silently select the first region\nPASS explicit unique ID updates only the requested duplicate-name region\nPASS ID takes precedence over an unrelated name that happens to equal it\nPASS duplicate IDs are rejected without choosing an arbitrary row\nPASS new object fields under a valid named entity are created and persist\nPASS missing object chain remains supported without partial invalid bracket scaffolding\nPASS explicit append can create a child collection under the actual selected ID\nPASS remove keeps legitimate ID/index operations but rejects missing and ambiguous names\nPASS atomic multi-edit rollback includes a later unresolved named entity\nPASS unsafe or prototype paths remain rejected even with force\nPASS detached draft edits do not touch caller-owned scenario data\n{\"source\":\"worktree\",\"pass\":25,\"fail\":0,\"total\":25,\"scope\":\"actual public authoring tools; no network or player data\"}\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-fixed-final-d7ee036d-d7df-4d48-8f5a-c3bff12b6dec",
+      "run": {
+        "label": "authoring-region-fixed-final",
+        "command": [
+          "node",
+          "web/scripts/smoke-authoring-region-paths.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:01:50.733Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "8bfd3a173dd60d078adb1fc1f32c573d875f3d88d88f39884791de07e99f650c",
+          "web/editor-authoring-agent.js": "81c0079e2c7d4d35290da3118bc323e6023e94e8b1865a809aa260b97aa4ac25",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "03553e2c031c694c7aecd7f105fdda75039c2aa77eb056ca7eb08f3fc0289a15"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 246.45510000000002,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "91643fb10145ddf5c391caab42919700c874fc3ff28e638f955cab96124ee591",
+          "text": "PASS nested map search returns a readable concrete path and ID\nPASS nested faction administrative search and write/read persistence\nPASS nested children collection supports explicit stable parent ID\nPASS virtual region collection roundtrips through its reported collection name\nPASS legacy mapData-only alias returns its real path without creating map\nPASS top-level character searches remain compatible and bounded\nPASS global search returned bracket paths still read and write the real row\nPASS reject intermediate array write without mutation\nPASS reject terminal array write without mutation\nPASS reject array length array write without mutation\nPASS reject negative index array write without mutation\nPASS reject out of bounds array write without mutation\nPASS failed append through a missing named region is not falsely successful\nPASS failed read and batch read accurately report a missing leaf\nPASS duplicate names cannot silently select the first region\nPASS explicit unique ID updates only the requested duplicate-name region\nPASS ID takes precedence over an unrelated name that happens to equal it\nPASS duplicate IDs are rejected without choosing an arbitrary row\nPASS new object fields under a valid named entity are created and persist\nPASS missing object chain remains supported without partial invalid bracket scaffolding\nPASS explicit append can create a child collection under the actual selected ID\nPASS remove keeps legitimate ID/index operations but rejects missing and ambiguous names\nPASS atomic multi-edit rollback includes a later unresolved named entity\nPASS unsafe or prototype paths remain rejected even with force\nPASS detached draft edits do not touch caller-owned scenario data\nPASS stable ID still selects the intended region after reordering\nPASS zero, false, null and readable array length are not mistaken for missing values\nPASS copy from missing field already fails and remains non-mutating\nPASS nested bracket indices including Chinese object keys remain supported\nPASS separate drafts with reused IDs never share lookup state\n{\"source\":\"worktree\",\"pass\":30,\"fail\":0,\"total\":30,\"scope\":\"actual public authoring tools; no network or player data\"}\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-full-55c102d7-fff1-44d3-a121-14dfa3ce0534",
+      "run": {
+        "label": "authoring-region-full",
+        "command": [
+          "node",
+          "web/scripts/ci-smokes.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:07:48.722Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "4370ab1fad23b743737b174571e0ea688f0a970c38d335901bf644ee0f1fbc46",
+          "web/editor-authoring-agent.js": "cf2279d228e97df8e790ee10e23c556fbe10b97cd686c553748152036e10b133",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "0dd507646958f6cc2112162e12ae3e95bb779287dce76311e4253f72bf046617"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 83446.6689,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "24c62da4e7b612735869f0ab0dae08c35c21372be734a3e8964f29695d17015a",
+          "text": "[ci-smokes] run=882d2b2f-505f-4ca2-b84d-d2253d3878f1 HEAD=12942b78fe64d20f4eb9ee01827a2c3567b38bf1 report=<user-profile>\\Desktop\\tianming-perf-round1\\web\\dev-tools\\arch-guard\\ci-G6Vrru\\smoke-report.json\n[run-smokes] 共 919 个 smoke · 选中 919 · 跳过 0 · 并发 8 · 超时 120s\n  [25/919] PASS    smoke-agent-mode-s2.js (0.2s)\n  [50/919] PASS    smoke-ai-structured-policy-detail-actions.js (0.2s)\n  [75/919] PASS    smoke-audit-manual-save-lease.js (0.2s)\n  [100/919] PASS    smoke-battle-report.js (0.2s)\n  [125/919] PASS    smoke-centralization-finance-guard.js (0.2s)\n  [150/919] PASS    smoke-class-character-relations.js (0.2s)\n  [175/919] PASS    smoke-conn-quickcheck.js (0.3s)\n  [200/919] PASS    smoke-court-social-uplift.js (0.3s)\n  [225/919] PASS    smoke-dianzhang.js (0.2s)\n  [250/919] PASS    smoke-edict-office-abolish-dynamic-lifecycle.js (0.3s)\n  [275/919] PASS    smoke-endturn-namespace-deps.js (0.2s)\n  [300/919] PASS    smoke-eunuch-minister.js (0.2s)\n  [325/919] PASS    smoke-faction-npc-isplayer-guard.js (0.2s)\n  [350/919] PASS    smoke-fiscal-dynamic-settlement.js (0.3s)\n  [375/919] PASS    smoke-g5-tongzi.js (0.2s)\n  [400/919] PASS    smoke-guoshi-write-sanitize.js (0.2s)\n  [425/919] PASS    smoke-inflation-tax-namespace.js (0.2s)\n  [450/919] PASS    smoke-loyalty-attribution.js (0.2s)\n  [475/919] PASS    smoke-memory-character-scope.js (0.2s)\n  [500/919] PASS    smoke-memory-legacy-source-migration.js (0.2s)\n  [525/919] PASS    smoke-memory-stance-netting.js (0.2s)\n  [550/919] PASS    smoke-memory-workshop-review-details.js (0.2s)\n  [575/919] PASS    smoke-neitang-inner-treasury-compat.js (0.2s)\n  [600/919] PASS    smoke-npc-relation-events.js (0.2s)\n  [625/919] PASS    smoke-offtree-appoint-deterministic.js (0.3s)\n  [650/919] PASS    smoke-party-goals-adaptive-evidence.js (0.2s)\n  [675/919] PASS    smoke-perf-map-render-path.js (3.7s)\n  [700/919] PASS    smoke-prompt-budget-guards.js (0.2s)\n  [725/919] PASS    smoke-renli-grain-shortfall.js (0.2s)\n  [750/919] PASS    smoke-restore-custom-scenarios.js (0.2s)\n  [775/919] PASS    smoke-s4-office-retirement.js (2.3s)\n  [800/919] PASS    smoke-semantic-cache-scheme-gate.js (0.2s)\n  [825/919] PASS    smoke-status-idempotency.js (0.3s)\n  [850/919] PASS    smoke-tianqi-map-runtime.js (0.8s)\n  [875/919] PASS    smoke-wave1-combo.js (0.2s)\n  [900/919] PASS    smoke-workshop-pipeline-e.js (0.2s)\n  [919/919] PASS    smoke-start-game-data-integrity.js (33.6s)\n\n[run-smokes] 完成：917 PASS · 0 FAIL · 0 SKIP · 2 WAIVED / 919 executed · 0 suspect(退出码0但输出FAIL) · 总耗时 526s(并行墙钟更短)\n\n--- 最慢 Top 10 ---\n  49.4s  smoke-full-turn-flow.js\n  33.6s  smoke-start-game-data-integrity.js\n  26.7s  smoke-perf-save-preparation.js\n  25.5s  smoke-deploy-manifest-atomicity.js\n  16.7s  smoke-workshop-lock-recovery.js\n  11.0s  smoke-character-location-travel.js\n  6.7s  smoke-tinyi-scenario-class-source.js\n  6.7s  smoke-tinyi-party-class-agenda.js\n  6.6s  smoke-party-goals-lifecycle.js\n  6.6s  smoke-tinyi-reissued.js\n\n[run-smokes] 报告 → dev-tools/arch-guard/ci-G6Vrru/smoke-report.json\n[ci-smokes] PASS gate {\"pass\":917,\"fail\":0,\"skip\":0,\"waived\":2,\"waivedChecks\":7,\"total\":919}\n[ci-smokes] 缺席资产检查已明确豁免；其余断言全部执行。\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-full-locked-03b50855-68d2-4515-a012-f6446a16a674",
+      "run": {
+        "label": "authoring-region-full-locked",
+        "command": [
+          "node",
+          "web/scripts/ci-smokes.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? docs/bugfix-authoring-region-paths-2026-09-08.md\n?? scripts/collect-authoring-region-evidence.cjs\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:20:57.973Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "docs/bugfix-authoring-region-paths-2026-09-08.md": "f7c8da0b46dd33adac9b05b80574e10a9b93abcf8b7a1c5958418ef0e7273c8e",
+          "scripts/collect-authoring-region-evidence.cjs": "04ddc90173bc3beff6715ea2ec9748182b38e479cd3d85c832c5fbe6513ac30f",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "41da7460d7882c1472ff53e4f1784f991d242f4bb5bac42685fa8c7908add25f",
+          "web/editor-authoring-agent.js": "761784e028cdf9dc527b7a113c334a29d929f6eda99a629352e4f1a2875fdd67",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "43a6f29f98c32b4f3c8d2482ff899cbe4fe1000fa8b6b63bec92bd6ee76554da"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 83341.7598,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "d6fad6923e000e02e657afe985dd13ae7048da968982d20dbd8f71889cc29ff8",
+          "text": "[ci-smokes] run=e78ffeba-9018-4bc7-a930-c58e7736e02a HEAD=12942b78fe64d20f4eb9ee01827a2c3567b38bf1 report=<user-profile>\\Desktop\\tianming-perf-round1\\web\\dev-tools\\arch-guard\\ci-mNnVhx\\smoke-report.json\n[run-smokes] 共 919 个 smoke · 选中 919 · 跳过 0 · 并发 8 · 超时 120s\n  [25/919] PASS    smoke-agent-mode-s2.js (0.7s)\n  [50/919] PASS    smoke-ai-structured-policy-actions.js (0.3s)\n  [75/919] PASS    smoke-audit-manual-save-lease.js (0.2s)\n  [100/919] PASS    smoke-battle-report.js (0.1s)\n  [125/919] PASS    smoke-centralization-finance-guard.js (0.2s)\n  [150/919] PASS    smoke-class-character-relations.js (0.2s)\n  [175/919] PASS    smoke-conn-quickcheck.js (0.2s)\n  [200/919] PASS    smoke-courtesy-address.js (0.2s)\n  [225/919] PASS    smoke-dianzhang.js (0.2s)\n  [250/919] PASS    smoke-deepread-wave-parallel.js (2.6s)\n  [275/919] PASS    smoke-endturn-namespace-deps.js (0.3s)\n  [300/919] PASS    smoke-environment-migration-capacity.js (0.4s)\n  [325/919] PASS    smoke-faction-npc-isplayer-guard.js (0.2s)\n  [350/919] PASS    smoke-fiscal-dynamic-settlement.js (0.3s)\n  [375/919] PASS    smoke-g5-tongzi.js (0.2s)\n  [400/919] PASS    smoke-guoshi-write-sanitize.js (0.2s)\n  [425/919] PASS    smoke-inflation-tax-namespace.js (0.2s)\n  [450/919] PASS    smoke-loyalty-attribution.js (0.2s)\n  [475/919] PASS    smoke-memory-character-scope.js (0.2s)\n  [500/919] PASS    smoke-memory-loop-closure.js (0.2s)\n  [525/919] PASS    smoke-memory-stance-netting.js (0.2s)\n  [550/919] PASS    smoke-memory-workshop-review-details.js (0.2s)\n  [575/919] PASS    smoke-neitang-inner-treasury-compat.js (0.2s)\n  [600/919] PASS    smoke-npc-relation-events.js (0.2s)\n  [625/919] PASS    smoke-offtree-appoint-deterministic.js (0.2s)\n  [650/919] PASS    smoke-party-goals-adaptive-evidence.js (0.2s)\n  [675/919] PASS    smoke-player-death-adjudicator.js (0.2s)\n  [700/919] PASS    smoke-prompt-budget-guards.js (0.2s)\n  [725/919] PASS    smoke-renli-fugitive-authority.js (0.2s)\n  [750/919] PASS    smoke-restore-custom-scenarios.js (0.2s)\n  [775/919] PASS    smoke-s4-office-retirement.js (2.4s)\n  [800/919] PASS    smoke-semantic-cache-scheme-gate.js (0.2s)\n  [825/919] PASS    smoke-status-idempotency.js (0.3s)\n  [850/919] PASS    smoke-tier3-supplement.js (0.2s)\n  [875/919] PASS    smoke-wave1-combo.js (0.2s)\n  [900/919] PASS    smoke-workshop-pipeline-e.js (0.2s)\n  [919/919] PASS    smoke-start-game-data-integrity.js (33.2s)\n\n[run-smokes] 完成：917 PASS · 0 FAIL · 0 SKIP · 2 WAIVED / 919 executed · 0 suspect(退出码0但输出FAIL) · 总耗时 529s(并行墙钟更短)\n\n--- 最慢 Top 10 ---\n  49.3s  smoke-full-turn-flow.js\n  33.2s  smoke-start-game-data-integrity.js\n  26.2s  smoke-perf-save-preparation.js\n  25.0s  smoke-deploy-manifest-atomicity.js\n  17.4s  smoke-workshop-lock-recovery.js\n  11.1s  smoke-character-location-travel.js\n  6.6s  smoke-party-goals-lifecycle.js\n  6.6s  smoke-class-demand-party-goals.js\n  6.6s  smoke-tinyi-scenario-class-source.js\n  6.6s  smoke-tinyi-reissued.js\n\n[run-smokes] 报告 → dev-tools/arch-guard/ci-mNnVhx/smoke-report.json\n[ci-smokes] PASS gate {\"pass\":917,\"fail\":0,\"skip\":0,\"waived\":2,\"waivedChecks\":7,\"total\":919}\n[ci-smokes] 缺席资产检查已明确豁免；其余断言全部执行。\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-hot-final-835dcf0f-480c-4704-b937-1d792928f6b9",
+      "run": {
+        "label": "authoring-region-hot-final",
+        "command": [
+          "node",
+          "scripts/sync-hot-baseline.js",
+          "--write",
+          "--version",
+          "1.3.4.11",
+          "--asset-root",
+          "<user-profile>/Desktop/tianming",
+          "--temp-root",
+          "E:/tianming-perf-temp"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:04:34.421Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "8bfd3a173dd60d078adb1fc1f32c573d875f3d88d88f39884791de07e99f650c",
+          "web/editor-authoring-agent.js": "cf2279d228e97df8e790ee10e23c556fbe10b97cd686c553748152036e10b133",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "0dd507646958f6cc2112162e12ae3e95bb779287dce76311e4253f72bf046617"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 54757.2352,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "acfdca91e5efcfb1784f3e7b14b5c4cc07a15f6c94bbce4b67da9de27428ad6b",
+          "text": "[hot-baseline] asset-root overlay files=410 bytes=806161938\nWROTE <user-profile>\\Desktop\\tianming-perf-round1\\web\\.hot-update-manifest.json files=1094 version=1.3.4.11 fixed=2\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-hot-locked-6c810066-2c96-4c1f-8d9c-9d0b3311d4b9",
+      "run": {
+        "label": "authoring-region-hot-locked",
+        "command": [
+          "node",
+          "scripts/sync-hot-baseline.js",
+          "--write",
+          "--version",
+          "1.3.4.11",
+          "--asset-root",
+          "<user-profile>/Desktop/tianming",
+          "--temp-root",
+          "E:/tianming-perf-temp"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:10:27.557Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "4370ab1fad23b743737b174571e0ea688f0a970c38d335901bf644ee0f1fbc46",
+          "web/editor-authoring-agent.js": "761784e028cdf9dc527b7a113c334a29d929f6eda99a629352e4f1a2875fdd67",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "43a6f29f98c32b4f3c8d2482ff899cbe4fe1000fa8b6b63bec92bd6ee76554da"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 47408.9073,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "50fab47891d01102bc762fb6dae0fa920b730d3ff727e1140614764fad8c37a0",
+          "text": "[hot-baseline] asset-root overlay files=410 bytes=806161938\nWROTE <user-profile>\\Desktop\\tianming-perf-round1\\web\\.hot-update-manifest.json files=1094 version=1.3.4.11 fixed=1\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-hot-sync-67044306-117f-46a1-bc36-3863e60ed0cb",
+      "run": {
+        "label": "authoring-region-hot-sync",
+        "command": [
+          "node",
+          "scripts/sync-hot-baseline.js",
+          "--write",
+          "--version",
+          "1.3.4.11",
+          "--asset-root",
+          "<user-profile>/Desktop/tianming",
+          "--temp-root",
+          "E:/tianming-perf-temp"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:00:03.086Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "1255a5094a4054ee07295d29748c2600673aa5cd4bf5943fc45d62ffb03692b7",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/editor-authoring-agent.js": "8fc466deeeea342f82704a55387566ef576de2a9d59bac5617a11e4162f2f404",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "62491ee866138a5b03576e741b0f8278aef3065f9aefdb848012e3ef80ab2d2d",
+          "web/scripts/smoke-authoring-region-paths.js": "331e7aa4ab535c234bb0da16a708d0afcc7f35212ccee97119f1077c3ada8d43"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 46410.156800000004,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "3f0dca70417f5e244baae0d5c7cc6e21e4ed194636dce3cb235822e375370645",
+          "text": "[hot-baseline] asset-root overlay files=410 bytes=806161938\nWROTE <user-profile>\\Desktop\\tianming-perf-round1\\web\\.hot-update-manifest.json files=1094 version=1.3.4.11 fixed=3\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-official-sync-d18f98f2-b57a-4fc9-91f6-8386dd8c6d90",
+      "run": {
+        "label": "authoring-region-official-sync",
+        "command": [
+          "node",
+          "web/scripts/sync-official-scenarios.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T14:59:59.558Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "1255a5094a4054ee07295d29748c2600673aa5cd4bf5943fc45d62ffb03692b7",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/editor-authoring-agent.js": "8fc466deeeea342f82704a55387566ef576de2a9d59bac5617a11e4162f2f404",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "62491ee866138a5b03576e741b0f8278aef3065f9aefdb848012e3ef80ab2d2d",
+          "web/scripts/smoke-authoring-region-paths.js": "331e7aa4ab535c234bb0da16a708d0afcc7f35212ccee97119f1077c3ada8d43"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 2751.0229,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "79bcdcf5972c85f1965b2ca7f979806efc04283324a542c7bb6e3a0110f64309",
+          "text": "[official-sync] sync PASS · sources=2 artifacts=9\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-parity-00552eb6-1e51-470d-a5bf-6e5732dff4af",
+      "run": {
+        "label": "authoring-region-parity",
+        "command": [
+          "node",
+          "web/scripts/verify-official-scenario-parity.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:05:56.112Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "4370ab1fad23b743737b174571e0ea688f0a970c38d335901bf644ee0f1fbc46",
+          "web/editor-authoring-agent.js": "cf2279d228e97df8e790ee10e23c556fbe10b97cd686c553748152036e10b133",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "0dd507646958f6cc2112162e12ae3e95bb779287dce76311e4253f72bf046617"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 3219.8998,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "76e27a09f9c0c3f9ecabc195f27e7bf7bf3988b17b84783c9c680a4cbc59dd7e",
+          "text": "[official-sync] parity PASS · sources=2 artifacts=9\n  ok·seeder/preview/reset artifacts registered\n  ok·tianqi7 builtin embeds the complete root JSON\n  ok·tianqi7 builtin remains reviewable compact output\n  ok·tianqi7 seeder embeds the complete root JSON\n  ok·tianqi7 editor preview embeds the complete root JSON\n  ok·editor reset embeds the complete Tianqi root JSON (embedded=6342549/a66ec5dc5e00721c21e6d22404221a6b11bc2ea4b943699586510573ea2b43b9, root=6342549/a66ec5dc5e00721c21e6d22404221a6b11bc2ea4b943699586510573ea2b43b9, differingKeys=)\n  ok·tianqi7 bundled JSON is byte-identical to root JSON\n  ok·shaosong builtin embeds the complete root JSON\n  ok·shaosong builtin remains reviewable compact output\n  ok·shaosong seeder embeds the complete root JSON\n  ok·shaosong editor preview embeds the complete root JSON\n  ok·shaosong bundled JSON is byte-identical to root JSON\n  ok·manifest.js equals manifest.json\n  ok·tianqi7 metadata exists\n  ok·tianqi7 metadata script sha256 is correct\n  ok·tianqi7 metadata script bytes is correct\n  ok·tianqi7 metadata source sha256 is correct\n  ok·tianqi7 metadata source bytes is correct\n  ok·tianqi7 metadata loader path is correct\n  ok·tianqi7 metadata counts are correct\n  ok·shaosong metadata exists\n  ok·shaosong metadata script sha256 is correct\n  ok·shaosong metadata script bytes is correct\n  ok·shaosong metadata source sha256 is correct\n  ok·shaosong metadata source bytes is correct\n  ok·shaosong metadata loader path is correct\n  ok·shaosong metadata counts are correct\nPASS assertions=27\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-parity-locked-e5d9c57b-ae53-4e2e-9271-f9e120f279c3",
+      "run": {
+        "label": "authoring-region-parity-locked",
+        "command": [
+          "node",
+          "web/scripts/verify-official-scenario-parity.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? docs/bugfix-authoring-region-paths-2026-09-08.md\n?? scripts/collect-authoring-region-evidence.cjs\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:13:50.678Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "docs/bugfix-authoring-region-paths-2026-09-08.md": "f7c8da0b46dd33adac9b05b80574e10a9b93abcf8b7a1c5958418ef0e7273c8e",
+          "scripts/collect-authoring-region-evidence.cjs": "04ddc90173bc3beff6715ea2ec9748182b38e479cd3d85c832c5fbe6513ac30f",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "41da7460d7882c1472ff53e4f1784f991d242f4bb5bac42685fa8c7908add25f",
+          "web/editor-authoring-agent.js": "761784e028cdf9dc527b7a113c334a29d929f6eda99a629352e4f1a2875fdd67",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "43a6f29f98c32b4f3c8d2482ff899cbe4fe1000fa8b6b63bec92bd6ee76554da"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 3901.4695,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "76e27a09f9c0c3f9ecabc195f27e7bf7bf3988b17b84783c9c680a4cbc59dd7e",
+          "text": "[official-sync] parity PASS · sources=2 artifacts=9\n  ok·seeder/preview/reset artifacts registered\n  ok·tianqi7 builtin embeds the complete root JSON\n  ok·tianqi7 builtin remains reviewable compact output\n  ok·tianqi7 seeder embeds the complete root JSON\n  ok·tianqi7 editor preview embeds the complete root JSON\n  ok·editor reset embeds the complete Tianqi root JSON (embedded=6342549/a66ec5dc5e00721c21e6d22404221a6b11bc2ea4b943699586510573ea2b43b9, root=6342549/a66ec5dc5e00721c21e6d22404221a6b11bc2ea4b943699586510573ea2b43b9, differingKeys=)\n  ok·tianqi7 bundled JSON is byte-identical to root JSON\n  ok·shaosong builtin embeds the complete root JSON\n  ok·shaosong builtin remains reviewable compact output\n  ok·shaosong seeder embeds the complete root JSON\n  ok·shaosong editor preview embeds the complete root JSON\n  ok·shaosong bundled JSON is byte-identical to root JSON\n  ok·manifest.js equals manifest.json\n  ok·tianqi7 metadata exists\n  ok·tianqi7 metadata script sha256 is correct\n  ok·tianqi7 metadata script bytes is correct\n  ok·tianqi7 metadata source sha256 is correct\n  ok·tianqi7 metadata source bytes is correct\n  ok·tianqi7 metadata loader path is correct\n  ok·tianqi7 metadata counts are correct\n  ok·shaosong metadata exists\n  ok·shaosong metadata script sha256 is correct\n  ok·shaosong metadata script bytes is correct\n  ok·shaosong metadata source sha256 is correct\n  ok·shaosong metadata source bytes is correct\n  ok·shaosong metadata loader path is correct\n  ok·shaosong metadata counts are correct\nPASS assertions=27\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-player-electron-444bc5e8-fc81-4f82-a395-1ffc5f112a42",
+      "run": {
+        "label": "authoring-region-player-electron",
+        "command": [
+          "node",
+          "scripts/verify-electron-bridge.js",
+          "--authoring-regions"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:01:51.937Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "8bfd3a173dd60d078adb1fc1f32c573d875f3d88d88f39884791de07e99f650c",
+          "web/editor-authoring-agent.js": "81c0079e2c7d4d35290da3118bc323e6023e94e8b1865a809aa260b97aa4ac25",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "03553e2c031c694c7aecd7f105fdda75039c2aa77eb056ca7eb08f3fc0289a15"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 33682.7963,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "ca3d8bc5e59c9d1c43f721eb5fe1f50da63961cd2dd109e0f139c65979172fee",
+          "text": "{\"mode\":\"authoring-regions\",\"ok\":true,\"exitCode\":0,\"detail\":{\"complete\":true,\"ok\":true,\"mode\":\"authoring-regions\",\"baseline\":false,\"versions\":{\"node\":\"20.18.3\",\"acorn\":\"8.14.0\",\"ada\":\"2.9.2\",\"ares\":\"1.34.4\",\"base64\":\"0.5.2\",\"brotli\":\"1.0.9\",\"cjs_module_lexer\":\"1.4.1\",\"cldr\":\"44.1\",\"icu\":\"74.2\",\"llhttp\":\"8.1.2\",\"modules\":\"130\",\"napi\":\"9\",\"nghttp2\":\"1.61.0\",\"openssl\":\"0.0.0\",\"simdutf\":\"5.6.4\",\"tz\":\"2024a\",\"undici\":\"6.21.1\",\"unicode\":\"15.1\",\"uv\":\"1.46.0\",\"uvwasi\":\"0.0.21\",\"v8\":\"13.0.245.25-electron.0\",\"zlib\":\"1.3.0.1-motley\",\"electron\":\"33.4.11\",\"chrome\":\"130.0.6723.191\"},\"results\":[{\"name\":\"locked-electron-runtime\",\"status\":\"PASS\"},{\"name\":\"production-webpreferences\",\"status\":\"PASS\"},{\"name\":\"observed-turn-data-protocol\",\"value\":2,\"status\":\"PASS\",\"required\":2},{\"name\":\"real-bridge-and-ipc\",\"status\":\"PASS\"},{\"name\":\"production-test-exports-boundary\",\"status\":\"PASS\"},{\"name\":\"actual-editor-page-and-bridge\",\"status\":\"PASS\"},{\"name\":\"nested-search-and-real-ID-readback\",\"status\":\"PASS\"},{\"name\":\"missing-region-error-has-no-partial-write\",\"status\":\"PASS\"},{\"name\":\"actual-adapter-commits-valid-region-economy-and-minxin\",\"status\":\"PASS\"},{\"name\":\"saved-region-state-survives-actual-editor-reload\",\"status\":\"PASS\"},{\"name\":\"legacy-editor-entry-loads-the-same-production-tools\",\"status\":\"PASS\"},{\"name\":\"original-fixture-is-unchanged\",\"status\":\"PASS\"}],\"failures\":[],\"securityScope\":\"real unpackaged production main/preload; hidden window; temporary userData; external network denied; read-only user-supplied scenario clone\",\"temporaryUserData\":\"<user-profile>\\\\AppData\\\\Local\\\\Temp\\\\tm-bridge-series-Ffemmz\\\\production\"}}\nELECTRON_REPORT web\\dev-tools\\electron-bridge\\fd3a111b-fba2-465f-b05c-93343b767095\\report.json\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-player-final-6ebfe717-b237-48d4-a75c-131f13c30c8d",
+      "run": {
+        "label": "authoring-region-player-final",
+        "command": [
+          "node",
+          "scripts/verify-electron-bridge.js",
+          "--authoring-regions"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:06:21.112Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "4370ab1fad23b743737b174571e0ea688f0a970c38d335901bf644ee0f1fbc46",
+          "web/editor-authoring-agent.js": "cf2279d228e97df8e790ee10e23c556fbe10b97cd686c553748152036e10b133",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "0dd507646958f6cc2112162e12ae3e95bb779287dce76311e4253f72bf046617"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 29587.3676,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "b0b089bbfc68405d45c140c839ba19ebafe87478f0430c2f72abd5f8b0829383",
+          "text": "{\"mode\":\"authoring-regions\",\"ok\":true,\"exitCode\":0,\"detail\":{\"complete\":true,\"ok\":true,\"mode\":\"authoring-regions\",\"baseline\":false,\"versions\":{\"node\":\"20.18.3\",\"acorn\":\"8.14.0\",\"ada\":\"2.9.2\",\"ares\":\"1.34.4\",\"base64\":\"0.5.2\",\"brotli\":\"1.0.9\",\"cjs_module_lexer\":\"1.4.1\",\"cldr\":\"44.1\",\"icu\":\"74.2\",\"llhttp\":\"8.1.2\",\"modules\":\"130\",\"napi\":\"9\",\"nghttp2\":\"1.61.0\",\"openssl\":\"0.0.0\",\"simdutf\":\"5.6.4\",\"tz\":\"2024a\",\"undici\":\"6.21.1\",\"unicode\":\"15.1\",\"uv\":\"1.46.0\",\"uvwasi\":\"0.0.21\",\"v8\":\"13.0.245.25-electron.0\",\"zlib\":\"1.3.0.1-motley\",\"electron\":\"33.4.11\",\"chrome\":\"130.0.6723.191\"},\"results\":[{\"name\":\"locked-electron-runtime\",\"status\":\"PASS\"},{\"name\":\"production-webpreferences\",\"status\":\"PASS\"},{\"name\":\"observed-turn-data-protocol\",\"value\":2,\"status\":\"PASS\",\"required\":2},{\"name\":\"real-bridge-and-ipc\",\"status\":\"PASS\"},{\"name\":\"production-test-exports-boundary\",\"status\":\"PASS\"},{\"name\":\"actual-editor-page-and-bridge\",\"status\":\"PASS\"},{\"name\":\"nested-search-and-real-ID-readback\",\"status\":\"PASS\"},{\"name\":\"missing-region-error-has-no-partial-write\",\"status\":\"PASS\"},{\"name\":\"actual-adapter-commits-valid-region-economy-and-minxin\",\"status\":\"PASS\"},{\"name\":\"saved-region-state-survives-actual-editor-reload\",\"status\":\"PASS\"},{\"name\":\"legacy-editor-entry-loads-the-same-production-tools\",\"status\":\"PASS\"},{\"name\":\"original-fixture-is-unchanged\",\"status\":\"PASS\"}],\"failures\":[],\"securityScope\":\"real unpackaged production main/preload; hidden window; temporary userData; external network denied; read-only user-supplied scenario clone\",\"temporaryUserData\":\"<user-profile>\\\\AppData\\\\Local\\\\Temp\\\\tm-bridge-series-9z9akD\\\\production\"}}\nELECTRON_REPORT web\\dev-tools\\electron-bridge\\e0f23b60-edbe-42a3-9a22-534ceb6adc15\\report.json\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-player-locked-8fb92d24-2092-4774-ab4f-7c1427e1a629",
+      "run": {
+        "label": "authoring-region-player-locked",
+        "command": [
+          "node",
+          "scripts/verify-electron-bridge.js",
+          "--authoring-regions"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? docs/bugfix-authoring-region-paths-2026-09-08.md\n?? scripts/collect-authoring-region-evidence.cjs\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:14:21.217Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "docs/bugfix-authoring-region-paths-2026-09-08.md": "f7c8da0b46dd33adac9b05b80574e10a9b93abcf8b7a1c5958418ef0e7273c8e",
+          "scripts/collect-authoring-region-evidence.cjs": "04ddc90173bc3beff6715ea2ec9748182b38e479cd3d85c832c5fbe6513ac30f",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "41da7460d7882c1472ff53e4f1784f991d242f4bb5bac42685fa8c7908add25f",
+          "web/editor-authoring-agent.js": "761784e028cdf9dc527b7a113c334a29d929f6eda99a629352e4f1a2875fdd67",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "43a6f29f98c32b4f3c8d2482ff899cbe4fe1000fa8b6b63bec92bd6ee76554da"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 32008.8278,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "c32898b177778445333ee4881069193b4d4179acd2c9a1fc1dcf08a697cb207b",
+          "text": "{\"mode\":\"authoring-regions\",\"ok\":true,\"exitCode\":0,\"detail\":{\"complete\":true,\"ok\":true,\"mode\":\"authoring-regions\",\"baseline\":false,\"versions\":{\"node\":\"20.18.3\",\"acorn\":\"8.14.0\",\"ada\":\"2.9.2\",\"ares\":\"1.34.4\",\"base64\":\"0.5.2\",\"brotli\":\"1.0.9\",\"cjs_module_lexer\":\"1.4.1\",\"cldr\":\"44.1\",\"icu\":\"74.2\",\"llhttp\":\"8.1.2\",\"modules\":\"130\",\"napi\":\"9\",\"nghttp2\":\"1.61.0\",\"openssl\":\"0.0.0\",\"simdutf\":\"5.6.4\",\"tz\":\"2024a\",\"undici\":\"6.21.1\",\"unicode\":\"15.1\",\"uv\":\"1.46.0\",\"uvwasi\":\"0.0.21\",\"v8\":\"13.0.245.25-electron.0\",\"zlib\":\"1.3.0.1-motley\",\"electron\":\"33.4.11\",\"chrome\":\"130.0.6723.191\"},\"results\":[{\"name\":\"locked-electron-runtime\",\"status\":\"PASS\"},{\"name\":\"production-webpreferences\",\"status\":\"PASS\"},{\"name\":\"observed-turn-data-protocol\",\"value\":2,\"status\":\"PASS\",\"required\":2},{\"name\":\"real-bridge-and-ipc\",\"status\":\"PASS\"},{\"name\":\"production-test-exports-boundary\",\"status\":\"PASS\"},{\"name\":\"actual-editor-page-and-bridge\",\"status\":\"PASS\"},{\"name\":\"nested-search-and-real-ID-readback\",\"status\":\"PASS\"},{\"name\":\"missing-region-error-has-no-partial-write\",\"status\":\"PASS\"},{\"name\":\"actual-adapter-commits-valid-region-economy-and-minxin\",\"status\":\"PASS\"},{\"name\":\"saved-region-state-survives-actual-editor-reload\",\"status\":\"PASS\"},{\"name\":\"legacy-editor-entry-loads-the-same-production-tools\",\"status\":\"PASS\"},{\"name\":\"original-fixture-is-unchanged\",\"status\":\"PASS\"}],\"failures\":[],\"securityScope\":\"real unpackaged production main/preload; hidden window; temporary userData; external network denied; read-only user-supplied scenario clone\",\"temporaryUserData\":\"<user-profile>\\\\AppData\\\\Local\\\\Temp\\\\tm-bridge-series-UBhKyV\\\\production\"}}\nELECTRON_REPORT web\\dev-tools\\electron-bridge\\65a3fdc5-feed-486f-958a-f2154c0b6f16\\report.json\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-related-1f636afa-a3cb-4300-829d-4a003cf63327",
+      "run": {
+        "label": "authoring-region-related",
+        "command": [
+          "node",
+          "web/scripts/run-smokes.js",
+          "--grep",
+          "authoring",
+          "--grep",
+          "agent-optims",
+          "--grep",
+          "office-source"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M web/editor-authoring-agent.js\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T14:52:04.597Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          "web/editor-authoring-agent.js": "8fc466deeeea342f82704a55387566ef576de2a9d59bac5617a11e4162f2f404",
+          "web/scripts/smoke-authoring-region-paths.js": "331e7aa4ab535c234bb0da16a708d0afcc7f35212ccee97119f1077c3ada8d43"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 6704.6768,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "a884ec2a8a5b15938170566dcff18bdce8706a756bc6e84765ac8091521c6461",
+          "text": "[run-smokes] 共 919 个 smoke · 选中 9 · 跳过 0 · 并发 8 · 超时 120s\n  [9/9] PASS    smoke-authoring-agent-tools.js (6.3s)\n\n[run-smokes] 完成：9 PASS · 0 FAIL · 0 SKIP · 0 WAIVED / 9 executed · 0 suspect(退出码0但输出FAIL) · 总耗时 14s(并行墙钟更短)\n\n--- 最慢 Top 10 ---\n  6.3s  smoke-authoring-agent-tools.js\n  6.3s  smoke-authoring-agent-optims.js\n  0.4s  smoke-authoring-agent-office-source.js\n  0.2s  smoke-authoring-agent-runtime-contract.js\n  0.2s  smoke-authoring-region-paths.js\n  0.2s  smoke-authoring-agent-fiction.js\n  0.2s  smoke-authoring-user-write-failures.js\n  0.2s  smoke-authoring-ui-worldkind.js\n  0.2s  smoke-dianzhang-office-source.js\n\n[run-smokes] 报告 → dev-tools/arch-guard/smoke-report.json\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-release-ee683a35-5741-4bab-b137-c447b67ecbe3",
+      "run": {
+        "label": "authoring-region-release",
+        "command": [
+          "node",
+          "scripts/verify-release-contract.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:05:53.277Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "4370ab1fad23b743737b174571e0ea688f0a970c38d335901bf644ee0f1fbc46",
+          "web/editor-authoring-agent.js": "cf2279d228e97df8e790ee10e23c556fbe10b97cd686c553748152036e10b133",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "0dd507646958f6cc2112162e12ae3e95bb779287dce76311e4253f72bf046617"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 1895.5392000000002,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "c04f55defdffadfbce96b644399b491d8149a1f082a5098015ec60b6d4af98f1",
+          "text": "  ok·release-excludes schema\n  ok·canonical 热更基线是发布树 required file\n  ok·release-excludes 无重复\n  ok·安全排除项 _archive\n  ok·安全排除项 backups\n  ok·安全排除项 _screenshots\n  ok·安全排除项 test-results\n  ok·安全排除项 _codex_tmp\n  ok·安全排除项 dev-tools\n  ok·安全排除项 docs\n  ok·安全排除项 scripts\n  ok·安全排除项 tools\n  ok·安全排除项 godot\n  ok·安全排除项 .git\n  ok·安全排除项 node_modules\n  ok·安全排除项 .playwright-cli\n  ok·安全排除项 .cache\n  ok·安全排除项 .tmp\n  ok·安全排除项 tmp\n  ok·安全排除项 dist\n  ok·安全排除项 build\n  ok·安全排除项 release\n  ok·安全排除项 coverage\n  ok·安全排除项 .hot-update-staging\n  ok·安全排除项 _pw-scratch\n  ok·安全排除项 generated_images\n  ok·安全排除项 .vscode\n  ok·安全排除项 .bak-\n  ok·安全排除项 _codex\n  ok·安全排除项 .git-defunct-\n  ok·安全排除项 **/*.bak*\n  ok·安全排除项 **/*.log\n  ok·安全排除项 **/*.yml\n  ok·安全排除项 **/*.save.json\n  ok·安全排除项 **/_game-entry-shot.png\n  ok·安全排除项 **/_ingame*.png\n  ok·安全排除项 .claude/**\n  ok·安全排除项 output/**\n  ok·安全排除项 _audit_deadhandlers.py\n  ok·安全排除项 analyze_globals.py\n  ok·安全排除项 detect_globals.js\n  ok·安全排除项 scan_globals.js\n  ok·安全排除项 final_scan.sh\n  ok·安全排除项 scan.sh\n  ok·安全排除项 start-server.bat\n  ok·安全排除项 tm-tools.d.ts\n  ok·安全排除项 types.d.ts\n  ok·安全排除项 maps/**\n  ok·安全排除项 data/maps/tianqi-ming2/tianqi-ming2.preview-data.js\n  ok·安全排除项 preview-launch*.html\n  ok·安全排除项 preview-launch-assets/**\n  ok·安全排除项 assets/ui/home/home-menu-imperial-study-v1-ambient.gif\n  ok·安全排除项 preview/shots/**\n  ok·安全排除项 preview/**/*verify*.png\n  ok·安全排除项 preview/home-ui-concepts/**\n  ok·安全排除项 preview/workshop-ui-concepts/**\n  ok·web 运行时引用/required files 未被误排：\n  ok·web 源体积/文件数在闸内：\n  ok·发布树保留 preview 运行时与 preview/img（目录探针不可误杀整树）\n  ok·发布树排除根目录游戏截图\n  ok·发布树排除根目录开发脚本与类型声明\n  ok·发布树排除审计脚本、旧启幕稿、无引用预览数据与失配 GIF\n  ok·发布树明确排除本机开发产物:.claude/launch.json\n  ok·发布树明确排除本机开发产物:output/playwright/shot.png\n  ok·发布树明确排除本机开发产物:maps/asia-map.png\n  ok·发布树明确排除本机开发产物:preview-launch-assets/hero-bg.png\n  ok·发布树不误杀运行资产:preview/img/topbar-imperial-rail.png\n  ok·发布树不误杀运行资产:battle/assets/models/unit_lod.glb\n  ok·发布树不误杀运行资产:vendor/models/Xenova/bge-small-zh-v1.5/onnx/model_quantized.onnx\n  ok·package-lock 根版本两处与 package.json 同版\n  ok·tracked mobile canonical version 与 buildVersion 同版\n  ok·electron-builder 消费 dir:_archive\n  ok·electron-builder 消费 dir:backups\n  ok·electron-builder 消费 dir:_screenshots\n  ok·electron-builder 消费 dir:test-results\n  ok·electron-builder 消费 dir:_codex_tmp\n  ok·electron-builder 消费 dir:dev-tools\n  ok·electron-builder 消费 dir:docs\n  ok·electron-builder 消费 dir:scripts\n  ok·electron-builder 消费 dir:tools\n  ok·electron-builder 消费 dir:godot\n  ok·electron-builder 消费 dir:.git\n  ok·electron-builder 消费 dir:node_modules\n  ok·electron-builder 消费 dir:.playwright-cli\n  ok·electron-builder 消费 dir:.cache\n  ok·electron-builder 消费 dir:.tmp\n  ok·electron-builder 消费 dir:tmp\n  ok·electron-builder 消费 dir:dist\n  ok·electron-builder 消费 dir:build\n  ok·electron-builder 消费 dir:release\n  ok·electron-builder 消费 dir:coverage\n  ok·electron-builder 消费 dir:.hot-update-staging\n  ok·electron-builder 消费 dir:_pw-scratch\n  ok·electron-builder 消费 dir:generated_images\n  ok·electron-builder 消费 dir:.vscode\n  ok·electron-builder 消费 prefix file:.bak-\n  ok·electron-builder 消费 prefix dir:.bak-\n  ok·electron-builder 消费 prefix file:_codex\n  ok·electron-builder 消费 prefix dir:_codex\n  ok·electron-builder 消费 prefix file:.git-defunct-\n  ok·electron-builder 消费 prefix dir:.git-defunct-\n  ok·electron-builder 消费 glob:**/*.bak*\n  ok·electron-builder 消费 glob:**/*.log\n  ok·electron-builder 消费 glob:**/*.yml\n  ok·electron-builder 消费 glob:**/*.save.json\n  ok·electron-builder 消费 glob:**/_game-entry-shot.png\n  ok·electron-builder 消费 glob:**/_ingame*.png\n  ok·electron-builder 消费 glob:.claude/**\n  ok·electron-builder 消费 glob:output/**\n  ok·electron-builder 消费 glob:_audit_deadhandlers.py\n  ok·electron-builder 消费 glob:analyze_globals.py\n  ok·electron-builder 消费 glob:detect_globals.js\n  ok·electron-builder 消费 glob:scan_globals.js\n  ok·electron-builder 消费 glob:final_scan.sh\n  ok·electron-builder 消费 glob:scan.sh\n  ok·electron-builder 消费 glob:start-server.bat\n  ok·electron-builder 消费 glob:tm-tools.d.ts\n  ok·electron-builder 消费 glob:types.d.ts\n  ok·electron-builder 消费 glob:maps/**\n  ok·electron-builder 消费 glob:data/maps/tianqi-ming2/tianqi-ming2.preview-data.js\n  ok·electron-builder 消费 glob:preview-launch*.html\n  ok·electron-builder 消费 glob:preview-launch-assets/**\n  ok·electron-builder 消费 glob:assets/ui/home/home-menu-imperial-study-v1-ambient.gif\n  ok·electron-builder 消费 glob:preview/shots/**\n  ok·electron-builder 消费 glob:preview/**/*verify*.png\n  ok·electron-builder 消费 glob:preview/home-ui-concepts/**\n  ok·electron-builder 消费 glob:preview/workshop-ui-concepts/**\n  ok·electron-builder 消费 previewMockup 例外\n  ok·installer 固定携带热更新发布者公钥\n  ok·installer 携带回合分卷两阶段提交模块\n  ok·热更新固定公钥类型为 Ed25519\n  ok·三平台构建统一走受检 build-electron wrapper\n  ok·Windows builder 强制签名、编辑签名与更新发布者验证\n  ok·Windows 构建缺发布者/证书时 fail-closed\n  ok·Windows 保留仓主输出目录并锁定发布者/证书身份\n  ok·mac 使用平台本地可移植输出目录\n  ok·linux 使用平台本地可移植输出目录\n  ok·所有官方 JSON 均登记进统一生成器\n  ok·electron installer 包含官方剧本 天启七年·九月（官方）.json\n  ok·electron installer 包含官方剧本 绍宋·建炎元年八月（官方）.json\n  ok·hot builder 消费共享 release-tree\n  ok·hot builder 收集战斗模型与本地语义模型扩展名\n  ok·新扩展名自动携带旧壳阻断所需 minAppVersion\n  ok·内容 OTA 构建器不再收集 main/preload 主进程代码\n  ok·热更新 manifest/feed 强制 Ed25519 发布者签名\n  ok·桌面壳层放行 collector 会发出的运行资产扩展名\n  ok·本地模型完整性探针包含 ONNX 主体，拒绝半包误判\n  ok·Capgo/APK 消费共享 release-tree\n  ok·Capgo/APK staging 先生成官方剧本派生物\n  ok·Capacitor 只读取派生 www\n  ok·npm sync 强制 stage→cap sync→native hash verify\n  ok·open/run 不可绕过 sync gate\n  ok·native 仅容忍 Capacitor 两个注入文件\n  ok·native extra allowlist 仅放两项，其余仍 fail-closed\n  ok·派生目录已 ignore\n  ok·web canonical 热更基线未被 ignore\n  ok·canonical 热更基线存在且与 buildVersion 同版\n  ok·canonical 热更基线不含 main/preload 可执行桥\n  ok·canonical 基线自带首页、正式 UI、战斗模型与语义模型运行资产\n  ok·canonical 基线不夹带开发产物、旧设计稿与无引用大文件\n  ok·canonical 基线逐路径/hash/size 对齐当前 production hot tree：PASS canonical hot baseline files=684 version=1.3.4.11（容忍 410 条本 checkout 缺席的未跟踪资产条目）\n  ok·staging 拒绝清空 web 源码子目录\n  ok·staging 拒绝清空已有普通目录\n  ok·staging 仅放行已知 mobile/www 派生目录\n  ok·publish 在上传 installer 前复验 Authenticode 发布者与时间戳\n  ok·release.js 显式 prepare/publish 两阶段\n  ok·prepare 要求 clean 短命分支与新版本\n  ok·只有 prepare 盖戳并刷新 tracked 基线\n  ok·prepare 无任何发布外写\n  ok·publish 构建前/上传前双重仓库闸\n  ok·publish 只消费已盖戳版本并复验基线\n  ok·publish 不修改 tracked 版本/基线\n  ok·最终仓库闸先于 GitHub 上传\n  ok·--no-upload 硬关闭 release 与 autodeploy 外写\n  ok·release tag 锁定已验证 main HEAD\n  ok·publish 拒绝 dirty/非 main/未同步\n  ok·prepare/publish 只信官方 origin\n  ok·prepare 基线写入复用 production manifest collector\n  ok·正式外写前验证 gh 当前账号为仓库 owner\n  ok·prepare 拒绝 main 与陈旧分支\n  ok·offline 不能绕过正式发布线上闸\n  ok·版本扇出采用只读规划、全量验证和原子应用三阶段\n  ok·版本文件与备份均经同目录 fsync+rename 原子提交\n  ok·版本扇出深层失败抛错并逆序恢复原字节，不以 process.exit 绕过回滚\n  ok·Pages 无 release/tag 触发（改 workflow_dispatch/main）\n  ok·publish 以仓主身份自触发 Pages（workflow_dispatch·ref=main）\n  ok·Pages 门禁·workflow_dispatch:\n  ok·Pages 门禁·fetch-depth: 0\n  ok·Pages 门禁·npm ci --ignore-scripts\n  ok·Pages 门禁·github.actor == github.repository_owner\n  ok·Pages 门禁·git merge-base --is-ancestor HEAD origin/main\n  ok·Pages 门禁·node web/scripts/sync-official-scenarios.js\n  ok·Pages 门禁·git diff --exit-code\n  ok·Pages 门禁·node web/scripts/verify-official-scenario-parity.js\n  ok·Pages 门禁·node scripts/verify-release-contract.js\n  ok·Pages 门禁·node web/scripts/verify-hot-builder-gates.js\n  ok·Pages 门禁·node scripts/lint-arch-all.js\n  ok·Pages 门禁·node scripts/ci-smokes.js\n  ok·Pages 门禁·node scripts/stage-web-release.js\n  ok·Pages 门禁·node scripts/verify-pages-artifact.js\n  ok·Pages 门禁·actions/deploy-pages@v4\n  ok·Pages 完整门禁严格先于部署\n  ok·deploy 只 checkout dispatch 指定的 ref（默认 main）\n  ok·CONTRIBUTING 记录两阶段发版\n  ok·CLAUDE 协作约定记录两阶段发版\nPASS assertions=40\n  ok·两阶段 release/Pages 静态契约\nPASS assertions=166 files=689 bytes=129149579\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-release-locked-892b58ae-30f6-47f8-b529-2d18303136e2",
+      "run": {
+        "label": "authoring-region-release-locked",
+        "command": [
+          "node",
+          "scripts/verify-release-contract.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? docs/bugfix-authoring-region-paths-2026-09-08.md\n?? scripts/collect-authoring-region-evidence.cjs\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:13:48.109Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "docs/bugfix-authoring-region-paths-2026-09-08.md": "f7c8da0b46dd33adac9b05b80574e10a9b93abcf8b7a1c5958418ef0e7273c8e",
+          "scripts/collect-authoring-region-evidence.cjs": "04ddc90173bc3beff6715ea2ec9748182b38e479cd3d85c832c5fbe6513ac30f",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "41da7460d7882c1472ff53e4f1784f991d242f4bb5bac42685fa8c7908add25f",
+          "web/editor-authoring-agent.js": "761784e028cdf9dc527b7a113c334a29d929f6eda99a629352e4f1a2875fdd67",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "43a6f29f98c32b4f3c8d2482ff899cbe4fe1000fa8b6b63bec92bd6ee76554da"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 1633.263,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "ee9dbb4a16934ada6039fd7e443b3e04b417d354cbfb0433f4384c10c549ad13",
+          "text": "  ok·release-excludes schema\n  ok·canonical 热更基线是发布树 required file\n  ok·release-excludes 无重复\n  ok·安全排除项 _archive\n  ok·安全排除项 backups\n  ok·安全排除项 _screenshots\n  ok·安全排除项 test-results\n  ok·安全排除项 _codex_tmp\n  ok·安全排除项 dev-tools\n  ok·安全排除项 docs\n  ok·安全排除项 scripts\n  ok·安全排除项 tools\n  ok·安全排除项 godot\n  ok·安全排除项 .git\n  ok·安全排除项 node_modules\n  ok·安全排除项 .playwright-cli\n  ok·安全排除项 .cache\n  ok·安全排除项 .tmp\n  ok·安全排除项 tmp\n  ok·安全排除项 dist\n  ok·安全排除项 build\n  ok·安全排除项 release\n  ok·安全排除项 coverage\n  ok·安全排除项 .hot-update-staging\n  ok·安全排除项 _pw-scratch\n  ok·安全排除项 generated_images\n  ok·安全排除项 .vscode\n  ok·安全排除项 .bak-\n  ok·安全排除项 _codex\n  ok·安全排除项 .git-defunct-\n  ok·安全排除项 **/*.bak*\n  ok·安全排除项 **/*.log\n  ok·安全排除项 **/*.yml\n  ok·安全排除项 **/*.save.json\n  ok·安全排除项 **/_game-entry-shot.png\n  ok·安全排除项 **/_ingame*.png\n  ok·安全排除项 .claude/**\n  ok·安全排除项 output/**\n  ok·安全排除项 _audit_deadhandlers.py\n  ok·安全排除项 analyze_globals.py\n  ok·安全排除项 detect_globals.js\n  ok·安全排除项 scan_globals.js\n  ok·安全排除项 final_scan.sh\n  ok·安全排除项 scan.sh\n  ok·安全排除项 start-server.bat\n  ok·安全排除项 tm-tools.d.ts\n  ok·安全排除项 types.d.ts\n  ok·安全排除项 maps/**\n  ok·安全排除项 data/maps/tianqi-ming2/tianqi-ming2.preview-data.js\n  ok·安全排除项 preview-launch*.html\n  ok·安全排除项 preview-launch-assets/**\n  ok·安全排除项 assets/ui/home/home-menu-imperial-study-v1-ambient.gif\n  ok·安全排除项 preview/shots/**\n  ok·安全排除项 preview/**/*verify*.png\n  ok·安全排除项 preview/home-ui-concepts/**\n  ok·安全排除项 preview/workshop-ui-concepts/**\n  ok·web 运行时引用/required files 未被误排：\n  ok·web 源体积/文件数在闸内：\n  ok·发布树保留 preview 运行时与 preview/img（目录探针不可误杀整树）\n  ok·发布树排除根目录游戏截图\n  ok·发布树排除根目录开发脚本与类型声明\n  ok·发布树排除审计脚本、旧启幕稿、无引用预览数据与失配 GIF\n  ok·发布树明确排除本机开发产物:.claude/launch.json\n  ok·发布树明确排除本机开发产物:output/playwright/shot.png\n  ok·发布树明确排除本机开发产物:maps/asia-map.png\n  ok·发布树明确排除本机开发产物:preview-launch-assets/hero-bg.png\n  ok·发布树不误杀运行资产:preview/img/topbar-imperial-rail.png\n  ok·发布树不误杀运行资产:battle/assets/models/unit_lod.glb\n  ok·发布树不误杀运行资产:vendor/models/Xenova/bge-small-zh-v1.5/onnx/model_quantized.onnx\n  ok·package-lock 根版本两处与 package.json 同版\n  ok·tracked mobile canonical version 与 buildVersion 同版\n  ok·electron-builder 消费 dir:_archive\n  ok·electron-builder 消费 dir:backups\n  ok·electron-builder 消费 dir:_screenshots\n  ok·electron-builder 消费 dir:test-results\n  ok·electron-builder 消费 dir:_codex_tmp\n  ok·electron-builder 消费 dir:dev-tools\n  ok·electron-builder 消费 dir:docs\n  ok·electron-builder 消费 dir:scripts\n  ok·electron-builder 消费 dir:tools\n  ok·electron-builder 消费 dir:godot\n  ok·electron-builder 消费 dir:.git\n  ok·electron-builder 消费 dir:node_modules\n  ok·electron-builder 消费 dir:.playwright-cli\n  ok·electron-builder 消费 dir:.cache\n  ok·electron-builder 消费 dir:.tmp\n  ok·electron-builder 消费 dir:tmp\n  ok·electron-builder 消费 dir:dist\n  ok·electron-builder 消费 dir:build\n  ok·electron-builder 消费 dir:release\n  ok·electron-builder 消费 dir:coverage\n  ok·electron-builder 消费 dir:.hot-update-staging\n  ok·electron-builder 消费 dir:_pw-scratch\n  ok·electron-builder 消费 dir:generated_images\n  ok·electron-builder 消费 dir:.vscode\n  ok·electron-builder 消费 prefix file:.bak-\n  ok·electron-builder 消费 prefix dir:.bak-\n  ok·electron-builder 消费 prefix file:_codex\n  ok·electron-builder 消费 prefix dir:_codex\n  ok·electron-builder 消费 prefix file:.git-defunct-\n  ok·electron-builder 消费 prefix dir:.git-defunct-\n  ok·electron-builder 消费 glob:**/*.bak*\n  ok·electron-builder 消费 glob:**/*.log\n  ok·electron-builder 消费 glob:**/*.yml\n  ok·electron-builder 消费 glob:**/*.save.json\n  ok·electron-builder 消费 glob:**/_game-entry-shot.png\n  ok·electron-builder 消费 glob:**/_ingame*.png\n  ok·electron-builder 消费 glob:.claude/**\n  ok·electron-builder 消费 glob:output/**\n  ok·electron-builder 消费 glob:_audit_deadhandlers.py\n  ok·electron-builder 消费 glob:analyze_globals.py\n  ok·electron-builder 消费 glob:detect_globals.js\n  ok·electron-builder 消费 glob:scan_globals.js\n  ok·electron-builder 消费 glob:final_scan.sh\n  ok·electron-builder 消费 glob:scan.sh\n  ok·electron-builder 消费 glob:start-server.bat\n  ok·electron-builder 消费 glob:tm-tools.d.ts\n  ok·electron-builder 消费 glob:types.d.ts\n  ok·electron-builder 消费 glob:maps/**\n  ok·electron-builder 消费 glob:data/maps/tianqi-ming2/tianqi-ming2.preview-data.js\n  ok·electron-builder 消费 glob:preview-launch*.html\n  ok·electron-builder 消费 glob:preview-launch-assets/**\n  ok·electron-builder 消费 glob:assets/ui/home/home-menu-imperial-study-v1-ambient.gif\n  ok·electron-builder 消费 glob:preview/shots/**\n  ok·electron-builder 消费 glob:preview/**/*verify*.png\n  ok·electron-builder 消费 glob:preview/home-ui-concepts/**\n  ok·electron-builder 消费 glob:preview/workshop-ui-concepts/**\n  ok·electron-builder 消费 previewMockup 例外\n  ok·installer 固定携带热更新发布者公钥\n  ok·installer 携带回合分卷两阶段提交模块\n  ok·热更新固定公钥类型为 Ed25519\n  ok·三平台构建统一走受检 build-electron wrapper\n  ok·Windows builder 强制签名、编辑签名与更新发布者验证\n  ok·Windows 构建缺发布者/证书时 fail-closed\n  ok·Windows 保留仓主输出目录并锁定发布者/证书身份\n  ok·mac 使用平台本地可移植输出目录\n  ok·linux 使用平台本地可移植输出目录\n  ok·所有官方 JSON 均登记进统一生成器\n  ok·electron installer 包含官方剧本 天启七年·九月（官方）.json\n  ok·electron installer 包含官方剧本 绍宋·建炎元年八月（官方）.json\n  ok·hot builder 消费共享 release-tree\n  ok·hot builder 收集战斗模型与本地语义模型扩展名\n  ok·新扩展名自动携带旧壳阻断所需 minAppVersion\n  ok·内容 OTA 构建器不再收集 main/preload 主进程代码\n  ok·热更新 manifest/feed 强制 Ed25519 发布者签名\n  ok·桌面壳层放行 collector 会发出的运行资产扩展名\n  ok·本地模型完整性探针包含 ONNX 主体，拒绝半包误判\n  ok·Capgo/APK 消费共享 release-tree\n  ok·Capgo/APK staging 先生成官方剧本派生物\n  ok·Capacitor 只读取派生 www\n  ok·npm sync 强制 stage→cap sync→native hash verify\n  ok·open/run 不可绕过 sync gate\n  ok·native 仅容忍 Capacitor 两个注入文件\n  ok·native extra allowlist 仅放两项，其余仍 fail-closed\n  ok·派生目录已 ignore\n  ok·web canonical 热更基线未被 ignore\n  ok·canonical 热更基线存在且与 buildVersion 同版\n  ok·canonical 热更基线不含 main/preload 可执行桥\n  ok·canonical 基线自带首页、正式 UI、战斗模型与语义模型运行资产\n  ok·canonical 基线不夹带开发产物、旧设计稿与无引用大文件\n  ok·canonical 基线逐路径/hash/size 对齐当前 production hot tree：PASS canonical hot baseline files=684 version=1.3.4.11（容忍 410 条本 checkout 缺席的未跟踪资产条目）\n  ok·staging 拒绝清空 web 源码子目录\n  ok·staging 拒绝清空已有普通目录\n  ok·staging 仅放行已知 mobile/www 派生目录\n  ok·publish 在上传 installer 前复验 Authenticode 发布者与时间戳\n  ok·release.js 显式 prepare/publish 两阶段\n  ok·prepare 要求 clean 短命分支与新版本\n  ok·只有 prepare 盖戳并刷新 tracked 基线\n  ok·prepare 无任何发布外写\n  ok·publish 构建前/上传前双重仓库闸\n  ok·publish 只消费已盖戳版本并复验基线\n  ok·publish 不修改 tracked 版本/基线\n  ok·最终仓库闸先于 GitHub 上传\n  ok·--no-upload 硬关闭 release 与 autodeploy 外写\n  ok·release tag 锁定已验证 main HEAD\n  ok·publish 拒绝 dirty/非 main/未同步\n  ok·prepare/publish 只信官方 origin\n  ok·prepare 基线写入复用 production manifest collector\n  ok·正式外写前验证 gh 当前账号为仓库 owner\n  ok·prepare 拒绝 main 与陈旧分支\n  ok·offline 不能绕过正式发布线上闸\n  ok·版本扇出采用只读规划、全量验证和原子应用三阶段\n  ok·版本文件与备份均经同目录 fsync+rename 原子提交\n  ok·版本扇出深层失败抛错并逆序恢复原字节，不以 process.exit 绕过回滚\n  ok·Pages 无 release/tag 触发（改 workflow_dispatch/main）\n  ok·publish 以仓主身份自触发 Pages（workflow_dispatch·ref=main）\n  ok·Pages 门禁·workflow_dispatch:\n  ok·Pages 门禁·fetch-depth: 0\n  ok·Pages 门禁·npm ci --ignore-scripts\n  ok·Pages 门禁·github.actor == github.repository_owner\n  ok·Pages 门禁·git merge-base --is-ancestor HEAD origin/main\n  ok·Pages 门禁·node web/scripts/sync-official-scenarios.js\n  ok·Pages 门禁·git diff --exit-code\n  ok·Pages 门禁·node web/scripts/verify-official-scenario-parity.js\n  ok·Pages 门禁·node scripts/verify-release-contract.js\n  ok·Pages 门禁·node web/scripts/verify-hot-builder-gates.js\n  ok·Pages 门禁·node scripts/lint-arch-all.js\n  ok·Pages 门禁·node scripts/ci-smokes.js\n  ok·Pages 门禁·node scripts/stage-web-release.js\n  ok·Pages 门禁·node scripts/verify-pages-artifact.js\n  ok·Pages 门禁·actions/deploy-pages@v4\n  ok·Pages 完整门禁严格先于部署\n  ok·deploy 只 checkout dispatch 指定的 ref（默认 main）\n  ok·CONTRIBUTING 记录两阶段发版\n  ok·CLAUDE 协作约定记录两阶段发版\nPASS assertions=40\n  ok·两阶段 release/Pages 静态契约\nPASS assertions=166 files=689 bytes=129149600\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-standard-locked-73f62005-bdd4-4bf0-8dc4-908971d0ce31",
+      "run": {
+        "label": "authoring-region-standard-locked",
+        "command": [
+          "node",
+          "scripts/verify-electron-bridge.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? docs/bugfix-authoring-region-paths-2026-09-08.md\n?? scripts/collect-authoring-region-evidence.cjs\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:13:25.902Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "docs/bugfix-authoring-region-paths-2026-09-08.md": "f7c8da0b46dd33adac9b05b80574e10a9b93abcf8b7a1c5958418ef0e7273c8e",
+          "scripts/collect-authoring-region-evidence.cjs": "04ddc90173bc3beff6715ea2ec9748182b38e479cd3d85c832c5fbe6513ac30f",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "41da7460d7882c1472ff53e4f1784f991d242f4bb5bac42685fa8c7908add25f",
+          "web/editor-authoring-agent.js": "761784e028cdf9dc527b7a113c334a29d929f6eda99a629352e4f1a2875fdd67",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "43a6f29f98c32b4f3c8d2482ff899cbe4fe1000fa8b6b63bec92bd6ee76554da"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 22032.6323,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "ed6e933c9607ff7884b4dc6e7bf2331d40c9bf86ecf3869acab79c732c55c403",
+          "text": "{\"mode\":\"production\",\"ok\":true,\"exitCode\":0,\"detail\":{\"complete\":true,\"ok\":true,\"mode\":\"production\",\"baseline\":false,\"versions\":{\"node\":\"20.18.3\",\"acorn\":\"8.14.0\",\"ada\":\"2.9.2\",\"ares\":\"1.34.4\",\"base64\":\"0.5.2\",\"brotli\":\"1.0.9\",\"cjs_module_lexer\":\"1.4.1\",\"cldr\":\"44.1\",\"icu\":\"74.2\",\"llhttp\":\"8.1.2\",\"modules\":\"130\",\"napi\":\"9\",\"nghttp2\":\"1.61.0\",\"openssl\":\"0.0.0\",\"simdutf\":\"5.6.4\",\"tz\":\"2024a\",\"undici\":\"6.21.1\",\"unicode\":\"15.1\",\"uv\":\"1.46.0\",\"uvwasi\":\"0.0.21\",\"v8\":\"13.0.245.25-electron.0\",\"zlib\":\"1.3.0.1-motley\",\"electron\":\"33.4.11\",\"chrome\":\"130.0.6723.191\"},\"results\":[{\"name\":\"locked-electron-runtime\",\"status\":\"PASS\"},{\"name\":\"production-webpreferences\",\"status\":\"PASS\"},{\"name\":\"observed-turn-data-protocol\",\"value\":2,\"status\":\"PASS\",\"required\":2},{\"name\":\"real-bridge-and-ipc\",\"status\":\"PASS\"},{\"name\":\"production-test-exports-boundary\",\"status\":\"PASS\"},{\"name\":\"legacy-and-hash-save-real-ipc-roundtrip\",\"status\":\"PASS\"},{\"name\":\"autosave-text-bridge-real-ipc-and-invalid-input-preserves-disk\",\"status\":\"PASS\"},{\"name\":\"manual-save-world-switch-barrier-and-late-real-ipc\",\"status\":\"PASS\"},{\"name\":\"atomic-export-real-ipc-failure-and-cancel\",\"status\":\"PASS\"},{\"name\":\"real-worker-import-cancel-timeout-error-and-recovery\",\"status\":\"PASS\"},{\"name\":\"workshop-overwrite-rollback-through-real-ipc\",\"status\":\"PASS\"},{\"name\":\"canonical-world-and-receipt-committed-before-process-exit\",\"status\":\"PASS\"}],\"failures\":[],\"securityScope\":\"real unpackaged production main/preload; hidden window; temporary userData; external network denied; no player data\",\"temporaryUserData\":\"<user-profile>\\\\AppData\\\\Local\\\\Temp\\\\tm-bridge-series-RuMyLN\\\\production\"}}\n{\"mode\":\"test-exports\",\"ok\":true,\"exitCode\":0,\"detail\":{\"complete\":true,\"ok\":true,\"mode\":\"test-exports\",\"baseline\":false,\"versions\":{\"node\":\"20.18.3\",\"acorn\":\"8.14.0\",\"ada\":\"2.9.2\",\"ares\":\"1.34.4\",\"base64\":\"0.5.2\",\"brotli\":\"1.0.9\",\"cjs_module_lexer\":\"1.4.1\",\"cldr\":\"44.1\",\"icu\":\"74.2\",\"llhttp\":\"8.1.2\",\"modules\":\"130\",\"napi\":\"9\",\"nghttp2\":\"1.61.0\",\"openssl\":\"0.0.0\",\"simdutf\":\"5.6.4\",\"tz\":\"2024a\",\"undici\":\"6.21.1\",\"unicode\":\"15.1\",\"uv\":\"1.46.0\",\"uvwasi\":\"0.0.21\",\"v8\":\"13.0.245.25-electron.0\",\"zlib\":\"1.3.0.1-motley\",\"electron\":\"33.4.11\",\"chrome\":\"130.0.6723.191\"},\"results\":[{\"name\":\"locked-electron-runtime\",\"status\":\"PASS\"},{\"name\":\"production-webpreferences\",\"status\":\"PASS\"},{\"name\":\"observed-turn-data-protocol\",\"value\":2,\"status\":\"PASS\",\"required\":2},{\"name\":\"real-bridge-and-ipc\",\"status\":\"PASS\"},{\"name\":\"production-test-exports-boundary\",\"status\":\"PASS\"},{\"name\":\"legacy-and-hash-save-real-ipc-roundtrip\",\"status\":\"PASS\"},{\"name\":\"autosave-text-bridge-real-ipc-and-invalid-input-preserves-disk\",\"status\":\"PASS\"},{\"name\":\"manual-save-world-switch-barrier-and-late-real-ipc\",\"status\":\"PASS\"},{\"name\":\"atomic-export-real-ipc-failure-and-cancel\",\"status\":\"PASS\"},{\"name\":\"real-worker-import-cancel-timeout-error-and-recovery\",\"status\":\"PASS\"},{\"name\":\"workshop-overwrite-rollback-through-real-ipc\",\"status\":\"PASS\"}],\"failures\":[],\"securityScope\":\"real unpackaged production main/preload; hidden window; temporary userData; external network denied; no player data\",\"temporaryUserData\":\"<user-profile>\\\\AppData\\\\Local\\\\Temp\\\\tm-bridge-series-RuMyLN\\\\exports\"}}\n{\"mode\":\"restart\",\"ok\":true,\"exitCode\":0,\"detail\":{\"complete\":true,\"ok\":true,\"mode\":\"restart\",\"baseline\":false,\"versions\":{\"node\":\"20.18.3\",\"acorn\":\"8.14.0\",\"ada\":\"2.9.2\",\"ares\":\"1.34.4\",\"base64\":\"0.5.2\",\"brotli\":\"1.0.9\",\"cjs_module_lexer\":\"1.4.1\",\"cldr\":\"44.1\",\"icu\":\"74.2\",\"llhttp\":\"8.1.2\",\"modules\":\"130\",\"napi\":\"9\",\"nghttp2\":\"1.61.0\",\"openssl\":\"0.0.0\",\"simdutf\":\"5.6.4\",\"tz\":\"2024a\",\"undici\":\"6.21.1\",\"unicode\":\"15.1\",\"uv\":\"1.46.0\",\"uvwasi\":\"0.0.21\",\"v8\":\"13.0.245.25-electron.0\",\"zlib\":\"1.3.0.1-motley\",\"electron\":\"33.4.11\",\"chrome\":\"130.0.6723.191\"},\"results\":[{\"name\":\"locked-electron-runtime\",\"status\":\"PASS\"},{\"name\":\"production-webpreferences\",\"status\":\"PASS\"},{\"name\":\"observed-turn-data-protocol\",\"value\":2,\"status\":\"PASS\",\"required\":2},{\"name\":\"real-bridge-and-ipc\",\"status\":\"PASS\"},{\"name\":\"production-test-exports-boundary\",\"status\":\"PASS\"},{\"name\":\"canonical-receipt-and-folio-recover-after-real-process-exit\",\"status\":\"PASS\"}],\"failures\":[],\"securityScope\":\"real unpackaged production main/preload; hidden window; temporary userData; external network denied; no player data\",\"temporaryUserData\":\"<user-profile>\\\\AppData\\\\Local\\\\Temp\\\\tm-bridge-series-RuMyLN\\\\production\"}}\nELECTRON_REPORT web\\dev-tools\\electron-bridge\\8a9fbbd0-1c79-4b89-bcff-5d581a668792\\report.json\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-target-complete-9ed142bc-ece9-4049-8264-b19503b43ee5",
+      "run": {
+        "label": "authoring-region-target-complete",
+        "command": [
+          "node",
+          "web/scripts/smoke-authoring-region-paths.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:04:32.731Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "8bfd3a173dd60d078adb1fc1f32c573d875f3d88d88f39884791de07e99f650c",
+          "web/editor-authoring-agent.js": "cf2279d228e97df8e790ee10e23c556fbe10b97cd686c553748152036e10b133",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "0dd507646958f6cc2112162e12ae3e95bb779287dce76311e4253f72bf046617"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 347.0541999999999,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "0f53df455a6a6a291f8749921e477c135e757deefef5088e307a5c212c07f07c",
+          "text": "PASS nested map search returns a readable concrete path and ID\nPASS nested faction administrative search and write/read persistence\nPASS nested children collection supports explicit stable parent ID\nPASS virtual region collection roundtrips through its reported collection name\nPASS legacy mapData-only alias returns its real path without creating map\nPASS top-level character searches remain compatible and bounded\nPASS global search returned bracket paths still read and write the real row\nPASS reject intermediate array write without mutation\nPASS reject terminal array write without mutation\nPASS reject array length array write without mutation\nPASS reject negative index array write without mutation\nPASS reject out of bounds array write without mutation\nPASS failed append through a missing named region is not falsely successful\nPASS failed read and batch read accurately report a missing leaf\nPASS duplicate names cannot silently select the first region\nPASS explicit unique ID updates only the requested duplicate-name region\nPASS ID takes precedence over an unrelated name that happens to equal it\nPASS duplicate IDs are rejected without choosing an arbitrary row\nPASS new object fields under a valid named entity are created and persist\nPASS missing object chain remains supported without partial invalid bracket scaffolding\nPASS explicit append can create a child collection under the actual selected ID\nPASS remove keeps legitimate ID/index operations but rejects missing and ambiguous names\nPASS atomic multi-edit rollback includes a later unresolved named entity\nPASS unsafe or prototype paths remain rejected even with force\nPASS detached draft edits do not touch caller-owned scenario data\nPASS stable ID still selects the intended region after reordering\nPASS zero, false, null and readable array length are not mistaken for missing values\nPASS copy from missing field already fails and remains non-mutating\nPASS nested bracket indices including Chinese object keys remain supported\nPASS separate drafts with reused IDs never share lookup state\nPASS filtered bulk update accepts the same nested collection as search\nPASS numeric aggregate reads the same nested administrative values\n{\"source\":\"worktree\",\"pass\":32,\"fail\":0,\"total\":32,\"scope\":\"actual public authoring tools; no network or player data\"}\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    },
+    {
+      "directory": "web\\dev-tools\\perf-round1\\authoring-region-target-locked-f2c0f2d0-ed31-469c-b3c2-9ab31ba5f2e3",
+      "run": {
+        "label": "authoring-region-target-locked",
+        "command": [
+          "node",
+          "web/scripts/smoke-authoring-region-paths.js"
+        ],
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "arch": "x64",
+        "node": "v24.14.0",
+        "cpu": "13th Gen Intel(R) Core(TM) i5-13420H",
+        "logicalCpus": 12,
+        "memoryBytes": 25480257536,
+        "startedAt": "2026-09-08T15:10:26.299Z",
+        "sourceHashes": {
+          "web/tm-storage.js": "88252c2e8b36c6ec860fbd4b42821c7876ca1ccc02d5e03180b6678f85cb8c6c",
+          "web/phase8-formal-map.js": "fe592b5946d06f966e6d655425ebfe631c2223b564ecbb668c8c09832deb6d3b",
+          "web/tm-save-lifecycle.js": "9674a683b6a1c31f1d05e8eebc8a44b09458fa7929edeca41ef21e0ad1b68fda"
+        },
+        "dirtyFileHashes": {
+          ".github/workflows/ci.yml": "c5c0d950c4552d54fad51ab2300a2c46352f285d0c2417f1bdfa8ca951691501",
+          "scripts/electron/authoring-region-cases.cjs": "69c77a65b5ac55f7218b87f81eade20557e7d666c8e1d7d6c59e304abee50503",
+          "scripts/electron/bridge-main.cjs": "2b0aa5ddbbda08011b56d3a0cc685c7009ec4f68ecd49a6e5b421ccf6e683a6f",
+          "scripts/verify-electron-bridge.js": "084e8bc1bc0fe8f0d533b37e17c1e6267d1432c5045e50af83e537c4dec89cac",
+          "web/.hot-update-manifest.json": "4370ab1fad23b743737b174571e0ea688f0a970c38d335901bf644ee0f1fbc46",
+          "web/editor-authoring-agent.js": "761784e028cdf9dc527b7a113c334a29d929f6eda99a629352e4f1a2875fdd67",
+          "web/editor.html": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+          "web/preview/scenario-editor-reset-preview.html": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+          "web/scripts/smoke-authoring-region-paths.js": "43a6f29f98c32b4f3c8d2482ff899cbe4fe1000fa8b6b63bec92bd6ee76554da"
+        },
+        "exitCode": 0,
+        "signal": null,
+        "elapsedMs": 264.52599999999995,
+        "complete": true
+      },
+      "logs": {
+        "stdout.log": {
+          "sha256": "5ce068bec525eca9fdead6996e71b78e5948a753cf58b1ed07877130db1e303d",
+          "text": "PASS nested map search returns a readable concrete path and ID\nPASS nested faction administrative search and write/read persistence\nPASS nested children collection supports explicit stable parent ID\nPASS virtual region collection roundtrips through its reported collection name\nPASS legacy mapData-only alias returns its real path without creating map\nPASS top-level character searches remain compatible and bounded\nPASS global search returned bracket paths still read and write the real row\nPASS reject intermediate array write without mutation\nPASS reject terminal array write without mutation\nPASS reject array length array write without mutation\nPASS reject negative index array write without mutation\nPASS reject out of bounds array write without mutation\nPASS failed append through a missing named region is not falsely successful\nPASS failed read and batch read accurately report a missing leaf\nPASS duplicate names cannot silently select the first region\nPASS explicit unique ID updates only the requested duplicate-name region\nPASS ID takes precedence over an unrelated name that happens to equal it\nPASS duplicate IDs are rejected without choosing an arbitrary row\nPASS new object fields under a valid named entity are created and persist\nPASS missing object chain remains supported without partial invalid bracket scaffolding\nPASS explicit append can create a child collection under the actual selected ID\nPASS remove keeps legitimate ID/index operations but rejects missing and ambiguous names\nPASS atomic multi-edit rollback includes a later unresolved named entity\nPASS unsafe or prototype paths remain rejected even with force\nPASS detached draft edits do not touch caller-owned scenario data\nPASS stable ID still selects the intended region after reordering\nPASS zero, false, null and readable array length are not mistaken for missing values\nPASS copy from missing field already fails and remains non-mutating\nPASS nested bracket indices including Chinese object keys remain supported\nPASS separate drafts with reused IDs never share lookup state\nPASS filtered bulk update accepts the same nested collection as search\nPASS numeric aggregate reads the same nested administrative values\nPASS append preserves an existing array without reassigning its read-only owner property\n{\"source\":\"worktree\",\"pass\":33,\"fail\":0,\"total\":33,\"scope\":\"actual public authoring tools; no network or player data\"}\n"
+        },
+        "stderr.log": {
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "text": ""
+        }
+      }
+    }
+  ],
+  "incomplete": [
+    {
+      "directory": "authoring-region-audit-e5a3116a-b4c0-4c33-b720-b6b13b6db3d9",
+      "reason": "no finalized runner metadata; initial npm.cmd spawn EINVAL is documented"
+    }
+  ],
+  "electron": [
+    {
+      "label": "authoring-region-editor-locked",
+      "source": "web\\dev-tools\\electron-bridge\\0bacf75e-ef9e-4fb8-bf09-51ee38cfd4be\\report.json",
+      "sha256": "d6bb5f665e9abd76245821cba5392bc01bd8f2218bb39c0b14eceb9ccb89f9a6",
+      "report": {
+        "runId": "0bacf75e-ef9e-4fb8-bf09-51ee38cfd4be",
+        "repo": "<user-profile>\\Desktop\\tianming-perf-round1",
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? docs/bugfix-authoring-region-paths-2026-09-08.md\n?? scripts/collect-authoring-region-evidence.cjs\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "node": "v24.14.0",
+        "baseline": false,
+        "complete": true,
+        "results": [
+          {
+            "mode": "authoring-regions",
+            "ok": true,
+            "exitCode": 0,
+            "detail": {
+              "complete": true,
+              "ok": true,
+              "mode": "authoring-regions",
+              "baseline": false,
+              "versions": {
+                "node": "20.18.3",
+                "acorn": "8.14.0",
+                "ada": "2.9.2",
+                "ares": "1.34.4",
+                "base64": "0.5.2",
+                "brotli": "1.0.9",
+                "cjs_module_lexer": "1.4.1",
+                "cldr": "44.1",
+                "icu": "74.2",
+                "llhttp": "8.1.2",
+                "modules": "130",
+                "napi": "9",
+                "nghttp2": "1.61.0",
+                "openssl": "0.0.0",
+                "simdutf": "5.6.4",
+                "tz": "2024a",
+                "undici": "6.21.1",
+                "unicode": "15.1",
+                "uv": "1.46.0",
+                "uvwasi": "0.0.21",
+                "v8": "13.0.245.25-electron.0",
+                "zlib": "1.3.0.1-motley",
+                "electron": "33.4.11",
+                "chrome": "130.0.6723.191"
+              },
+              "results": [
+                {
+                  "name": "locked-electron-runtime",
+                  "status": "PASS"
+                },
+                {
+                  "name": "production-webpreferences",
+                  "status": "PASS"
+                },
+                {
+                  "name": "observed-turn-data-protocol",
+                  "value": 2,
+                  "status": "PASS",
+                  "required": 2
+                },
+                {
+                  "name": "real-bridge-and-ipc",
+                  "status": "PASS"
+                },
+                {
+                  "name": "production-test-exports-boundary",
+                  "status": "PASS"
+                },
+                {
+                  "name": "actual-editor-page-and-bridge",
+                  "status": "PASS"
+                },
+                {
+                  "name": "nested-search-and-real-ID-readback",
+                  "status": "PASS"
+                },
+                {
+                  "name": "missing-region-error-has-no-partial-write",
+                  "status": "PASS"
+                },
+                {
+                  "name": "actual-adapter-commits-valid-region-economy-and-minxin",
+                  "status": "PASS"
+                },
+                {
+                  "name": "saved-region-state-survives-actual-editor-reload",
+                  "status": "PASS"
+                },
+                {
+                  "name": "legacy-editor-entry-loads-the-same-production-tools",
+                  "status": "PASS"
+                },
+                {
+                  "name": "original-fixture-is-unchanged",
+                  "status": "PASS"
+                }
+              ],
+              "failures": [],
+              "securityScope": "real unpackaged production main/preload; hidden window; temporary userData; external network denied; no player data",
+              "temporaryUserData": "<user-profile>\\AppData\\Local\\Temp\\tm-bridge-series-40wIXl\\production"
+            }
+          }
+        ],
+        "ok": true
+      }
+    },
+    {
+      "label": "authoring-region-player-locked",
+      "source": "web\\dev-tools\\electron-bridge\\65a3fdc5-feed-486f-958a-f2154c0b6f16\\report.json",
+      "sha256": "c98097f0f3d683d33bf0dda7c78ea7e3e217703099efd38d0c38dbcc260f1d87",
+      "report": {
+        "runId": "65a3fdc5-feed-486f-958a-f2154c0b6f16",
+        "repo": "<user-profile>\\Desktop\\tianming-perf-round1",
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? docs/bugfix-authoring-region-paths-2026-09-08.md\n?? scripts/collect-authoring-region-evidence.cjs\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "node": "v24.14.0",
+        "baseline": false,
+        "complete": true,
+        "results": [
+          {
+            "mode": "authoring-regions",
+            "ok": true,
+            "exitCode": 0,
+            "detail": {
+              "complete": true,
+              "ok": true,
+              "mode": "authoring-regions",
+              "baseline": false,
+              "versions": {
+                "node": "20.18.3",
+                "acorn": "8.14.0",
+                "ada": "2.9.2",
+                "ares": "1.34.4",
+                "base64": "0.5.2",
+                "brotli": "1.0.9",
+                "cjs_module_lexer": "1.4.1",
+                "cldr": "44.1",
+                "icu": "74.2",
+                "llhttp": "8.1.2",
+                "modules": "130",
+                "napi": "9",
+                "nghttp2": "1.61.0",
+                "openssl": "0.0.0",
+                "simdutf": "5.6.4",
+                "tz": "2024a",
+                "undici": "6.21.1",
+                "unicode": "15.1",
+                "uv": "1.46.0",
+                "uvwasi": "0.0.21",
+                "v8": "13.0.245.25-electron.0",
+                "zlib": "1.3.0.1-motley",
+                "electron": "33.4.11",
+                "chrome": "130.0.6723.191"
+              },
+              "results": [
+                {
+                  "name": "locked-electron-runtime",
+                  "status": "PASS"
+                },
+                {
+                  "name": "production-webpreferences",
+                  "status": "PASS"
+                },
+                {
+                  "name": "observed-turn-data-protocol",
+                  "value": 2,
+                  "status": "PASS",
+                  "required": 2
+                },
+                {
+                  "name": "real-bridge-and-ipc",
+                  "status": "PASS"
+                },
+                {
+                  "name": "production-test-exports-boundary",
+                  "status": "PASS"
+                },
+                {
+                  "name": "actual-editor-page-and-bridge",
+                  "status": "PASS"
+                },
+                {
+                  "name": "nested-search-and-real-ID-readback",
+                  "status": "PASS"
+                },
+                {
+                  "name": "missing-region-error-has-no-partial-write",
+                  "status": "PASS"
+                },
+                {
+                  "name": "actual-adapter-commits-valid-region-economy-and-minxin",
+                  "status": "PASS"
+                },
+                {
+                  "name": "saved-region-state-survives-actual-editor-reload",
+                  "status": "PASS"
+                },
+                {
+                  "name": "legacy-editor-entry-loads-the-same-production-tools",
+                  "status": "PASS"
+                },
+                {
+                  "name": "original-fixture-is-unchanged",
+                  "status": "PASS"
+                }
+              ],
+              "failures": [],
+              "securityScope": "real unpackaged production main/preload; hidden window; temporary userData; external network denied; read-only user-supplied scenario clone",
+              "temporaryUserData": "<user-profile>\\AppData\\Local\\Temp\\tm-bridge-series-UBhKyV\\production"
+            }
+          }
+        ],
+        "ok": true
+      }
+    },
+    {
+      "label": "authoring-region-standard-locked",
+      "source": "web\\dev-tools\\electron-bridge\\8a9fbbd0-1c79-4b89-bcff-5d581a668792\\report.json",
+      "sha256": "3195db88ee01f6abb9af5ccea48181832f65542cff05141536e1712fd2a70aae",
+      "report": {
+        "runId": "8a9fbbd0-1c79-4b89-bcff-5d581a668792",
+        "repo": "<user-profile>\\Desktop\\tianming-perf-round1",
+        "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+        "status": "M .github/workflows/ci.yml\n M scripts/electron/bridge-main.cjs\n M scripts/verify-electron-bridge.js\n M web/.hot-update-manifest.json\n M web/editor-authoring-agent.js\n M web/editor.html\n M web/preview/scenario-editor-reset-preview.html\n?? docs/bugfix-authoring-region-paths-2026-09-08.md\n?? scripts/collect-authoring-region-evidence.cjs\n?? scripts/electron/authoring-region-cases.cjs\n?? web/scripts/smoke-authoring-region-paths.js",
+        "platform": "win32",
+        "node": "v24.14.0",
+        "baseline": false,
+        "complete": true,
+        "results": [
+          {
+            "mode": "production",
+            "ok": true,
+            "exitCode": 0,
+            "detail": {
+              "complete": true,
+              "ok": true,
+              "mode": "production",
+              "baseline": false,
+              "versions": {
+                "node": "20.18.3",
+                "acorn": "8.14.0",
+                "ada": "2.9.2",
+                "ares": "1.34.4",
+                "base64": "0.5.2",
+                "brotli": "1.0.9",
+                "cjs_module_lexer": "1.4.1",
+                "cldr": "44.1",
+                "icu": "74.2",
+                "llhttp": "8.1.2",
+                "modules": "130",
+                "napi": "9",
+                "nghttp2": "1.61.0",
+                "openssl": "0.0.0",
+                "simdutf": "5.6.4",
+                "tz": "2024a",
+                "undici": "6.21.1",
+                "unicode": "15.1",
+                "uv": "1.46.0",
+                "uvwasi": "0.0.21",
+                "v8": "13.0.245.25-electron.0",
+                "zlib": "1.3.0.1-motley",
+                "electron": "33.4.11",
+                "chrome": "130.0.6723.191"
+              },
+              "results": [
+                {
+                  "name": "locked-electron-runtime",
+                  "status": "PASS"
+                },
+                {
+                  "name": "production-webpreferences",
+                  "status": "PASS"
+                },
+                {
+                  "name": "observed-turn-data-protocol",
+                  "value": 2,
+                  "status": "PASS",
+                  "required": 2
+                },
+                {
+                  "name": "real-bridge-and-ipc",
+                  "status": "PASS"
+                },
+                {
+                  "name": "production-test-exports-boundary",
+                  "status": "PASS"
+                },
+                {
+                  "name": "legacy-and-hash-save-real-ipc-roundtrip",
+                  "status": "PASS"
+                },
+                {
+                  "name": "autosave-text-bridge-real-ipc-and-invalid-input-preserves-disk",
+                  "status": "PASS"
+                },
+                {
+                  "name": "manual-save-world-switch-barrier-and-late-real-ipc",
+                  "status": "PASS"
+                },
+                {
+                  "name": "atomic-export-real-ipc-failure-and-cancel",
+                  "status": "PASS"
+                },
+                {
+                  "name": "real-worker-import-cancel-timeout-error-and-recovery",
+                  "status": "PASS"
+                },
+                {
+                  "name": "workshop-overwrite-rollback-through-real-ipc",
+                  "status": "PASS"
+                },
+                {
+                  "name": "canonical-world-and-receipt-committed-before-process-exit",
+                  "status": "PASS"
+                }
+              ],
+              "failures": [],
+              "securityScope": "real unpackaged production main/preload; hidden window; temporary userData; external network denied; no player data",
+              "temporaryUserData": "<user-profile>\\AppData\\Local\\Temp\\tm-bridge-series-RuMyLN\\production"
+            }
+          },
+          {
+            "mode": "test-exports",
+            "ok": true,
+            "exitCode": 0,
+            "detail": {
+              "complete": true,
+              "ok": true,
+              "mode": "test-exports",
+              "baseline": false,
+              "versions": {
+                "node": "20.18.3",
+                "acorn": "8.14.0",
+                "ada": "2.9.2",
+                "ares": "1.34.4",
+                "base64": "0.5.2",
+                "brotli": "1.0.9",
+                "cjs_module_lexer": "1.4.1",
+                "cldr": "44.1",
+                "icu": "74.2",
+                "llhttp": "8.1.2",
+                "modules": "130",
+                "napi": "9",
+                "nghttp2": "1.61.0",
+                "openssl": "0.0.0",
+                "simdutf": "5.6.4",
+                "tz": "2024a",
+                "undici": "6.21.1",
+                "unicode": "15.1",
+                "uv": "1.46.0",
+                "uvwasi": "0.0.21",
+                "v8": "13.0.245.25-electron.0",
+                "zlib": "1.3.0.1-motley",
+                "electron": "33.4.11",
+                "chrome": "130.0.6723.191"
+              },
+              "results": [
+                {
+                  "name": "locked-electron-runtime",
+                  "status": "PASS"
+                },
+                {
+                  "name": "production-webpreferences",
+                  "status": "PASS"
+                },
+                {
+                  "name": "observed-turn-data-protocol",
+                  "value": 2,
+                  "status": "PASS",
+                  "required": 2
+                },
+                {
+                  "name": "real-bridge-and-ipc",
+                  "status": "PASS"
+                },
+                {
+                  "name": "production-test-exports-boundary",
+                  "status": "PASS"
+                },
+                {
+                  "name": "legacy-and-hash-save-real-ipc-roundtrip",
+                  "status": "PASS"
+                },
+                {
+                  "name": "autosave-text-bridge-real-ipc-and-invalid-input-preserves-disk",
+                  "status": "PASS"
+                },
+                {
+                  "name": "manual-save-world-switch-barrier-and-late-real-ipc",
+                  "status": "PASS"
+                },
+                {
+                  "name": "atomic-export-real-ipc-failure-and-cancel",
+                  "status": "PASS"
+                },
+                {
+                  "name": "real-worker-import-cancel-timeout-error-and-recovery",
+                  "status": "PASS"
+                },
+                {
+                  "name": "workshop-overwrite-rollback-through-real-ipc",
+                  "status": "PASS"
+                }
+              ],
+              "failures": [],
+              "securityScope": "real unpackaged production main/preload; hidden window; temporary userData; external network denied; no player data",
+              "temporaryUserData": "<user-profile>\\AppData\\Local\\Temp\\tm-bridge-series-RuMyLN\\exports"
+            }
+          },
+          {
+            "mode": "restart",
+            "ok": true,
+            "exitCode": 0,
+            "detail": {
+              "complete": true,
+              "ok": true,
+              "mode": "restart",
+              "baseline": false,
+              "versions": {
+                "node": "20.18.3",
+                "acorn": "8.14.0",
+                "ada": "2.9.2",
+                "ares": "1.34.4",
+                "base64": "0.5.2",
+                "brotli": "1.0.9",
+                "cjs_module_lexer": "1.4.1",
+                "cldr": "44.1",
+                "icu": "74.2",
+                "llhttp": "8.1.2",
+                "modules": "130",
+                "napi": "9",
+                "nghttp2": "1.61.0",
+                "openssl": "0.0.0",
+                "simdutf": "5.6.4",
+                "tz": "2024a",
+                "undici": "6.21.1",
+                "unicode": "15.1",
+                "uv": "1.46.0",
+                "uvwasi": "0.0.21",
+                "v8": "13.0.245.25-electron.0",
+                "zlib": "1.3.0.1-motley",
+                "electron": "33.4.11",
+                "chrome": "130.0.6723.191"
+              },
+              "results": [
+                {
+                  "name": "locked-electron-runtime",
+                  "status": "PASS"
+                },
+                {
+                  "name": "production-webpreferences",
+                  "status": "PASS"
+                },
+                {
+                  "name": "observed-turn-data-protocol",
+                  "value": 2,
+                  "status": "PASS",
+                  "required": 2
+                },
+                {
+                  "name": "real-bridge-and-ipc",
+                  "status": "PASS"
+                },
+                {
+                  "name": "production-test-exports-boundary",
+                  "status": "PASS"
+                },
+                {
+                  "name": "canonical-receipt-and-folio-recover-after-real-process-exit",
+                  "status": "PASS"
+                }
+              ],
+              "failures": [],
+              "securityScope": "real unpackaged production main/preload; hidden window; temporary userData; external network denied; no player data",
+              "temporaryUserData": "<user-profile>\\AppData\\Local\\Temp\\tm-bridge-series-RuMyLN\\production"
+            }
+          }
+        ],
+        "ok": true
+      }
+    }
+  ],
+  "smoke": {
+    "runId": "e78ffeba-9018-4bc7-a930-c58e7736e02a",
+    "head": "12942b78fe64d20f4eb9ee01827a2c3567b38bf1",
+    "complete": true,
+    "expected": 919,
+    "uniqueResults": 919,
+    "summary": {
+      "selected": 919,
+      "pass": 917,
+      "fail": 0,
+      "waived": 2,
+      "flaky": 0,
+      "suspect": 0,
+      "skipped": 0
+    },
+    "waivers": [
+      {
+        "name": "smoke-audio-bgm.js",
+        "checks": [
+          {
+            "code": "optional-asset-absent",
+            "path": "assets/audio/bgm/tianming-hegui.mp3"
+          },
+          {
+            "code": "optional-asset-absent",
+            "path": "assets/audio/bgm/gucheng-junqi.mp3"
+          },
+          {
+            "code": "optional-asset-absent",
+            "path": "assets/audio/bgm/hanwei-fengyun.mp3"
+          },
+          {
+            "code": "optional-asset-absent",
+            "path": "assets/audio/bgm/changhe-zhangu.mp3"
+          },
+          {
+            "code": "optional-asset-absent",
+            "path": "assets/audio/bgm/yunkai-wanli.mp3"
+          }
+        ]
+      },
+      {
+        "name": "smoke-mapeditor-ui.js",
+        "checks": [
+          {
+            "code": "optional-asset-absent",
+            "path": "assets/fonts/ZCOOLXiaoWei-Regular.ttf"
+          },
+          {
+            "code": "optional-asset-absent",
+            "path": "assets/fonts/MaShanZheng-Regular.ttf"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/collect-authoring-region-evidence.cjs
+++ b/scripts/collect-authoring-region-evidence.cjs
@@ -1,0 +1,43 @@
+'use strict';
+// Export scoped command logs and summaries, never the user's scenario body.
+const fs = require('fs'), path = require('path'), crypto = require('crypto'), os = require('os'), assert = require('assert/strict');
+const root = path.resolve(__dirname, '..'), base = path.join(root, 'web/dev-tools/perf-round1');
+const baseline = '12942b78fe64d20f4eb9ee01827a2c3567b38bf1';
+const read = p => JSON.parse(fs.readFileSync(p, 'utf8'));
+const hash = p => crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex');
+function redact(x) {
+  if (typeof x === 'string') return x.replaceAll(os.homedir().replace(/\\/g, '\\\\'), '<user-profile>').replaceAll(os.homedir(), '<user-profile>').replaceAll(os.homedir().replace(/\\/g, '/'), '<user-profile>');
+  if (Array.isArray(x)) return x.map(redact);
+  return x && typeof x === 'object' ? Object.fromEntries(Object.entries(x).map(([k, v]) => [k, redact(v)])) : x;
+}
+const executions = [], incomplete = [];
+for (const dir of fs.readdirSync(base).filter(d => d.startsWith('authoring-region-'))) {
+  const file = path.join(base, dir, 'run.json');
+  if (!fs.existsSync(file)) { incomplete.push({ directory: dir, reason: 'no finalized runner metadata; initial npm.cmd spawn EINVAL is documented' }); continue; }
+  const run = read(file);
+  if (run.head !== baseline || !run.complete) { incomplete.push({ directory: dir, run }); continue; }
+  const logs = Object.fromEntries(['stdout.log', 'stderr.log'].map(name => {
+    const p = path.join(base, dir, name); return [name, { sha256: hash(p), text: fs.readFileSync(p, 'utf8') }];
+  }));
+  executions.push({ directory: path.relative(root, path.dirname(file)), run, logs });
+}
+const final = executions.find(e => e.run.label === 'authoring-region-full-locked');
+assert(final && final.run.exitCode === 0, 'final full run required');
+const files = ['web/editor-authoring-agent.js', 'web/editor.html', 'web/preview/scenario-editor-reset-preview.html', 'web/.hot-update-manifest.json', 'web/scripts/smoke-authoring-region-paths.js', 'scripts/verify-electron-bridge.js', 'scripts/electron/bridge-main.cjs', 'scripts/electron/authoring-region-cases.cjs', '.github/workflows/ci.yml'];
+const sourceHashes = Object.fromEntries(files.map(p => [p, hash(path.join(root, p))]));
+for (const [p, h] of Object.entries(sourceHashes)) assert.equal(final.run.dirtyFileHashes[p], h, 'source changed after full suite: ' + p);
+const args = process.argv.slice(2), smoke = read(path.resolve(root, args[args.indexOf('--smoke') + 1]));
+assert(smoke.complete && smoke.head === baseline && smoke.summary.fail === 0);
+assert.equal(new Set(smoke.results.map(r => r.name)).size, smoke.expected.length);
+assert.deepEqual(smoke.results.map(r => r.name).sort(), smoke.expected.slice().sort());
+assert(final.logs['stdout.log'].text.includes(smoke.runId), 'smoke run identity mismatch');
+const electron = executions.filter(e => ['authoring-region-standard-locked', 'authoring-region-editor-locked', 'authoring-region-player-locked'].includes(e.run.label)).map(e => {
+  assert.equal(e.run.exitCode, 0);
+  const m = /ELECTRON_REPORT (.+)/.exec(e.logs['stdout.log'].text); assert(m);
+  const p = path.resolve(root, m[1].trim()), report = read(p); assert(report.complete && report.ok);
+  return { label: e.run.label, source: path.relative(root, p), sha256: hash(p), report };
+});
+assert.equal(electron.length, 3);
+const out = path.join(root, 'docs/bugfix-authoring-region-paths'); fs.mkdirSync(out, { recursive: true });
+fs.writeFileSync(path.join(out, 'evidence.json'), JSON.stringify(redact({ baseline, sourceHashes, executions, incomplete, electron, smoke: { runId: smoke.runId, head: smoke.head, complete: smoke.complete, expected: smoke.expected.length, uniqueResults: new Set(smoke.results.map(r => r.name)).size, summary: smoke.summary, waivers: smoke.results.filter(r => r.waivers.length).map(r => ({ name: r.name, checks: r.waivers })) } }), null, 2) + '\n');
+console.log(JSON.stringify({ executions: executions.length, incomplete: incomplete.length, hashes: 'MATCH', smoke: smoke.summary, electron: electron.map(e => ({ label: e.label, checks: e.report.results.reduce((n, r) => n + r.detail.results.length, 0) })) }));

--- a/scripts/electron/authoring-region-cases.cjs
+++ b/scripts/electron/authoring-region-cases.cjs
@@ -1,0 +1,77 @@
+'use strict';
+// Actual editor HTML, AuthoringAgent adapter and IndexedDB persistence in the
+// existing real Electron gate. No AI/network stub, mouse claim or live userData.
+const assert = require('assert/strict'), fs = require('fs'), path = require('path'), crypto = require('crypto');
+module.exports = async function({ win, root, check }) {
+  const file = process.env.TM_AUTHORING_REGION_FIXTURE;
+  const synthetic = { id: 'authoring-path-fixture', name: '地区编辑隔离回归', gameSettings: { startYear: 1207, daysPerTurn: 30 },
+    playerInfo: { factionName: '楚' }, factions: [{ id: 'f-1', name: '楚' }], characters: [],
+    map: { regions: [{ id: 'r-a', name: '雅州' }] }, adminHierarchy: { 楚: { divisions: [{ id: 'r-a', name: '雅州', minxinLocal: 58, economyBase: { farmland: 112 } }] } } };
+  const raw = file ? fs.readFileSync(file, 'utf8') : JSON.stringify(synthetic);
+  const hash = crypto.createHash('sha256').update(raw).digest('hex');
+  const js = source => win.webContents.executeJavaScript(source, true);
+  const ready = () => js(`(async()=>{const start=performance.now();while(document.body.dataset.scenarioEditorResetApp!=='ready'){if(performance.now()-start>10000)throw Error('editor IndexedDB initialization did not finish');await new Promise(r=>setTimeout(r,20));}return true;})()`);
+  await win.loadFile(path.join(root, 'web/preview/scenario-editor-reset-preview.html'));
+  await ready();
+  await check('actual-editor-page-and-bridge', async () => {
+    assert.equal(await js(`document.body.dataset.scenarioEditorResetApp==='ready' && !!TM.AuthoringAgent && !!TM_SCENARIO_EDITOR_RESET_APP && tianming.isDesktop===true && typeof require==='undefined'`), true);
+  });
+  await js(`window.__regionInput=JSON.parse(${JSON.stringify(raw)});(()=>{
+    const app=TM_SCENARIO_EDITOR_RESET_APP, AA=TM.AuthoringAgent;
+    const original=JSON.stringify(__regionInput); app.applyImportedScenario(AA.makeDraft(__regionInput),'隔离地区回归');
+    const faction=Object.keys(app.state.scenario.adminHierarchy).find(k=>Array.isArray(app.state.scenario.adminHierarchy[k].divisions)&&app.state.scenario.adminHierarchy[k].divisions.length);
+    const rows=app.state.scenario.adminHierarchy[faction].divisions;
+    const row=rows.find(d=>d.name==='雅州')||rows[0];
+    window.__regionProbe={original,faction,id:row.id,name:row.name,collection:'adminHierarchy.'+faction+'.divisions',draft:AA.makeDraft(app.state.scenario)};
+    return true;
+  })()`);
+  await check('nested-search-and-real-ID-readback', async () => assert.equal(await js(`(()=>{
+    const t=__regionProbe,AA=TM.AuthoringAgent;
+    const found=AA.dispatchTool(t.draft,'searchEntities',{collection:t.collection,query:t.id});
+    return found.ok&&found.count===1&&found.matches[0].id===t.id&&AA.dispatchTool(t.draft,'getField',{path:found.matches[0].path+'.name'}).value===t.name;
+  })()`), true));
+  await check('missing-region-error-has-no-partial-write', async () => assert.equal(await js(`(()=>{
+    const t=__regionProbe,AA=TM.AuthoringAgent,before=JSON.stringify(t.draft);
+    const p=t.collection+'.回归专用不存在地区.minxinLocal';
+    const result=AA.dispatchTool(t.draft,'applyEdit',{path:p,value:77});
+    const read=AA.dispatchTool(t.draft,'getField',{path:p});
+    return result.ok===false&&read.ok===false&&JSON.stringify(t.draft)===before&&Object.keys(t.draft.adminHierarchy[t.faction].divisions).every(k=>/^\\d+$/.test(k));
+  })()`), true));
+  await check('actual-adapter-commits-valid-region-economy-and-minxin', async () => assert.equal(await js(`(()=>{
+    const t=__regionProbe,AA=TM.AuthoringAgent,p=t.collection+'.'+t.id;
+    const result=AA.dispatchTool(t.draft,'multiEdit',{edits:[{path:p+'.minxinLocal',value:77},{path:p+'.economyBase.farmland',value:123.5},{path:p+'.economyBase.pathRegression.value',value:1.25}]});
+    if(!result.ok)return false;
+    const hostBefore=JSON.stringify(TM_SCENARIO_EDITOR_RESET_APP.state.scenario);
+    if(hostBefore!==t.original)return false;
+    const adapter=AA.makeResetEditorAdapter(window); if(!adapter.commit(t.draft).ok)return false;
+    const row=TM_SCENARIO_EDITOR_RESET_APP.state.scenario.adminHierarchy[t.faction].divisions.find(d=>d.id===t.id);
+    return row.minxinLocal===77&&row.economyBase.farmland===123.5&&row.economyBase.pathRegression.value===1.25;
+  })()`), true));
+  const saved = await js(`(async()=>{
+    const app=TM_SCENARIO_EDITOR_RESET_APP,t=__regionProbe;
+    const snapshot=await app.saveProjectSnapshot('隔离地区路径回归',{newCopy:true});
+    return {id:snapshot.id,faction:t.faction,regionId:t.id};
+  })()`);
+  // A reload discards all JS objects/caches. Success must come from real local
+  // persistence, not from reusing the in-memory draft or a mocked save result.
+  await new Promise((resolve, reject) => {
+    const deadline = setTimeout(() => reject(Error('editor reload timed out')), 10000);
+    const done = () => { clearTimeout(deadline); resolve(); };
+    win.webContents.once('did-finish-load', done);
+    win.webContents.reload();
+  });
+  await ready();
+  await check('saved-region-state-survives-actual-editor-reload', async () => assert.equal(await js(`(async()=>{
+    const saved=${JSON.stringify(saved)}, app=TM_SCENARIO_EDITOR_RESET_APP;
+    const snapshot=await app.loadProjectSnapshot(saved.id);if(!snapshot)return false;
+    const row=app.state.scenario.adminHierarchy[saved.faction].divisions.find(d=>d.id===saved.regionId);
+    return row.minxinLocal===77&&row.economyBase.farmland===123.5&&row.economyBase.pathRegression.value===1.25;
+  })()`), true));
+  await check('legacy-editor-entry-loads-the-same-production-tools', async () => {
+    await win.loadFile(path.join(root, 'web/editor.html'));
+    assert.equal(await js(`typeof TM.AuthoringAgent.dispatchTool==='function'&&TM.AuthoringAgent.dispatchTool({adminHierarchy:{楚:{divisions:[{id:'a',name:'雅州'}]}}},'searchEntities',{collection:'adminHierarchy.楚.divisions',query:'雅州'}).count===1`), true);
+  });
+  await check('original-fixture-is-unchanged', () => {
+    if (file) assert.equal(crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex'), hash);
+  });
+};

--- a/scripts/electron/bridge-main.cjs
+++ b/scripts/electron/bridge-main.cjs
@@ -58,7 +58,7 @@ function finish(error) {
   if (finished) return; finished = true;
   if (error) failures.push(String(error.stack || error));
   const report = { complete: true, ok: failures.length === 0, mode, baseline, versions: process.versions, results, failures,
-    securityScope: 'real unpackaged production main/preload; '+(visibleWindow ? 'visible' : 'hidden')+' window; temporary userData; external network denied; no player data',
+    securityScope: 'real unpackaged production main/preload; '+(visibleWindow ? 'visible' : 'hidden')+' window; temporary userData; external network denied; '+(mode === 'authoring-regions' && process.env.TM_AUTHORING_REGION_FIXTURE ? 'read-only user-supplied scenario clone' : 'no player data'),
     temporaryUserData: temp, performance: performanceReport };
   fs.writeFileSync(process.env.TM_BRIDGE_TEST_REPORT, JSON.stringify(report, null, 2) + '\n');
   // This exits the disposable gate process, not the application's production quit path.
@@ -110,6 +110,7 @@ app.on('browser-window-created', (_event, win) => {
       else if (mode === 'performance-panels') performanceReport = await require('../perf/panels-electron-cases.cjs')({ win, root, temp, check, recordPerformance: report => { performanceReport = report; } });
       else if (mode === 'building-appraisal') await require('./building-appraisal-cases.cjs')({ win, temp, check });
       else if (mode === 'edict-polish') await require('./edict-polish-cases.cjs')({ win, temp, check });
+      else if (mode === 'authoring-regions') await require('./authoring-region-cases.cjs')({ win, root, temp, check });
       else if (!baseline) await require('./desktop-cases.cjs')({ win, root, temp, mode, controls, check });
       finish();
     } catch (error) { finish(error); }

--- a/scripts/verify-electron-bridge.js
+++ b/scripts/verify-electron-bridge.js
@@ -7,7 +7,7 @@ const repo = argv.includes('--repo') ? path.resolve(argv[argv.indexOf('--repo') 
 const reportDir = path.join(root, 'web/dev-tools/electron-bridge', crypto.randomUUID());
 fs.mkdirSync(reportDir, { recursive: true });
 const temporary = fs.mkdtempSync(path.join(require('os').tmpdir(), 'tm-bridge-series-'));
-const modes = argv.includes('--edict-polish') ? ['edict-polish'] : argv.includes('--building-appraisal') ? ['building-appraisal'] : argv.includes('--baseline') ? ['production', 'test-exports'] : ['production', 'test-exports', 'restart'];
+const modes = argv.includes('--authoring-regions') ? ['authoring-regions'] : argv.includes('--edict-polish') ? ['edict-polish'] : argv.includes('--building-appraisal') ? ['building-appraisal'] : argv.includes('--baseline') ? ['production', 'test-exports'] : ['production', 'test-exports', 'restart'];
 const report = { runId: path.basename(reportDir), repo, head: cp.execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8' }).trim(),
   status: cp.execFileSync('git', ['status', '--short'], { cwd: repo, encoding: 'utf8' }).trim(), platform: process.platform, node: process.version,
   baseline: argv.includes('--baseline'), complete: false, results: [] };

--- a/web/.hot-update-manifest.json
+++ b/web/.hot-update-manifest.json
@@ -2,7 +2,7 @@
   "type": "tianming-hot-update",
   "version": "1.3.4.11",
   "entry": "index.html",
-  "generatedAt": "2026-09-08T12:41:34.999Z",
+  "generatedAt": "2026-09-08T15:11:13.129Z",
   "files": [
     {
       "path": "_preview_map.json",
@@ -2031,8 +2031,8 @@
     },
     {
       "path": "editor-authoring-agent.js",
-      "sha256": "8a9e2f2825191a4fd44ac9eed5cae13c26824783cb74022959e90d15bc4dc42c",
-      "size": 277776
+      "sha256": "761784e028cdf9dc527b7a113c334a29d929f6eda99a629352e4f1a2875fdd67",
+      "size": 277915
     },
     {
       "path": "editor-core.js",
@@ -2136,8 +2136,8 @@
     },
     {
       "path": "editor.html",
-      "sha256": "74f2e956edf6d35972ee3723e8b74074d9be5f82d09c45e35018ce02217211f1",
-      "size": 184668
+      "sha256": "95ccc1815229b486e8bc510a78a1377426a3a47b80de4c3546f0ea97b5113fd3",
+      "size": 184666
     },
     {
       "path": "editor.js",
@@ -3246,8 +3246,8 @@
     },
     {
       "path": "preview/scenario-editor-reset-preview.html",
-      "sha256": "a187e4789ff14932b06192a14b4422f325bcd201e85067de4757cef3dc62e3d1",
-      "size": 32308
+      "sha256": "83de84d31a0cbf5547297684ea9a2542f1e248ffcd26983eab609ba999359abb",
+      "size": 32306
     },
     {
       "path": "preview/scenario-editor-reset-style.css",

--- a/web/editor-authoring-agent.js
+++ b/web/editor-authoring-agent.js
@@ -46,49 +46,58 @@
   var _UNSAFE_PATH_SEGMENTS = { '__proto__': 1, 'prototype': 1, 'constructor': 1 };
   function _hasOwn(obj, key) { return obj != null && Object.prototype.hasOwnProperty.call(obj, key); }
   function _hasUnsafePathSegment(path) {
-    return String(path == null ? '' : path).split('.').some(function(raw) {
+    return String(path == null ? '' : path).replace(/\[(\d+)\]/g, '.$1').split('.').some(function(raw) {
       var seg = String(raw).replace(/\[\d+\]$/, '').toLowerCase();
       return !!_UNSAFE_PATH_SEGMENTS[seg];
     });
   }
-  function _resolvePath(obj, path) {
-    if (!obj || !path || _hasUnsafePathSegment(path)) return { parent: null, key: null, exists: false, value: undefined };
-    var keys = String(path).split('.');
-    var parent = obj;
-    for (var i = 0; i < keys.length - 1; i++) {
-      var k = keys[i];
-      var m = k.match(/^(\w+)\[(\d+)\]$/);
-      if (m) {
-        if (!_hasOwn(parent, m[1]) || !parent[m[1]]) return { parent: null, key: null, exists: false, value: undefined };
-        parent = parent[m[1]][Number(m[2])];
-      } else if (Array.isArray(parent) && isNaN(Number(k))) {
-        var nextParent = parent.find(function(it) { return it && ((_hasOwn(it, 'name') && it.name === k) || (_hasOwn(it, 'id') && it.id === k)); });
-        if (!nextParent) return { parent: null, key: null, exists: false, value: undefined };
-        parent = nextParent;
-      } else if (Array.isArray(parent) && !isNaN(Number(k))) {
-        if (!_hasOwn(parent, Number(k))) return { parent: null, key: null, exists: false, value: undefined };
-        parent = parent[Number(k)];
-      } else {
-        if (!_hasOwn(parent, k) || parent[k] === undefined || parent[k] === null) return { parent: null, key: null, exists: false, value: undefined };
-        parent = parent[k];
+  function _resolvePath(obj, path, createParents) {
+    function fail(code, reason) { return { parent: null, key: null, exists: false, value: undefined, code: code, reason: reason + ': ' + path }; }
+    if (!obj || !path || _hasUnsafePathSegment(path)) return fail('authoring-path-invalid', '无效或不安全的路径');
+    var keys = String(path).replace(/\[(\d+)\]/g, '.$&').split('.');
+    if (keys.some(function(k) { return !k || (/[\[\]]/.test(k) && !/^\[\d+\]$/.test(k)); })) return fail('authoring-path-invalid', '无效的路径语法');
+    var parent = obj, attach = null;
+    for (var i = 0; i < keys.length; i++) {
+      var k = keys[i], indexed = /^\[(\d+)\]$/.exec(k), readOnly = false;
+      if (indexed) k = indexed[1];
+      if (!parent || typeof parent !== 'object') return fail('authoring-path-not-found', '路径中间段不是对象');
+      if (indexed && !Array.isArray(parent)) return fail('authoring-path-not-found', '数组索引前不是数组');
+      if (Array.isArray(parent)) {
+        if (!indexed && k === 'length') readOnly = true;
+        else if (/^(0|[1-9]\d*)$/.test(k)) {
+          k = Number(k);
+          if (!_hasOwn(parent, k)) return fail('authoring-array-reference-not-found', '数组索引不存在；新增实体请用 applyPush');
+        } else {
+          var ids = [], names = [];
+          parent.forEach(function(it, index) {
+            if (it && _hasOwn(it, 'id') && it.id === k) ids.push(index);
+            if (it && _hasOwn(it, 'name') && it.name === k) names.push(index);
+          });
+          var matches = ids.length ? ids : names;
+          if (!matches.length) return fail('authoring-array-reference-not-found', '未找到数组中的实体；请先搜索实际 ID/名称，新增实体请用 applyPush');
+          if (matches.length !== 1) return fail('ambiguous-reference', '实体匹配不唯一；请使用唯一 ID 或明确索引');
+          k = matches[0];
+        }
       }
-      if (parent === undefined || parent === null) return { parent: null, key: null, exists: false, value: undefined };
-    }
-    var lastKey = keys[keys.length - 1];
-    var lastIndexed = lastKey.match(/^(\w+)\[(\d+)\]$/);
-    if (lastIndexed) {
-      if (!_hasOwn(parent, lastIndexed[1]) || !Array.isArray(parent[lastIndexed[1]])) return { parent: null, key: null, exists: false, value: undefined };
-      var lastArray = parent[lastIndexed[1]], lastIndex = Number(lastIndexed[2]);
-      return { parent: lastArray, key: lastIndex, exists: _hasOwn(lastArray, lastIndex), value: lastArray[lastIndex] };
-    }
-    if (Array.isArray(parent) && isNaN(Number(lastKey))) {
-      var target = parent.find(function(it) { return it && ((_hasOwn(it, 'name') && it.name === lastKey) || (_hasOwn(it, 'id') && it.id === lastKey)); });
-      if (target !== undefined) {
-        return { parent: parent, key: parent.indexOf(target), exists: true, value: target };
+      var exists = _hasOwn(parent, k), value = exists ? parent[k] : undefined;
+      if (i === keys.length - 1) return { parent: parent, key: k, exists: exists, value: value, attach: attach, readOnly: readOnly };
+      if (!exists || value == null) {
+        if (!createParents || Array.isArray(parent)) return fail('authoring-path-not-found', '路径不存在');
+        // 缺失对象链先在脱离草稿的分支上构造；后续索引/实体校验失败时不留下半截字段。
+        value = {};
+        if (!attach) attach = { parent: parent, key: k, value: value };
+        else parent[k] = value;
       }
+      parent = value;
     }
-    var resolvedKey = (Array.isArray(parent) && !isNaN(Number(lastKey))) ? Number(lastKey) : lastKey;
-    return { parent: parent, key: resolvedKey, exists: _hasOwn(parent, resolvedKey), value: _hasOwn(parent, resolvedKey) ? parent[resolvedKey] : undefined };
+  }
+
+  function _pathWriteFailure(r, path) {
+    return { ok: false, code: r.code || 'authoring-path-read-only', reason: r.reason || ('只读数组属性: ' + path) };
+  }
+  function _setResolvedPath(r, value) {
+    r.parent[r.key] = value;
+    if (r.attach) r.attach.parent[r.attach.key] = r.attach.value;
   }
 
   function _agentClone(x) {
@@ -183,26 +192,11 @@
       } else { value = [value]; }
     }
 
-    var r = _resolvePath(draft, path);
-    if (!r.parent) {
-      // 创建缺失路径（仅纯对象路径；数组按名创建不支持）
-      var keys = String(path).split('.');
-      var cur = draft;
-      for (var i = 0; i < keys.length - 1; i++) {
-        var k = keys[i];
-        if (/[\[\]]/.test(k)) return { ok: false, reason: '无法创建数组索引路径: ' + path };
-        if (!_hasOwn(cur, k) || cur[k] === undefined || cur[k] === null) cur[k] = {};
-        if (!cur[k] || typeof cur[k] !== 'object') return { ok: false, reason: '路径中间段不是对象: ' + k };
-        cur = cur[k];
-      }
-      var last = keys[keys.length - 1];
-      var oldCreated = cur[last];
-      cur[last] = value;
-      return { ok: true, path: path, old: oldCreated, new: value, created: true };
-    }
+    var r = _resolvePath(draft, path, true);
+    if (!r.parent || r.readOnly) return _pathWriteFailure(r, path);
     var old = r.exists ? r.value : undefined;
-    r.parent[r.key] = value;
-    return { ok: true, path: path, old: old, new: value };
+    _setResolvedPath(r, value);
+    return { ok: true, path: path, old: old, new: value, created: !!r.attach || !r.exists };
   }
 
   /** 在 draft 上按 path 向数组追加元素（同样旁路副作用）。 */
@@ -222,21 +216,12 @@
     }
     var _vals = Array.isArray(value) ? value : [value];   // 出数组→逐条入列（LLM 常把整批塞进一个值·不当单元素嵌套）
 
-    var r = _resolvePath(draft, path);
-    if (!r.parent) {
-      var keys = String(path).split('.');
-      var cur = draft;
-      for (var i = 0; i < keys.length - 1; i++) {
-        if (!_hasOwn(cur, keys[i]) || cur[keys[i]] === undefined || cur[keys[i]] === null) cur[keys[i]] = {};
-        if (!cur[keys[i]] || typeof cur[keys[i]] !== 'object') return { ok: false, reason: '路径中间段不是对象: ' + keys[i] };
-        cur = cur[keys[i]];
-      }
-      cur[keys[keys.length - 1]] = _vals.slice();
-      return { ok: true, path: path, pushed: value, pushedCount: _vals.length, created: true };
-    }
-    if (!Array.isArray(r.parent[r.key])) r.parent[r.key] = [];
-    for (var _pi = 0; _pi < _vals.length; _pi++) r.parent[r.key].push(_vals[_pi]);
-    return { ok: true, path: path, pushed: value, pushedCount: _vals.length };
+    var r = _resolvePath(draft, path, true);
+    if (!r.parent || r.readOnly) return _pathWriteFailure(r, path);
+    var arr = Array.isArray(r.value) ? r.value : [];
+    for (var _pi = 0; _pi < _vals.length; _pi++) arr.push(_vals[_pi]);
+    if (arr !== r.value) _setResolvedPath(r, arr);
+    return { ok: true, path: path, pushed: value, pushedCount: _vals.length, created: !!r.attach || !r.exists };
   }
 
   /** 删除 draft 某路径的元素（数组按索引 splice·对象 delete）。同样旁路副作用。 */
@@ -247,7 +232,7 @@
     if (_hasUnsafePathSegment(path)) return { ok: false, reason: 'unsafe path: ' + path };
     if (!opts.force && isBlocked(path)) return { ok: false, reason: 'blocked path: ' + path };
     var r = _resolvePath(draft, path);
-    if (!r.parent) return { ok: false, reason: 'path not found: ' + path };
+    if (!r.parent || r.readOnly) return _pathWriteFailure(r, path);
     if (Array.isArray(r.parent) && typeof r.key === 'number') {
       var removed = r.parent.splice(r.key, 1);
       return { ok: true, path: path, removed: removed[0] };
@@ -260,19 +245,20 @@
 
   /** 在 draft 某数组集合里按关键词查实体（读工具·让 agent 不盲改）。 */
   function _searchEntities(draft, collection, query) {
-    var arr = draft && draft[collection];
+    var resolved = _resolvePath(draft, collection), arr = resolved.value;
     // 虚拟集合：地图地块不在顶层数组，映射到 map.regions（mapData.regions 为镜像）
     if (!Array.isArray(arr) && (collection === 'regions' || collection === '省' || collection === '地块')) {
-      var _m = (draft && draft.map) || (draft && draft.mapData) || {};
-      if (Array.isArray(_m.regions)) { arr = _m.regions; collection = 'map.regions'; }
+      var _mapField = draft && draft.map ? 'map' : 'mapData';
+      var _m = (draft && draft[_mapField]) || {};
+      if (Array.isArray(_m.regions)) { arr = _m.regions; collection = _mapField + '.regions'; }
     }
-    if (!Array.isArray(arr)) return { ok: false, reason: collection + ' 不是数组或不存在' };
+    if (!Array.isArray(arr)) return { ok: false, code: resolved.code || 'authoring-collection-not-found', reason: resolved.reason || (collection + ' 不是数组或不存在') };
     var q = String(query == null ? '' : query).trim();
     var matches = [];
     arr.forEach(function(it, i) {
       if (!it || typeof it !== 'object') return;
       var hay = [it.name, it.faction, it.id, it.title, it.leader, it.adminBinding].filter(Boolean).join(' ');
-      if (!q || hay.indexOf(q) >= 0) matches.push({ index: i, name: it.name, faction: it.faction, fields: Object.keys(it).slice(0, 8) });
+      if (!q || hay.indexOf(q) >= 0) matches.push({ index: i, id: it.id, path: collection + '[' + i + ']', name: it.name, faction: it.faction, fields: Object.keys(it).slice(0, 8) });
     });
     return { ok: true, collection: collection, count: matches.length, matches: matches.slice(0, 40) };
   }
@@ -1224,7 +1210,7 @@
     },
     {
       name: 'applyEdit',
-      description: '在剧本草稿上按 path 设值。path 形如 "name" / "factions.明.leader" / "playerInfo.factionName"。',
+      description: '在剧本草稿上按 path 设值。可用搜索返回的完整路径，或以唯一 ID 定位数组实体。支持给已存在的实体新增对象字段；找不到实体或同名歧义会失败，不会自动新增地区。新增实体请用 applyPush。改地区民心/经济应先查 adminHierarchy 中实际字段，不是只改地图显示数据。',
       parameters: { type: 'object', properties: {
         path: { type: 'string', description: '字段路径' },
         value: { type: ['string', 'number', 'boolean', 'object', 'array', 'null'], description: '要设置的值' },
@@ -1251,7 +1237,7 @@
     },
     {
       name: 'searchEntities',
-      description: '在某集合按关键词查实体。collection 如 characters/factions/parties；query 匹配 name/faction/id/title 包含（留空=全部）。',
+      description: '在数组集合按关键词查实体，支持 characters/factions/parties、map.regions、adminHierarchy.势力名.divisions 等完整嵌套路径。query 匹配 name/faction/id/title/adminBinding 包含（留空=全部）。返回 id 和可直接用于 getField/applyEdit 的 path；同名实体必须按唯一 ID 或明确索引定位。',
       parameters: { type: 'object', properties: {
         collection: { type: 'string' }, query: { type: 'string' }
       }, required: ['collection'] }
@@ -2177,7 +2163,7 @@
       }
       case 'bulkUpdate': {   // 刀②(2026-07-10 智能升级C)：按条件批量改·逐条复用 applyEdit 享权限/指纹/落账
         var _buDraft = _agentClone(draft);
-        var _buArr = _buDraft ? _buDraft[input.collection] : null;
+        var _buArr = _resolvePath(_buDraft, input.collection).value;
         if (!Array.isArray(_buArr)) return { ok: false, reason: '集合不存在或非数组: ' + input.collection };
         if (!input.where || typeof input.where !== 'object') return { ok: false, reason: '需要 where 筛选条件(全集也须显式给空对象·防误伤)' };
         if (!input.field || ['set', 'add', 'mul'].indexOf(input.op) < 0) return { ok: false, reason: '需要 field 与合法 op(set/add/mul)' };
@@ -2232,7 +2218,7 @@
         });
       }
       case 'statsAggregate': {   // 刀②：确定性数值聚合·平衡审读真账而非 LLM 目测
-        var _saArr = draft ? draft[input.collection] : null;
+        var _saArr = _resolvePath(draft, input.collection).value;
         if (!Array.isArray(_saArr)) return { ok: false, reason: '集合不存在或非数组: ' + input.collection };
         var _saMetrics = Array.isArray(input.metrics) ? input.metrics.slice(0, 8) : [];
         if (!_saMetrics.length) return { ok: false, reason: '需要 metrics 数值字段列表' };
@@ -2261,7 +2247,7 @@
       }
       case 'getField': {
         var rr = _resolvePath(draft, input.path);
-        if (!rr.parent) return { ok: false, reason: 'path not found: ' + input.path };
+        if (!rr.parent || !rr.exists) return { ok: false, code: rr.code || 'authoring-path-not-found', reason: rr.reason || ('path not found: ' + input.path) };
         return { ok: true, path: input.path, value: rr.value };
       }
       case 'getFields': {
@@ -2269,7 +2255,7 @@
         if (!_gpaths.length) return { ok: false, reason: '需要非空 paths[]（路径数组）' };
         var _gvals = _gpaths.slice(0, 40).map(function (p) {
           var rr2 = _resolvePath(draft, p);
-          if (!rr2.parent) return { path: p, found: false };
+          if (!rr2.parent || !rr2.exists) return { path: p, found: false, code: rr2.code || 'authoring-path-not-found' };
           return { path: p, found: true, value: _truncForLLM(rr2.value, 600) };
         });
         return { ok: true, count: _gvals.length, values: _gvals };

--- a/web/editor.html
+++ b/web/editor.html
@@ -2715,8 +2715,8 @@
   <script src="editor-ai-multipass.js" defer=""></script>
   <script src="editor-ai-validate.js" defer=""></script>
   <script src="tm-agent-kernel.js?v=20260719-kernel1" defer=""></script>
-  <script src="editor-authoring-agent-provider.js?v=20260812-office-source1" defer=""></script>
-  <script src="editor-authoring-agent.js?v=20260812-office-source1" defer=""></script>
+  <script src="editor-authoring-agent-provider.js?v=20260908-region-paths1" defer=""></script>
+  <script src="editor-authoring-agent.js?v=20260908-region-paths1" defer=""></script>
   <!-- 第十八拆(20260706)：ui 巨石→icons(前)+origin+render(后)·装载序 icons→origin→render·契约见 lint-split-contracts -->
   <script src="editor-authoring-agent-ui-icons.js?v=20260812-office-source1" defer=""></script>
   <script src="editor-authoring-agent-ui.js?v=20260812-office-source1" defer=""></script>

--- a/web/preview/scenario-editor-reset-preview.html
+++ b/web/preview/scenario-editor-reset-preview.html
@@ -575,8 +575,8 @@
   <script src="../map-editor-to-game.js"></script>
   <script src="scenario-editor-reset-app.js?v=20260719-guoshi-dock"></script>
   <script src="../tm-agent-kernel.js?v=20260719-kernel1"></script>
-  <script src="../editor-authoring-agent-provider.js?v=20260812-office-source1"></script>
-  <script src="../editor-authoring-agent.js?v=20260812-office-source1"></script>
+  <script src="../editor-authoring-agent-provider.js?v=20260908-region-paths1"></script>
+  <script src="../editor-authoring-agent.js?v=20260908-region-paths1"></script>
   <!-- 第十八拆(20260706)：ui 巨石→icons(前)+origin+render(后)·装载序契约见 lint-split-contracts -->
   <script src="../editor-authoring-agent-ui-icons.js?v=20260812-office-source1"></script>
   <script src="../editor-authoring-agent-ui.js?v=20260812-office-source1"></script>

--- a/web/scripts/smoke-authoring-region-paths.js
+++ b/web/scripts/smoke-authoring-region-paths.js
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+'use strict';
+// Same behavioral invariants against the actual worktree or --ref Git source.
+const fs = require('fs'), path = require('path'), vm = require('vm'), cp = require('child_process'), assert = require('assert/strict');
+const root = path.resolve(__dirname, '../..');
+const refIndex = process.argv.indexOf('--ref');
+const ref = refIndex < 0 ? null : process.argv[refIndex + 1];
+const files = ['editor-authoring-agent-provider.js', 'editor-authoring-agent.js'];
+const sandbox = { console, setTimeout, clearTimeout, AbortController, URL };
+sandbox.global = sandbox;
+vm.createContext(sandbox);
+for (const file of files) {
+  const text = ref ? cp.execFileSync('git', ['show', ref + ':web/' + file], { cwd: root, encoding: 'utf8', maxBuffer: 4e6 }) : fs.readFileSync(path.join(root, 'web', file), 'utf8');
+  vm.runInContext(text, sandbox, { filename: file });
+}
+const AA = sandbox.TM.AuthoringAgent;
+const roundtrip = x => JSON.parse(JSON.stringify(x));
+function fixture() {
+  return { name: '隔离路径回归', map: { regions: [{ id: 'r-a', name: '雅州' }, { id: 'r-b', name: '同名州' }, { id: 'r-c', name: '同名州' }] },
+    adminHierarchy: { 楚: { divisions: [{ id: 'r-a', name: '雅州', minxinLocal: 58, economyBase: { farmland: 112 }, children: [{ id: 'r-child', name: '附县', minxinLocal: 41 }] }, { id: 'r-b', name: '同名州', minxinLocal: 20 }, { id: 'r-c', name: '同名州', minxinLocal: 80 }] } },
+    characters: [{ id: 'c-1', name: '甲', loyalty: 50 }], factions: [{ id: 'f-1', name: '楚' }] };
+}
+const divs = 'adminHierarchy.楚.divisions';
+const tests = [];
+function test(name, body) { tests.push({ name, body }); }
+function call(draft, tool, input) { return AA.dispatchTool(draft, tool, input); }
+function unchanged(draft, operation) {
+  const before = roundtrip(draft), keys = Reflect.ownKeys(draft.adminHierarchy.楚.divisions);
+  const result = operation();
+  assert.equal(result.ok, false, 'operation must report failure');
+  assert.deepEqual(roundtrip(draft), before, 'no partial serialized writes');
+  assert.deepEqual(Reflect.ownKeys(draft.adminHierarchy.楚.divisions), keys, 'no phantom array properties');
+  return result;
+}
+test('nested map search returns a readable concrete path and ID', () => {
+  const d = fixture(), r = call(d, 'searchEntities', { collection: 'map.regions', query: '雅州' });
+  assert.equal(r.ok, true); assert.equal(r.count, 1); assert.equal(r.matches[0].id, 'r-a');
+  assert.equal(call(d, 'getField', { path: r.matches[0].path + '.name' }).value, '雅州');
+});
+test('nested faction administrative search and write/read persistence', () => {
+  const d = fixture(), r = call(d, 'searchEntities', { collection: divs, query: '雅州' });
+  assert.equal(r.ok, true); assert.equal(r.count, 1);
+  const p = r.matches[0].path + '.minxinLocal';
+  assert.equal(call(d, 'applyEdit', { path: p, value: 77 }).ok, true);
+  assert.equal(call(roundtrip(d), 'getField', { path: p }).value, 77);
+  assert.equal(d.map.regions[0].minxinLocal, undefined, 'map presentation is not the administrative ledger');
+});
+test('nested children collection supports explicit stable parent ID', () => {
+  const d = fixture(), r = call(d, 'searchEntities', { collection: divs + '.r-a.children', query: 'r-child' });
+  assert.equal(r.ok, true); assert.equal(r.matches[0].name, '附县');
+});
+test('virtual region collection roundtrips through its reported collection name', () => {
+  const d = fixture(), first = call(d, 'searchEntities', { collection: 'regions', query: '雅州' });
+  assert.equal(first.ok, true);
+  assert.equal(call(d, 'searchEntities', { collection: first.collection, query: '雅州' }).count, 1);
+});
+test('legacy mapData-only alias returns its real path without creating map', () => {
+  const d = fixture(); d.mapData = d.map; delete d.map;
+  const r = call(d, 'searchEntities', { collection: 'regions', query: '雅州' });
+  assert.equal(r.ok, true); assert.equal(r.collection, 'mapData.regions');
+  assert.equal(call(d, 'getField', { path: r.matches[0].path + '.id' }).value, 'r-a');
+  assert.equal(d.map, undefined);
+});
+test('top-level character searches remain compatible and bounded', () => {
+  const d = fixture(); d.characters = Array.from({ length: 65 }, (_, i) => ({ id: 'c-' + i, name: '人' + i }));
+  const r = call(d, 'searchEntities', { collection: 'characters', query: '' });
+  assert.equal(r.ok, true); assert.equal(r.count, 65); assert.equal(r.matches.length, 40);
+});
+test('global search returned bracket paths still read and write the real row', () => {
+  const d = fixture(), r = call(d, 'globalSearch', { query: '附县' });
+  const hit = r.hits.find(h => h.path.startsWith('adminHierarchy.'));
+  assert(hit); const p = hit.path.replace(/\.name$/, '.minxinLocal');
+  assert.equal(call(d, 'applyEdit', { path: p, value: 73 }).ok, true);
+  assert.equal(call(roundtrip(d), 'getField', { path: p }).value, 73);
+});
+// Keep each failure case independent so baseline evidence includes every defect.
+for (const [label, suffix] of [['intermediate', '.不存在.minxinLocal'], ['terminal', '.不存在'], ['array length', '.length'], ['negative index', '.-1'], ['out of bounds', '[999].minxinLocal']]) {
+  test('reject ' + label + ' array write without mutation', () => {
+    const d = fixture(); unchanged(d, () => call(d, 'applyEdit', { path: divs + suffix, value: 77 }));
+  });
+}
+test('failed append through a missing named region is not falsely successful', () => {
+  const d = fixture(); unchanged(d, () => call(d, 'applyPush', { path: divs + '.不存在.children', value: { id: 'new', name: '新县' } }));
+});
+test('failed read and batch read accurately report a missing leaf', () => {
+  const d = fixture(), p = divs + '.r-a.noSuchField';
+  assert.equal(call(d, 'getField', { path: p }).ok, false);
+  assert.equal(call(d, 'getFields', { paths: [p] }).values[0].found, false);
+});
+test('duplicate names cannot silently select the first region', () => {
+  const d = fixture(), p = divs + '.同名州.minxinLocal';
+  assert.equal(call(d, 'getField', { path: p }).ok, false);
+  unchanged(d, () => call(d, 'applyEdit', { path: p, value: 77 }));
+});
+test('explicit unique ID updates only the requested duplicate-name region', () => {
+  const d = fixture(); assert.equal(AA.applyEdit(d, divs + '.r-c.minxinLocal', 77).ok, true);
+  assert.equal(d.adminHierarchy.楚.divisions[1].minxinLocal, 20);
+  assert.equal(d.adminHierarchy.楚.divisions[2].minxinLocal, 77);
+});
+test('ID takes precedence over an unrelated name that happens to equal it', () => {
+  const d = fixture(); d.adminHierarchy.楚.divisions[0].name = 'r-c';
+  assert.equal(AA.applyEdit(d, divs + '.r-c.minxinLocal', 77).ok, true);
+  assert.equal(d.adminHierarchy.楚.divisions[0].minxinLocal, 58);
+  assert.equal(d.adminHierarchy.楚.divisions[2].minxinLocal, 77);
+});
+test('duplicate IDs are rejected without choosing an arbitrary row', () => {
+  const d = fixture(); d.adminHierarchy.楚.divisions[2].id = 'r-b';
+  unchanged(d, () => AA.applyEdit(d, divs + '.r-b.minxinLocal', 77));
+});
+test('new object fields under a valid named entity are created and persist', () => {
+  const d = fixture(), p = divs + '.r-a.economyBase.newMetric.value';
+  assert.equal(AA.applyEdit(d, p, 1.25).ok, true);
+  assert.equal(call(roundtrip(d), 'getField', { path: p }).value, 1.25);
+  assert.equal(d.adminHierarchy.楚.divisions[0].economyBase.farmland, 112);
+});
+test('missing object chain remains supported without partial invalid bracket scaffolding', () => {
+  const d = fixture(); assert.equal(AA.applyEdit(d, 'worldSettings.religion', '儒').ok, true);
+  unchanged(d, () => AA.applyEdit(d, 'newConfig.rows[0].name', '无效'));
+});
+test('explicit append can create a child collection under the actual selected ID', () => {
+  const d = fixture(), p = divs + '.r-c.children';
+  assert.equal(AA.applyPush(d, p, { id: 'child', name: '新县' }).ok, true);
+  assert.equal(call(roundtrip(d), 'getField', { path: p + '[0].name' }).value, '新县');
+});
+test('remove keeps legitimate ID/index operations but rejects missing and ambiguous names', () => {
+  const d = fixture(); unchanged(d, () => AA.applyRemove(d, divs + '.不存在'));
+  unchanged(d, () => AA.applyRemove(d, divs + '.同名州'));
+  assert.equal(AA.applyRemove(d, divs + '.r-c').ok, true);
+  assert.equal(d.adminHierarchy.楚.divisions.length, 2);
+});
+test('atomic multi-edit rollback includes a later unresolved named entity', () => {
+  const d = fixture(); unchanged(d, () => call(d, 'multiEdit', { edits: [{ path: divs + '.r-a.minxinLocal', value: 77 }, { path: divs + '.不存在.minxinLocal', value: 90 }] }));
+});
+test('unsafe or prototype paths remain rejected even with force', () => {
+  const d = fixture(); for (const p of ['__proto__.polluted', 'constructor.prototype.polluted', divs + '.constructor.polluted']) {
+    assert.equal(AA.applyEdit(d, p, true, { force: true }).ok, false);
+    assert.equal(AA.applyPush(d, p, {}, { force: true }).ok, false);
+  }
+  assert.equal({}.polluted, undefined);
+});
+test('detached draft edits do not touch caller-owned scenario data', () => {
+  const source = fixture(), d = AA.makeDraft(source), before = roundtrip(source);
+  assert.equal(AA.applyEdit(d, divs + '.r-a.minxinLocal', 88).ok, true);
+  assert.deepEqual(source, before);
+});
+test('stable ID still selects the intended region after reordering', () => {
+  const d = fixture(); d.adminHierarchy.楚.divisions.reverse();
+  assert.equal(AA.applyEdit(d, divs + '.r-c.minxinLocal', 0).ok, true);
+  assert.equal(d.adminHierarchy.楚.divisions[0].id, 'r-c');
+  assert.equal(d.adminHierarchy.楚.divisions[0].minxinLocal, 0);
+  assert.equal(d.adminHierarchy.楚.divisions.find(r => r.id === 'r-b').minxinLocal, 20);
+});
+test('zero, false, null and readable array length are not mistaken for missing values', () => {
+  const d = fixture(); Object.assign(d.adminHierarchy.楚.divisions[0], { count: 0, enabled: false, desc: null });
+  const p = divs + '.r-a';
+  const r = call(d, 'getFields', { paths: [p + '.count', p + '.enabled', p + '.desc', divs + '.length'] });
+  assert(r.values.every(v => v.found));
+  assert.equal(call(d, 'getField', { path: divs + '.length' }).value, 3);
+});
+test('copy from missing field already fails and remains non-mutating', () => {
+  const d = fixture(); unchanged(d, () => call(d, 'copyField', { from: divs + '.r-a.absent', to: 'overview' }));
+});
+test('nested bracket indices including Chinese object keys remain supported', () => {
+  const d = fixture(); d.区域矩阵 = [[{ name: '甲', minxinLocal: 12 }]];
+  assert.equal(AA.applyEdit(d, '区域矩阵[0][0].minxinLocal', 13).ok, true);
+  assert.equal(call(roundtrip(d), 'getField', { path: '区域矩阵[0][0].minxinLocal' }).value, 13);
+});
+test('separate drafts with reused IDs never share lookup state', () => {
+  const a = fixture(), b = fixture(); b.adminHierarchy.楚.divisions[0].minxinLocal = 3;
+  assert.equal(AA.applyEdit(a, divs + '.r-a.minxinLocal', 77).ok, true);
+  assert.equal(call(b, 'getField', { path: divs + '.r-a.minxinLocal' }).value, 3);
+});
+test('filtered bulk update accepts the same nested collection as search', () => {
+  const d = fixture();
+  const r = call(d, 'bulkUpdate', { collection: divs, where: { id: 'r-c' }, field: 'minxinLocal', op: 'set', value: 77 });
+  assert.equal(r.ok, true); assert.equal(r.changed, 1);
+  assert.equal(call(roundtrip(d), 'getField', { path: divs + '.r-c.minxinLocal' }).value, 77);
+  assert.equal(d.adminHierarchy.楚.divisions[1].minxinLocal, 20);
+});
+test('numeric aggregate reads the same nested administrative values', () => {
+  const r = call(fixture(), 'statsAggregate', { collection: divs, metrics: ['minxinLocal'] });
+  assert.equal(r.ok, true); assert.equal(r.stats['(全部)'].count, 3);
+  assert.equal(r.stats['(全部)'].metrics.minxinLocal.sum, 158);
+});
+test('append preserves an existing array without reassigning its read-only owner property', () => {
+  const d = { items: [] }, original = d.items; Object.freeze(d);
+  assert.equal(AA.applyPush(d, 'items', { name: '追加项' }).ok, true);
+  assert.equal(d.items, original); assert.equal(d.items.length, 1);
+});
+let pass = 0, fail = 0;
+(async function () {
+  for (const t of tests) try { await t.body(); pass++; console.log('PASS ' + t.name); } catch (e) { fail++; console.error('FAIL ' + t.name + ': ' + e.message); }
+  console.log(JSON.stringify({ source: ref || 'worktree', pass, fail, total: tests.length, scope: 'actual public authoring tools; no network or player data' }));
+  process.exitCode = fail ? 1 : 0;
+})().catch(e => { console.error(e.stack); process.exitCode = 1; });


### PR DESCRIPTION
## Scope and authorization

Owner authorized source push and merge of this completed bugfix only. No release, version change, installer/OTA build, tag, production deployment, force push, branch deletion or player-data modification.

- Base: `main@12942b78fe64d20f4eb9ee01827a2c3567b38bf1`.
- Head: `f4e89f8b524b1620b53fe9df1ae3970c12e6b03f`.
- Exactly one commit / 12 changed files, including tests and source-bound logs; original user worktree changes and private scenario JSON are excluded.

## Fix

- Resolve nested collections consistently for search, single-field reads/writes, filtered bulk updates and numeric aggregation. Search returns actual IDs and usable paths.
- Reject missing/ambiguous array entities instead of creating non-index properties that falsely report success and vanish during JSON export. Unique IDs take precedence over names; explicit indices remain supported.
- Stage new object parents off-draft so later invalid indices leave no partial writes. Preserve valid deep additions, explicit append/remove, atomic multi-edit rollback, readable array length and prototype protections.
- Update the existing script-family cache stamps in both real editor entries. Official manifest generator changes only the three affected runtime entries, retaining all 1094 entries and version 1.3.4.11.

No game mechanics, geography, region names, save format or fiscal/minxin values are redefined. Previously discarded phantom edits cannot be reconstructed and must be submitted again after the fix.

## Verification

- Same actual-source behavior test: baseline **12 PASS / 21 FAIL**, candidate **33 PASS**. Delivery-time candidate rerun also 33 PASS.
- Final local full suite: **917 PASS / 0 FAIL / 0 SKIP / 2 WAIVED, 919 scripts executed**, seven existing precise absent-asset checks only.
- Existing authoring/office family: 9 scripts pass. Architecture 13, release contract 166, official parity 27, hot-builder fixtures 27 pass; production dependency audit found zero vulnerabilities.
- Real Windows Electron 33.4.11: standard production/test/restart 29 checks; new editor synthetic case 12; read-only supplied-scenario clone 12. Actual editor adapter, IndexedDB save, page reload and readback are exercised. No live AI calls, physical-mouse assertion, signed-installer or whole-game regional-mechanics acceptance claim.
- New synthetic editor Electron case runs in the existing Windows CI job; missing runtime/startup failures remain blocking.
- Raw `git diff --check` flags CR bytes on two deliberately preserved CRLF HTML lines; the documented CR-aware check retains all normal whitespace checks. No line-ending conversion or Git config weakening.

[Full report](https://github.com/misfit-user/tianming/blob/f4e89f8b524b1620b53fe9df1ae3970c12e6b03f/docs/bugfix-authoring-region-paths-2026-09-08.md) · [Source hashes and execution evidence](https://github.com/misfit-user/tianming/blob/f4e89f8b524b1620b53fe9df1ae3970c12e6b03f/docs/bugfix-authoring-region-paths/evidence.json)

The report retains initial failures and harness corrections, including the async editor-ready wait and an append-compatibility issue fixed before the final full run. Historical local evidence does not substitute for the fresh PR checks required before this authorized normal merge.
